### PR TITLE
Add 'sort_by' query parameter support

### DIFF
--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -14,13 +14,13 @@ import (
 // function that defines how we get the dao - default implementation below.
 var getApplicationTypeDao func(c echo.Context) (dao.ApplicationTypeDao, error)
 
-func getApplicationTypeDaoWithoutTenant(c echo.Context) (dao.ApplicationTypeDao, error) {
+func getApplicationTypeDaoWithTenant(c echo.Context) (dao.ApplicationTypeDao, error) {
 	var tenantID int64
 	var ok bool
+	tenantVal := c.Get("tenantID")
 
-	tenancyRequired := !(c.Get("withoutTenancy") == true)
-
-	if tenancyRequired {
+	// if we set the tenant on this request - include it. otherwise do not.
+	if tenantVal != nil {
 		tenantVal := c.Get("tenantID")
 		if tenantID, ok = tenantVal.(int64); !ok {
 			return nil, fmt.Errorf("failed to pull tenant from request")

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -74,7 +74,6 @@ func TestApplicationTypeList(t *testing.T) {
 	c.Set("limit", 100)
 	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
-	c.Set("withoutTenancy", true)
 
 	err := ApplicationTypeList(c)
 	if err != nil {
@@ -123,7 +122,6 @@ func TestApplicationTypeGet(t *testing.T) {
 	c := e.NewContext(req, rec)
 	c.SetParamNames("id")
 	c.SetParamValues("1")
-	c.Set("withoutTenancy", true)
 
 	err := ApplicationTypeGet(c)
 	if err != nil {

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -17,7 +17,7 @@ func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 		Offset(offset).
 		Where("tenant_id = ?", a.TenantID)
 
-	err := applyFilters(query, filters)
+	query, err := applyFilters(query, filters)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -20,7 +20,7 @@ func (a *ApplicationDaoImpl) SubCollectionList(primaryCollection interface{}, li
 
 	query := sourceType.HasMany(&m.Application{}, DB.Debug())
 
-	err = applyFilters(query, filters)
+	query, err = applyFilters(query, filters)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -38,7 +38,7 @@ func (a *ApplicationDaoImpl) List(limit int, offset int, filters []middleware.Fi
 		Offset(offset).
 		Where("tenant_id = ?", a.TenantID)
 
-	err := applyFilters(query, filters)
+	query, err := applyFilters(query, filters)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -36,7 +36,7 @@ func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []middleware.Fi
 	apptypes := make([]m.ApplicationType, 0, limit)
 	query := DB.Model(&m.ApplicationType{}).Debug()
 
-	err := applyFilters(query, filters)
+	query, err := applyFilters(query, filters)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -21,7 +21,7 @@ func (a *EndpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit
 	query := sourceType.HasMany(&m.Endpoint{}, DB.Debug())
 	query = query.Where("endpoints.tenant_id = ?", a.TenantID)
 
-	err = applyFilters(query, filters)
+	query, err = applyFilters(query, filters)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -39,7 +39,7 @@ func (a *EndpointDaoImpl) List(limit int, offset int, filters []middleware.Filte
 		Offset(offset).
 		Where("tenant_id = ?", a.TenantID)
 
-	err := applyFilters(query, filters)
+	query, err := applyFilters(query, filters)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/dao/filtering.go
+++ b/dao/filtering.go
@@ -56,6 +56,8 @@ func applyFilters(query *gorm.DB, filters []middleware.Filter) error {
 			query = query.Where(fmt.Sprintf("%v ILIKE ?", filterName), fmt.Sprintf("%s%%", filter.Value[0]))
 		case "[ends_with_i]":
 			query = query.Where(fmt.Sprintf("%v ILIKE ?", filterName), fmt.Sprintf("%%%s", filter.Value[0]))
+		case "sort_by":
+			query = query.Order(filter.Value[0])
 		default:
 			return fmt.Errorf("unsupported operation %v", filter.Operation)
 		}

--- a/dao/filtering.go
+++ b/dao/filtering.go
@@ -8,11 +8,11 @@ import (
 	"gorm.io/gorm"
 )
 
-func applyFilters(query *gorm.DB, filters []middleware.Filter) error {
+func applyFilters(query *gorm.DB, filters []middleware.Filter) (*gorm.DB, error) {
 	if query.Statement.Table == "" {
 		err := query.Statement.Parse(query.Statement.Model)
 		if err != nil {
-			return fmt.Errorf("failed to parse statement: %v", err)
+			return nil, fmt.Errorf("failed to parse statement: %v", err)
 		}
 	}
 	var filterName string
@@ -59,9 +59,9 @@ func applyFilters(query *gorm.DB, filters []middleware.Filter) error {
 		case "sort_by":
 			query = query.Order(filter.Value[0])
 		default:
-			return fmt.Errorf("unsupported operation %v", filter.Operation)
+			return nil, fmt.Errorf("unsupported operation %v", filter.Operation)
 		}
 	}
 
-	return nil
+	return query, nil
 }

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -12,16 +12,16 @@ type MetaDataDaoImpl struct {
 }
 
 func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.MetaData, *int64, error) {
-	endpoints := make([]m.MetaData, 0, limit)
-	sourceType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
+	metadatas := make([]m.MetaData, 0, limit)
+	collection, err := m.NewRelationObject(primaryCollection, -1, DB.Debug())
 	if err != nil {
 		return nil, nil, err
 	}
 
-	query := sourceType.HasMany(&m.MetaData{}, DB.Debug())
+	query := collection.HasMany(&m.MetaData{}, DB.Debug())
 	query = query.Where("meta_data.type = 'AppMetaData'")
 
-	err = applyFilters(query, filters)
+	query, err = applyFilters(query, filters)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -29,15 +29,15 @@ func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit
 	count := int64(0)
 	query.Model(&m.MetaData{}).Count(&count)
 
-	result := query.Limit(limit).Offset(offset).Find(&endpoints)
-	return endpoints, &count, result.Error
+	result := query.Limit(limit).Offset(offset).Find(&metadatas)
+	return metadatas, &count, result.Error
 }
 
 func (a *MetaDataDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
 	metaData := make([]m.MetaData, 0, limit)
 	query := DB.Debug().Model(&m.MetaData{})
 
-	err := applyFilters(query, filters)
+	query, err := applyFilters(query, filters)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -24,7 +24,7 @@ func (s *SourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 
 	query = query.Where("sources.tenant_id = ?", s.TenantID)
 
-	err = applyFilters(query, filters)
+	query, err = applyFilters(query, filters)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +45,7 @@ func (s *SourceDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]
 		Offset(offset).
 		Where("tenant_id = ?", s.TenantID)
 
-	err := applyFilters(query, filters)
+	query, err := applyFilters(query, filters)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -14,7 +14,7 @@ func (a *SourceTypeDaoImpl) List(limit, offset int, filters []middleware.Filter)
 	sourceTypes := make([]m.SourceType, 0, limit)
 	query := DB.Debug().Model(&m.SourceType{})
 
-	err := applyFilters(query, filters)
+	query, err := applyFilters(query, filters)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/main.go
+++ b/main.go
@@ -34,10 +34,10 @@ func main() {
 	getSourceDao = getSourceDaoWithTenant
 	getApplicationDao = getApplicationDaoWithTenant
 	getApplicationAuthenticationDao = getApplicationAuthenticationDaoWithTenant
-	getApplicationTypeDao = getApplicationTypeDaoWithoutTenant
+	getApplicationTypeDao = getApplicationTypeDaoWithTenant
 	getSourceTypeDao = getSourceTypeDaoWithoutTenant
 	getEndpointDao = getEndpointDaoWithTenant
-	getMetaDataDao = getMetaDataDaoWithoutTenant
+	getMetaDataDao = getMetaDataDaoWithTenant
 
 	e.Logger.Fatal(e.Start(":8000"))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -49,10 +49,10 @@ func TestMain(t *testing.M) {
 		getSourceDao = getSourceDaoWithTenant
 		getApplicationDao = getApplicationDaoWithTenant
 		getEndpointDao = getEndpointDaoWithTenant
-		getApplicationTypeDao = getApplicationTypeDaoWithoutTenant
+		getApplicationTypeDao = getApplicationTypeDaoWithTenant
 		getApplicationAuthenticationDao = getApplicationAuthenticationDaoWithTenant
 		getSourceTypeDao = getSourceTypeDaoWithoutTenant
-		getMetaDataDao = getMetaDataDaoWithoutTenant
+		getMetaDataDao = getMetaDataDaoWithTenant
 
 		dao.DB.Create(&m.Tenant{Id: 1})
 

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -14,14 +14,13 @@ import (
 // function that defines how we get the dao - default implementation below.
 var getMetaDataDao func(c echo.Context) (dao.MetaDataDao, error)
 
-func getMetaDataDaoWithoutTenant(c echo.Context) (dao.MetaDataDao, error) {
+func getMetaDataDaoWithTenant(c echo.Context) (dao.MetaDataDao, error) {
 	var tenantID int64
 	var ok bool
+	tenantVal := c.Get("tenantID")
 
-	tenancyRequired := !(c.Get("withoutTenancy") == true)
-
-	if tenancyRequired {
-		tenantVal := c.Get("tenantID")
+	// if we set the tenant on this request - include it. otherwise do not.
+	if tenantVal != nil {
 		if tenantID, ok = tenantVal.(int64); !ok {
 			return nil, fmt.Errorf("failed to pull tenant from request")
 		}

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -21,12 +21,7 @@ func TestParseFilterWithOperation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?filter[name][eq]=test", nil)
 	c := e.NewContext(req, nil)
 
-	parseFilterIntoRequest(c)
-
-	filters, ok := c.Get("filters").([]Filter)
-	if !ok {
-		t.Error("filter did not parse correctly")
-	}
+	filters := parseFilter(c)
 
 	if len(filters) != 1 {
 		t.Error("wrong number of filters")
@@ -51,12 +46,7 @@ func TestParseFilterWithoutOperation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?filter[name]=test", nil)
 	c := e.NewContext(req, nil)
 
-	parseFilterIntoRequest(c)
-
-	filters, ok := c.Get("filters").([]Filter)
-	if !ok {
-		t.Error("filter did not parse correctly")
-	}
+	filters := parseFilter(c)
 
 	if len(filters) != 1 {
 		t.Error("wrong number of filters")
@@ -74,5 +64,51 @@ func TestParseFilterWithoutOperation(t *testing.T) {
 
 	if f.Value[0] != "test" {
 		t.Error("did not parse value correctly")
+	}
+}
+
+func TestParseSorting(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?sort_by=name", nil)
+	c := e.NewContext(req, nil)
+
+	sortFilter := parseSorting(c)
+
+	if sortFilter == nil {
+		t.Error("sorting did not parse correctly")
+		t.FailNow()
+	}
+
+	if len(sortFilter.Value) != 1 {
+		t.Error("wrong number of sorts")
+	}
+
+	s := sortFilter.Value[0]
+
+	if s != "name" {
+		t.Error("sort value did not get parsed correctly")
+	}
+}
+
+func TestParseSortingMultiple(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?sort_by=name&sort_by=uid", nil)
+	c := e.NewContext(req, nil)
+
+	sortFilter := parseSorting(c)
+
+	if sortFilter == nil {
+		t.Error("sorting did not parse correctly")
+		t.FailNow()
+	}
+
+	if len(sortFilter.Value) != 2 {
+		t.Error("wrong number of sorts")
+	}
+
+	if sortFilter.Value[0] != "name" {
+		t.Error("sort[0] value did not get parsed correctly")
+	}
+
+	if sortFilter.Value[1] != "uid" {
+		t.Error("sort[1] value did not get parsed correctly")
 	}
 }

--- a/middleware/pagination.go
+++ b/middleware/pagination.go
@@ -8,7 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func ParsePagination(next echo.HandlerFunc) echo.HandlerFunc {
+func Pagination(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		err := parsePaginationIntoContext(c)
 		if err != nil {

--- a/routes.go
+++ b/routes.go
@@ -32,43 +32,43 @@ func setupRoutes(e *echo.Echo) {
 		return c.String(http.StatusOK, out)
 	})
 
-	v3 := e.Group("/api/sources/v3.1", enforceTenancy, middleware.HandleErrors)
+	v3 := e.Group("/api/sources/v3.1", middleware.HandleErrors)
 
 	// Sources
-	v3.GET("/sources", SourceList, middleware.ParseFilter, middleware.ParsePagination)
-	v3.GET("/sources/:id", SourceGet)
-	v3.POST("/sources", SourceCreate)
-	v3.PATCH("/sources/:id", SourceEdit)
-	v3.DELETE("/sources/:id", SourceDelete)
-	v3.GET("/sources/:source_id/application_types", SourceListApplicationTypes, middleware.ParseFilter, middleware.ParsePagination)
-	v3.GET("/sources/:source_id/applications", SourceListApplications, middleware.ParseFilter, middleware.ParsePagination)
-	v3.GET("/sources/:source_id/endpoints", SourceListEndpoint, middleware.ParseFilter, middleware.ParsePagination)
+	v3.GET("/sources", SourceList, enforceTenancy, middleware.SortAndFilter, middleware.Pagination)
+	v3.GET("/sources/:id", SourceGet, enforceTenancy)
+	v3.POST("/sources", SourceCreate, enforceTenancy)
+	v3.PATCH("/sources/:id", SourceEdit, enforceTenancy)
+	v3.DELETE("/sources/:id", SourceDelete, enforceTenancy)
+	v3.GET("/sources/:source_id/application_types", SourceListApplicationTypes, middleware.SortAndFilter, middleware.Pagination)
+	v3.GET("/sources/:source_id/applications", SourceListApplications, middleware.SortAndFilter, middleware.Pagination)
+	v3.GET("/sources/:source_id/endpoints", SourceListEndpoint, middleware.SortAndFilter, middleware.Pagination)
 
 	// Applications
-	v3.GET("/applications", ApplicationList, middleware.ParseFilter, middleware.ParsePagination)
-	v3.GET("/applications/:id", ApplicationGet)
+	v3.GET("/applications", ApplicationList, enforceTenancy, middleware.SortAndFilter, middleware.Pagination)
+	v3.GET("/applications/:id", ApplicationGet, enforceTenancy)
 
 	// ApplicationTypes
-	v3.GET("/application_types", ApplicationTypeList, middleware.ParseFilter, middleware.ParsePagination, withoutTenancy)
+	v3.GET("/application_types", ApplicationTypeList, middleware.SortAndFilter, middleware.Pagination, withoutTenancy)
 	v3.GET("/application_types/:id", ApplicationTypeGet, withoutTenancy)
-	v3.GET("/application_types/:application_type_id/sources", ApplicationTypeListSource, middleware.ParseFilter, middleware.ParsePagination)
+	v3.GET("/application_types/:application_type_id/sources", ApplicationTypeListSource, middleware.SortAndFilter, middleware.Pagination)
 
 	// Endpoints
-	v3.GET("/endpoints", EndpointList, middleware.ParseFilter, middleware.ParsePagination)
+	v3.GET("/endpoints", EndpointList, middleware.SortAndFilter, middleware.Pagination)
 	v3.GET("/endpoints/:id", EndpointGet)
 
 	// ApplicationAuthentications
-	v3.GET("/application_authentications", ApplicationAuthenticationList, middleware.ParseFilter, middleware.ParsePagination)
+	v3.GET("/application_authentications", ApplicationAuthenticationList, middleware.SortAndFilter, middleware.Pagination)
 	v3.GET("/application_authentications/:id", ApplicationAuthenticationGet)
 
-	v3.GET("/app_meta_data", MetaDataList, middleware.ParseFilter, middleware.ParsePagination, withoutTenancy)
+	v3.GET("/app_meta_data", MetaDataList, middleware.SortAndFilter, middleware.Pagination, withoutTenancy)
 	v3.GET("/app_meta_data/:id", MetaDataGet, withoutTenancy)
-	v3.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, middleware.ParseFilter, middleware.ParsePagination)
+	v3.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, middleware.SortAndFilter, middleware.Pagination)
 
 	// SourceTypes
-	v3.GET("/source_types", SourceTypeList, middleware.ParseFilter, middleware.ParsePagination)
+	v3.GET("/source_types", SourceTypeList, middleware.SortAndFilter, middleware.Pagination)
 	v3.GET("/source_types/:id", SourceTypeGet)
-	v3.GET("/source_types/:source_type_id/sources", SourceTypeListSource, middleware.ParseFilter, middleware.ParsePagination)
+	v3.GET("/source_types/:source_type_id/sources", SourceTypeListSource, middleware.SortAndFilter, middleware.Pagination)
 }
 
 func withoutTenancy(next echo.HandlerFunc) echo.HandlerFunc {


### PR DESCRIPTION
Added `sort_by` support on list operations, since we have customers that use that a lot. 

also moved the `enforceTenancy` call out of the base group and only included it where it's needed (Source + Application for now, don't need it on the *Type endpoints)