### PR TITLE
Add ApplicationType handler tests

### DIFF
--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -64,5 +64,5 @@ func ApplicationTypeGet(c echo.Context) error {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, appType)
+	return c.JSON(http.StatusOK, appType.ToResponse())
 }

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -11,20 +11,19 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-var sources = `[
-	{ "id": 1, "name": "Source1", "source_type_id": 1 },
-	{ "id": 2, "name": "Source2", "source_type_id": 1 }
+var apptypes = `[
+	{"id": 1, "display_name": "test app type"}
 ]`
 
-func TestSourceList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources", nil)
+func TestApplicationTypeList(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set("limit", 99)
-	c.Set("offset", -1)
+	c.Set("limit", 100)
+	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
 
-	err := SourceList(c)
+	err := ApplicationTypeList(c)
 	if err != nil {
 		t.Error(err)
 	}
@@ -39,38 +38,38 @@ func TestSourceList(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if out.Meta.Limit != 99 {
+	if out.Meta.Limit != 100 {
 		t.Error("limit not set correctly")
 	}
 
-	if out.Meta.Offset != -1 {
+	if out.Meta.Offset != 0 {
 		t.Error("offset not set correctly")
 	}
 
-	if len(out.Data) != 2 {
+	if len(out.Data) != 1 {
 		t.Error("not enough objects passed back from DB")
 	}
 
-	for _, src := range out.Data {
-		s, ok := src.(map[string]interface{})
+	for _, apptype := range out.Data {
+		s, ok := apptype.(map[string]interface{})
 		if !ok {
-			t.Error("model did not deserialize as a source")
+			t.Error("model did not deserialize as a application type response")
 		}
 
-		if s["name"] != "Source1" && s["name"] != "Source2" {
+		if s["display_name"] != "test app type" {
 			t.Error("ghosts infected the return")
 		}
 	}
 }
 
-func TestSourceGet(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1", nil)
+func TestApplicationTypeGet(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/1", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 
-	err := SourceGet(c)
+	err := ApplicationTypeGet(c)
 	if err != nil {
 		t.Error(err)
 	}
@@ -79,13 +78,13 @@ func TestSourceGet(t *testing.T) {
 		t.Error("Did not return 200")
 	}
 
-	var outSrc m.SourceResponse
-	err = json.Unmarshal(rec.Body.Bytes(), &outSrc)
+	var outAppType m.ApplicationTypeResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &outAppType)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if *outSrc.Name != "Source1" {
+	if outAppType.DisplayName != "test app type" {
 		t.Error("ghosts infected the return")
 	}
 }

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -11,6 +11,10 @@ type MockSourceDao struct {
 	Sources []m.Source
 }
 
+type MockApplicationTypeDao struct {
+	ApplicationTypes []m.ApplicationType
+}
+
 func (m *MockSourceDao) List(limit, offset int, filters []middleware.Filter) ([]m.Source, *int64, error) {
 	count := int64(len(m.Sources))
 	return m.Sources, &count, nil
@@ -41,4 +45,31 @@ func (m *MockSourceDao) Delete(id *int64) error {
 func (m *MockSourceDao) Tenant() *int64 {
 	tenant := int64(1)
 	return &tenant
+}
+
+func (a *MockApplicationTypeDao) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationType, *int64, error) {
+	count := int64(len(a.ApplicationTypes))
+	return a.ApplicationTypes, &count, nil
+}
+
+func (a *MockApplicationTypeDao) GetById(id *int64) (*m.ApplicationType, error) {
+	for _, i := range a.ApplicationTypes {
+		if i.Id == *id {
+			return &i, nil
+		}
+	}
+
+	return nil, fmt.Errorf("application Type not found")
+}
+
+func (a *MockApplicationTypeDao) Create(src *m.ApplicationType) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockApplicationTypeDao) Update(src *m.ApplicationType) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockApplicationTypeDao) Delete(id *int64) error {
+	panic("not implemented") // TODO: Implement
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/labstack/echo/v4"
+)
+
+var (
+	e                      *echo.Echo
+	mockSourceDao          dao.SourceDao
+	mockApplicationTypeDao dao.ApplicationTypeDao
+)
+
+func TestMain(t *testing.M) {
+	// flag to control running unit tests or connecting to a real db, usage:
+	// go test -integration
+	integration := flag.Bool("integration", false, "run unit or integration tests")
+	flag.Parse()
+
+	if *integration {
+		fmt.Fprintf(os.Stderr, "Integration not working yet, exiting.")
+		os.Exit(1)
+	} else {
+		mockSourceDao = setupSourceMockDao(sources)
+		mockApplicationTypeDao = setupApplicationTypeMockDao(apptypes)
+		getApplicationTypeDao = func(c echo.Context) (dao.ApplicationTypeDao, error) {
+			return mockApplicationTypeDao, nil
+		}
+		getSourceDao = func(c echo.Context) (dao.SourceDao, error) {
+			return mockSourceDao, nil
+		}
+	}
+
+	e = echo.New()
+	code := t.Run()
+	os.Exit(code)
+}
+
+func setupSourceMockDao(sources string) dao.SourceDao {
+	a := make([]m.Source, 0, 10)
+	err := json.Unmarshal([]byte(sources), &a)
+	if err != nil {
+		panic(err)
+	}
+	return &dao.MockSourceDao{Sources: a}
+}
+
+func setupApplicationTypeMockDao(apptypes string) dao.ApplicationTypeDao {
+	a := make([]m.ApplicationType, 0, 10)
+	err := json.Unmarshal([]byte(apptypes), &a)
+	if err != nil {
+		panic(err)
+	}
+	return &dao.MockApplicationTypeDao{ApplicationTypes: a}
+}


### PR DESCRIPTION
Adding some tests for ApplicationType, and just restructured some of the files.

- Forgot to pluralize `application_type_handler.go, renamed to `application_type_handlers.go`
- Forgot to call `ApplicationType#ToResponse()` on ApplicationTypeGet
- Added ApplicationType MockDAO
- Moved setup functions to `main_test.go` so they're in one place
- Added a flag to support integration tests (when we connect to an actual database for the tests)