### PR TITLE
Refactor DAO methods to return int64 instead of *int64

### DIFF
--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -52,7 +52,7 @@ func ApplicationAuthenticationList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
 }
 
 func ApplicationAuthenticationGet(c echo.Context) error {

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -52,7 +52,7 @@ func ApplicationList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
 }
 
 func ApplicationGet(c echo.Context) error {

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -45,7 +45,7 @@ func ApplicationTypeList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
 }
 
 func ApplicationTypeGet(c echo.Context) error {

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -11,7 +11,7 @@ type ApplicationAuthenticationDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationAuthentication, *int64, error) {
+func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationAuthentication, int64, error) {
 	applications := make([]m.ApplicationAuthentication, 0, limit)
 	query := DB.Debug().
 		Offset(offset).
@@ -19,14 +19,14 @@ func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 
 	err := applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	count := int64(0)
 	query.Model(&m.ApplicationAuthentication{}).Count(&count)
 
 	result := query.Limit(limit).Find(&applications)
-	return applications, &count, result.Error
+	return applications, count, result.Error
 }
 
 func (a *ApplicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAuthentication, error) {

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -11,7 +11,7 @@ type ApplicationDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Application, *int64, error) {
+func (a *ApplicationDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
 	applications := make([]m.Application, 0, limit)
 	query := DB.Debug().
 		Offset(offset).
@@ -19,14 +19,14 @@ func (a *ApplicationDaoImpl) List(limit int, offset int, filters []middleware.Fi
 
 	err := applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	count := int64(0)
 	query.Model(&m.Application{}).Count(&count)
 
 	result := query.Limit(limit).Find(&applications)
-	return applications, &count, result.Error
+	return applications, count, result.Error
 }
 
 func (a *ApplicationDaoImpl) GetById(id *int64) (*m.Application, error) {

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -8,7 +8,7 @@ import (
 type ApplicationTypeDaoImpl struct {
 }
 
-func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, *int64, error) {
+func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {
 	// allocating a slice of application types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	apptypes := make([]m.ApplicationType, 0, limit)
@@ -16,7 +16,7 @@ func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []middleware.Fi
 
 	err := applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	// getting the total count (filters included) for pagination
@@ -26,7 +26,7 @@ func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []middleware.Fi
 	// limiting + running the actual query.
 	result := query.Limit(limit).Offset(offset).Find(&apptypes)
 
-	return apptypes, &count, result.Error
+	return apptypes, count, result.Error
 }
 
 func (a *ApplicationTypeDaoImpl) GetById(id *int64) (*m.ApplicationType, error) {

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -11,7 +11,7 @@ type EndpointDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *EndpointDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, *int64, error) {
+func (a *EndpointDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
 	query := DB.Debug().
 		Offset(offset).
@@ -19,14 +19,14 @@ func (a *EndpointDaoImpl) List(limit int, offset int, filters []middleware.Filte
 
 	err := applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	count := int64(0)
 	query.Model(&m.Endpoint{}).Count(&count)
 
 	result := query.Limit(limit).Find(&endpoints)
-	return endpoints, &count, result.Error
+	return endpoints, count, result.Error
 }
 
 func (a *EndpointDaoImpl) GetById(id *int64) (*m.Endpoint, error) {

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -6,7 +6,7 @@ import (
 )
 
 type SourceDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.Source, *int64, error)
+	List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error)
 	GetById(id *int64) (*m.Source, error)
 	Create(src *m.Source) error
 	Update(src *m.Source) error
@@ -15,7 +15,7 @@ type SourceDao interface {
 }
 
 type ApplicationDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.Application, *int64, error)
+	List(limit, offset int, filters []middleware.Filter) ([]m.Application, int64, error)
 	GetById(id *int64) (*m.Application, error)
 	Create(src *m.Application) error
 	Update(src *m.Application) error
@@ -24,7 +24,7 @@ type ApplicationDao interface {
 }
 
 type ApplicationAuthenticationDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationAuthentication, *int64, error)
+	List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationAuthentication, int64, error)
 	GetById(id *int64) (*m.ApplicationAuthentication, error)
 	Create(src *m.ApplicationAuthentication) error
 	Update(src *m.ApplicationAuthentication) error
@@ -33,7 +33,7 @@ type ApplicationAuthenticationDao interface {
 }
 
 type ApplicationTypeDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, *int64, error)
+	List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error)
 	GetById(id *int64) (*m.ApplicationType, error)
 	Create(src *m.ApplicationType) error
 	Update(src *m.ApplicationType) error
