### PR TITLE
Add support for hitting the db during tests (aka integration testing)

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -9,12 +9,24 @@ import (
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"gorm.io/datatypes"
 )
 
-var applications = `[
-	{ "id": 1, "extra": {"extra": true}, "application_type_id": 1 },
-	{ "id": 2, "extra": {"extra": true}, "application_type_id": 1 }
-]`
+var testApplicationData = []m.Application{
+	{ID: 1, Extra: datatypes.JSON(getExtraValue("{\"extra\": true}")), ApplicationTypeID: 1, SourceID: 1, TenantID: 1},
+	{ID: 2, Extra: datatypes.JSON(getExtraValue("{\"extra\": false}")), ApplicationTypeID: 1, SourceID: 1, TenantID: 1},
+}
+
+func getExtraValue(val string) json.RawMessage {
+	var out json.RawMessage
+
+	err := json.Unmarshal([]byte(val), &out)
+	if err != nil {
+		panic(err)
+	}
+
+	return out
+}
 
 func TestApplicationList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/applications", nil)
@@ -23,6 +35,7 @@ func TestApplicationList(t *testing.T) {
 	c.Set("limit", 100)
 	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
+	c.Set("tenantID", int64(1))
 
 	err := ApplicationList(c)
 	if err != nil {
@@ -69,6 +82,7 @@ func TestApplicationGet(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.SetParamNames("id")
 	c.SetParamValues("1")
+	c.Set("tenantID", int64(1))
 
 	err := ApplicationGet(c)
 	if err != nil {

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-var apptypes = `[
-	{"id": 1, "display_name": "test app type"}
-]`
+var testApplicationTypeData = []m.ApplicationType{
+	{Id: 1, DisplayName: "test app type"},
+}
 
 func TestApplicationTypeList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types", nil)

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -30,7 +30,7 @@ func (a *ApplicationDaoImpl) List(limit int, offset int, filters []middleware.Fi
 }
 
 func (a *ApplicationDaoImpl) GetById(id *int64) (*m.Application, error) {
-	app := &m.Application{Id: *id}
+	app := &m.Application{ID: *id}
 	result := DB.First(&app)
 
 	return app, result.Error
@@ -47,7 +47,7 @@ func (a *ApplicationDaoImpl) Update(app *m.Application) error {
 }
 
 func (a *ApplicationDaoImpl) Delete(id *int64) error {
-	app := &m.Application{Id: *id}
+	app := &m.Application{ID: *id}
 	if result := DB.Delete(app); result.RowsAffected == 0 {
 		return fmt.Errorf("failed to delete application id %v", *id)
 	}

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -30,7 +30,7 @@ func (m *MockSourceDao) List(limit, offset int, filters []middleware.Filter) ([]
 
 func (m *MockSourceDao) GetById(id *int64) (*m.Source, error) {
 	for _, i := range m.Sources {
-		if i.Id == *id {
+		if i.ID == *id {
 			return &i, nil
 		}
 	}
@@ -116,7 +116,7 @@ func (a *MockApplicationDao) List(limit int, offset int, filters []middleware.Fi
 
 func (a *MockApplicationDao) GetById(id *int64) (*m.Application, error) {
 	for _, app := range a.Applications {
-		if app.Id == *id {
+		if app.ID == *id {
 			return &app, nil
 		}
 	}

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -33,7 +33,7 @@ func (s *SourceDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]
 }
 
 func (s *SourceDaoImpl) GetById(id *int64) (*m.Source, error) {
-	src := &m.Source{Id: *id}
+	src := &m.Source{ID: *id}
 	result := DB.First(src)
 
 	return src, result.Error
@@ -50,7 +50,7 @@ func (s *SourceDaoImpl) Update(src *m.Source) error {
 }
 
 func (s *SourceDaoImpl) Delete(id *int64) error {
-	src := &m.Source{Id: *id}
+	src := &m.Source{ID: *id}
 	if result := DB.Delete(src); result.RowsAffected == 0 {
 		return fmt.Errorf("failed to delete source id %v", *id)
 	}

--- a/model/application.go
+++ b/model/application.go
@@ -11,7 +11,7 @@ type Application struct {
 	AvailabilityStatus
 	Pause
 
-	Id        int64     `gorm:"primarykey" json:"id"`
+	ID        int64     `gorm:"primarykey" json:"id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
@@ -30,13 +30,13 @@ type Application struct {
 }
 
 func (app *Application) ToResponse() *ApplicationResponse {
-	id := strconv.FormatInt(app.Id, 10)
+	id := strconv.FormatInt(app.ID, 10)
 	sourceId := strconv.FormatInt(app.SourceID, 10)
 	appTypeId := strconv.FormatInt(app.ApplicationTypeID, 10)
 
 	return &ApplicationResponse{
 		AvailabilityStatus:      app.AvailabilityStatus,
-		Id:                      id,
+		ID:                      id,
 		CreatedAt:               app.CreatedAt,
 		UpdatedAt:               app.UpdatedAt,
 		Pause:                   app.Pause,

--- a/model/application_http.go
+++ b/model/application_http.go
@@ -10,7 +10,7 @@ type ApplicationResponse struct {
 	AvailabilityStatus
 	Pause
 
-	Id        string    `json:"id"`
+	ID        string    `json:"id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -3,7 +3,6 @@ package model
 type Authentication struct {
 	AvailabilityStatus
 	Pause
-	Tenancy
 	TimeStamps
 
 	Id int64 `json:"id"`
@@ -15,7 +14,11 @@ type Authentication struct {
 	Extra                   map[string]interface{} `json:"extra,omitempty"`
 	AvailabilityStatusError *string                `json:"availability_status_error,omitempty"`
 
-	SourceId     *int64  `json:"source_id"`
-	ResourceType *string `json:"resource_type"`
-	ResourceId   *int64  `json:"resource_id"`
+	SourceID int64 `json:"source_id"`
+	Source   Source
+	TenantID int64 `json:"tenant_id"`
+	Tenant   Tenant
+
+	ResourceType string `json:"resource_type"`
+	ResourceId   int64  `json:"resource_id"`
 }

--- a/model/common.go
+++ b/model/common.go
@@ -16,7 +16,3 @@ type AvailabilityStatus struct {
 	LastCheckedAt      time.Time `json:"last_checked_at,omitempty"`
 	LastAvailableAt    time.Time `json:"last_available_at,omitempty"`
 }
-
-type Tenancy struct {
-	TenantId *int64 `json:"tenant_id"`
-}

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -2,18 +2,15 @@ package model
 
 import (
 	"time"
-
-	"gorm.io/gorm"
 )
 
 type Endpoint struct {
 	AvailabilityStatus
-	Tenancy
+	Pause
 
-	Id        int64          `gorm:"primarykey" json:"id"`
-	CreatedAt time.Time      `json:"created_at"`
-	UpdatedAt time.Time      `json:"updated_at"`
-	DeletedAt gorm.DeletedAt `gorm:"column:paused_at" json:"paused_at"`
+	ID        int64     `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 
 	Role                    *string `json:"role,omitempty"`
 	Port                    *int    `json:"port,omitempty"`
@@ -27,6 +24,8 @@ type Endpoint struct {
 	AvailabilityStatusError *string `json:"availability_status_error,omitempty"`
 
 	SourceID int64 `json:"source_id"`
+	Source   Source
 
-	Source *Source
+	TenantID int64
+	Tenant   Tenant
 }

--- a/model/source.go
+++ b/model/source.go
@@ -10,10 +10,9 @@ import (
 type Source struct {
 	AvailabilityStatus
 	Pause
-	Tenancy
 
 	//fields for gorm
-	Id        int64     `gorm:"primarykey" json:"id"`
+	ID        int64     `gorm:"primarykey" json:"id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
@@ -25,20 +24,24 @@ type Source struct {
 	SourceRef           *string `json:"source_ref,omitempty"`
 	AppCreationWorkflow string  `gorm:"default:manual_configuration" json:"app_creation_workflow"`
 
-	SourceTypeId *int64 `json:"source_type_id"`
+	SourceType   SourceType
+	SourceTypeID int64 `json:"source_type_id"`
+
+	Tenant   Tenant
+	TenantID int64 `json:"tenant_id"`
 
 	Applications []Application
 	Endpoints    []Endpoint
 }
 
 func (src *Source) ToResponse() *SourceResponse {
-	id := strconv.FormatInt(src.Id, 10)
-	stid := strconv.FormatInt(*src.SourceTypeId, 10)
+	id := strconv.FormatInt(src.ID, 10)
+	stid := strconv.FormatInt(src.SourceTypeID, 10)
 
 	return &SourceResponse{
 		AvailabilityStatus:  src.AvailabilityStatus,
 		Pause:               src.Pause,
-		Id:                  &id,
+		ID:                  &id,
 		CreatedAt:           src.CreatedAt,
 		UpdatedAt:           src.UpdatedAt,
 		Name:                &src.Name,

--- a/model/source_http.go
+++ b/model/source_http.go
@@ -14,7 +14,7 @@ type SourceCreateRequest struct {
 	AppCreationWorkflow string  `json:"app_creation_workflow"`
 	AvailabilityStatus  string  `json:"availability_status"`
 
-	SourceTypeId *int64 `json:"source_type_id"`
+	SourceTypeID *int64 `json:"source_type_id"`
 }
 
 // SourceEditRequest manages what we can/cannot update on the source
@@ -33,7 +33,7 @@ type SourceResponse struct {
 	AvailabilityStatus
 	Pause
 
-	Id                  *string   `json:"id"`
+	ID                  *string   `json:"id"`
 	CreatedAt           time.Time `json:"created_at"`
 	UpdatedAt           time.Time `json:"updated_at"`
 	Name                *string   `json:"name"`

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -98,8 +98,7 @@ func SourceCreate(c echo.Context) error {
 		AvailabilityStatus: m.AvailabilityStatus{
 			AvailabilityStatus: input.AvailabilityStatus,
 		},
-		SourceTypeId: input.SourceTypeId,
-		Tenancy:      m.Tenancy{TenantId: sourcesDB.Tenant()},
+		SourceTypeID: *input.SourceTypeID,
 	}
 
 	err = sourcesDB.Create(source)

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-var sources = `[
-	{ "id": 1, "name": "Source1", "source_type_id": 1 },
-	{ "id": 2, "name": "Source2", "source_type_id": 1 }
-]`
+var testSourceData = []m.Source{
+	{ID: 1, Name: "Source1", SourceTypeID: 1, TenantID: 1},
+	{ID: 2, Name: "Source2", SourceTypeID: 1, TenantID: 1},
+}
 
 func TestSourceList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources", nil)
@@ -23,6 +23,7 @@ func TestSourceList(t *testing.T) {
 	c.Set("limit", 99)
 	c.Set("offset", -1)
 	c.Set("filters", []middleware.Filter{})
+	c.Set("tenantID", int64(1))
 
 	err := SourceList(c)
 	if err != nil {
@@ -69,6 +70,7 @@ func TestSourceGet(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.SetParamNames("id")
 	c.SetParamValues("1")
+	c.Set("tenantID", int64(1))
 
 	err := SourceGet(c)
 	if err != nil {

--- a/source_type_handlers_test.go
+++ b/source_type_handlers_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-var sourceTypesData = `[
-	{"id": 1, "name": "amazon"}
-]`
+var testSourceTypeData = []m.SourceType{
+	{Id: 1, Name: "amazon"},
+}
 
 func TestSourceTypeList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/source_types", nil)


### PR DESCRIPTION
Ok this is a large one. 

This adds support for running tests against the _actual_ db by running `go test -integration` instead of the regular. I converted the admittedly hacky JSON test data types in the handler tests to regular struct arrays so we can insert them OR use them in the mockDaos. 

Also finding out that GORM itself needs the IDs spelled like `ID` instead of `Id` in order to get associations to work, so I think I got most of those here. 