@@ -41,7 +41,7 @@ type ApplicationTypeDao interface {
 }
 
 type EndpointDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.Endpoint, *int64, error)
+	List(limit, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error)
 	GetById(id *int64) (*m.Endpoint, error)
 	Create(src *m.Endpoint) error
 	Update(src *m.Endpoint) error
@@ -50,7 +50,7 @@ type EndpointDao interface {
 }
 
 type MetaDataDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.MetaData, *int64, error)
+	List(limit, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error)
 	GetById(id *int64) (*m.MetaData, error)
 	Create(src *m.MetaData) error
 	Update(src *m.MetaData) error
@@ -58,7 +58,7 @@ type MetaDataDao interface {
 }
 
 type SourceTypeDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.SourceType, *int64, error)
+	List(limit, offset int, filters []middleware.Filter) ([]m.SourceType, int64, error)
 	GetById(id *int64) (*m.SourceType, error)
 	Create(src *m.SourceType) error
 	Update(src *m.SourceType) error

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -10,20 +10,20 @@ import (
 type MetaDataDaoImpl struct {
 }
 
-func (a *MetaDataDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.MetaData, *int64, error) {
+func (a *MetaDataDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
 	metaData := make([]m.MetaData, 0, limit)
 	query := DB.Debug()
 
 	err := applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	count := int64(0)
 	query.Model(&m.MetaData{}).Count(&count)
 
 	result := query.Limit(limit).Find(&metaData)
-	return metaData, &count, result.Error
+	return metaData, count, result.Error
 }
 
 func (a *MetaDataDaoImpl) GetById(id *int64) (*m.MetaData, error) {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -34,9 +34,9 @@ type MockMetaDataDao struct {
 	MetaDatas []m.MetaData
 }
 
-func (m *MockSourceDao) List(limit, offset int, filters []middleware.Filter) ([]m.Source, *int64, error) {
+func (m *MockSourceDao) List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
 	count := int64(len(m.Sources))
-	return m.Sources, &count, nil
+	return m.Sources, count, nil
 }
 
 func (m *MockSourceDao) GetById(id *int64) (*m.Source, error) {
@@ -66,9 +66,9 @@ func (m *MockSourceDao) Tenant() *int64 {
 	return &tenant
 }
 
-func (a *MockApplicationTypeDao) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationType, *int64, error) {
+func (a *MockApplicationTypeDao) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {
 	count := int64(len(a.ApplicationTypes))
-	return a.ApplicationTypes, &count, nil
+	return a.ApplicationTypes, count, nil
 }
 
 func (a *MockApplicationTypeDao) GetById(id *int64) (*m.ApplicationType, error) {
@@ -81,9 +81,9 @@ func (a *MockApplicationTypeDao) GetById(id *int64) (*m.ApplicationType, error) 
 	return nil, fmt.Errorf("application Type not found")
 }
 
-func (a *MockMetaDataDao) List(limit int, offset int, filters []middleware.Filter) ([]m.MetaData, *int64, error) {
+func (a *MockMetaDataDao) List(limit int, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
 	count := int64(len(a.MetaDatas))
-	return a.MetaDatas, &count, nil
+	return a.MetaDatas, count, nil
 }
 
 func (a *MockMetaDataDao) GetById(id *int64) (*m.MetaData, error) {
@@ -120,9 +120,9 @@ func (a *MockApplicationTypeDao) Delete(id *int64) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *MockSourceTypeDao) List(limit int, offset int, filters []middleware.Filter) ([]m.SourceType, *int64, error) {
+func (a *MockSourceTypeDao) List(limit int, offset int, filters []middleware.Filter) ([]m.SourceType, int64, error) {
 	count := int64(len(a.SourceTypes))
-	return a.SourceTypes, &count, nil
+	return a.SourceTypes, count, nil
 }
 
 func (a *MockSourceTypeDao) GetById(id *int64) (*m.SourceType, error) {
@@ -147,9 +147,9 @@ func (a *MockSourceTypeDao) Delete(id *int64) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *MockApplicationDao) List(limit int, offset int, filters []middleware.Filter) ([]m.Application, *int64, error) {
+func (a *MockApplicationDao) List(limit int, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
 	count := int64(len(a.Applications))
-	return a.Applications, &count, nil
+	return a.Applications, count, nil
 }
 
 func (a *MockApplicationDao) GetById(id *int64) (*m.Application, error) {
@@ -179,9 +179,9 @@ func (a *MockApplicationDao) Tenant() *int64 {
 	return &tenant
 }
 
-func (a *MockEndpointDao) List(limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, *int64, error) {
+func (a *MockEndpointDao) List(limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {
 	count := int64(len(a.Endpoints))
-	return a.Endpoints, &count, nil
+	return a.Endpoints, count, nil
 }
 
 func (a *MockEndpointDao) GetById(id *int64) (*m.Endpoint, error) {
@@ -221,9 +221,9 @@ func (a *MockApplicationAuthenticationDao) GetById(id *int64) (*m.ApplicationAut
 	return nil, fmt.Errorf("endpoint not found")
 }
 
-func (a *MockApplicationAuthenticationDao) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationAuthentication, *int64, error) {
+func (a *MockApplicationAuthenticationDao) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationAuthentication, int64, error) {
 	count := int64(len(a.ApplicationAuthentications))
-	return a.ApplicationAuthentications, &count, nil
+	return a.ApplicationAuthentications, count, nil
 }
 
 func (a *MockApplicationAuthenticationDao) Create(src *m.ApplicationAuthentication) error {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -11,7 +11,7 @@ type SourceDaoImpl struct {
 	TenantID *int64
 }
 
-func (s *SourceDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.Source, *int64, error) {
+func (s *SourceDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
 	sources := make([]m.Source, 0, limit)
 	query := DB.Debug().
 		Offset(offset).
@@ -19,7 +19,7 @@ func (s *SourceDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]
 
 	err := applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	// getting the total count (filters included) for pagination
@@ -29,7 +29,7 @@ func (s *SourceDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]
 	// limiting + running the actual query.
 	result := query.Limit(limit).Find(&sources)
 
-	return sources, &count, result.Error
+	return sources, count, result.Error
 }
 
 func (s *SourceDaoImpl) GetById(id *int64) (*m.Source, error) {

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -8,7 +8,7 @@ import (
 type SourceTypeDaoImpl struct {
 }
 
-func (a *SourceTypeDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.SourceType, *int64, error) {
+func (a *SourceTypeDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.SourceType, int64, error) {
 	// allocating a slice of source types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	sourceTypes := make([]m.SourceType, 0, limit)
@@ -16,7 +16,7 @@ func (a *SourceTypeDaoImpl) List(limit, offset int, filters []middleware.Filter)
 
 	err := applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	// getting the total count (filters included) for pagination
@@ -26,7 +26,7 @@ func (a *SourceTypeDaoImpl) List(limit, offset int, filters []middleware.Filter)
 	// limiting + running the actual query.
 	result := query.Limit(limit).Offset(offset).Find(&sourceTypes)
 
-	return sourceTypes, &count, result.Error
+	return sourceTypes, count, result.Error
 }
 
 func (a *SourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -52,7 +52,7 @@ func EndpointList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
 }
 
 func EndpointGet(c echo.Context) error {

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -44,7 +44,7 @@ func MetaDataList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
 }
 
 func MetaDataGet(c echo.Context) error {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -53,7 +53,7 @@ func SourceList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
 }
 
 func SourceGet(c echo.Context) error {

--- a/source_type_handlers.go
+++ b/source_type_handlers.go
@@ -47,7 +47,7 @@ func SourceTypeList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
 }
 
 func SourceTypeGet(c echo.Context) error {


### PR DESCRIPTION
Refactors the "list" methods of the DAOs to return values instead of pointers. In the case of having errors, the zero value for the `int64` is returned.

[[RHCLOUD-16095]](https://issues.redhat.com/browse/RHCLOUD-16095)