### PR TITLE
Don't escape links in response

### DIFF
--- a/application_handlers.go
+++ b/application_handlers.go
@@ -64,7 +64,7 @@ func SourceListApplications(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
 }
 
 func ApplicationList(c echo.Context) error {
@@ -101,7 +101,7 @@ func ApplicationList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
 }
 
 func ApplicationGet(c echo.Context) error {

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -32,8 +32,8 @@ func TestSourceApplicationSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/applications", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set("limit", 99)
-	c.Set("offset", -1)
+	c.Set("limit", 100)
+	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
 	c.Set("tenantID", int64(1))
 	c.SetParamNames("source_id")
@@ -54,11 +54,11 @@ func TestSourceApplicationSubcollectionList(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if out.Meta.Limit != 99 {
+	if out.Meta.Limit != 100 {
 		t.Error("limit not set correctly")
 	}
 
-	if out.Meta.Offset != -1 {
+	if out.Meta.Offset != 0 {
 		t.Error("offset not set correctly")
 	}
 
@@ -76,12 +76,14 @@ func TestSourceApplicationSubcollectionList(t *testing.T) {
 		if s["id"] != "1" && s["id"] != "2" {
 			t.Error("ghosts infected the return")
 		}
-
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/applications", nil)
+	path := "/api/sources/v3.1/applications"
+	req := httptest.NewRequest(http.MethodGet, path, nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.Set("limit", 100)
@@ -126,6 +128,8 @@ func TestApplicationList(t *testing.T) {
 			t.Error("ghosts infected the return")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationGet(t *testing.T) {

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -71,7 +71,7 @@ func SourceListApplicationTypes(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
 }
 
 func ApplicationTypeList(c echo.Context) error {
@@ -108,7 +108,7 @@ func ApplicationTypeList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
 }
 
 func ApplicationTypeGet(c echo.Context) error {

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -16,11 +16,11 @@ var testApplicationTypeData = []m.ApplicationType{
 }
 
 func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/:source_id/application_types", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/application_types", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set("limit", 99)
-	c.Set("offset", -1)
+	c.Set("limit", 100)
+	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
 	c.Set("tenantID", int64(1))
 	c.SetParamNames("source_id")
@@ -41,11 +41,11 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if out.Meta.Limit != 99 {
+	if out.Meta.Limit != 100 {
 		t.Error("limit not set correctly")
 	}
 
-	if out.Meta.Offset != -1 {
+	if out.Meta.Offset != 0 {
 		t.Error("offset not set correctly")
 	}
 
@@ -63,6 +63,8 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 			t.Error("ghosts infected the return")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationTypeList(t *testing.T) {
@@ -111,6 +113,8 @@ func TestApplicationTypeList(t *testing.T) {
 			t.Error("ghosts infected the return")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationTypeGet(t *testing.T) {

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -64,7 +64,7 @@ func SourceListEndpoint(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
 }
 
 func EndpointList(c echo.Context) error {
@@ -100,7 +100,7 @@ func EndpointList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
 }
 
 func EndpointGet(c echo.Context) error {

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -20,8 +20,8 @@ func TestSourceEndpointSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/endpoints", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set("limit", 99)
-	c.Set("offset", -1)
+	c.Set("limit", 100)
+	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
 	c.Set("tenantID", int64(1))
 	c.SetParamNames("source_id")
@@ -42,11 +42,11 @@ func TestSourceEndpointSubcollectionList(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if out.Meta.Limit != 99 {
+	if out.Meta.Limit != 100 {
 		t.Error("limit not set correctly")
 	}
 
-	if out.Meta.Offset != -1 {
+	if out.Meta.Offset != 0 {
 		t.Error("offset not set correctly")
 	}
 
@@ -65,6 +65,8 @@ func TestSourceEndpointSubcollectionList(t *testing.T) {
 			t.Error("ghosts infected the return")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestEndpointList(t *testing.T) {
@@ -109,6 +111,8 @@ func TestEndpointList(t *testing.T) {
 			t.Error("model did not deserialize as a endpoint")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestEndpointGet(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -160,4 +161,16 @@ func testDbString(dbname string) string {
 		config.Get().DatabaseHost,
 		config.Get().DatabasePort,
 	)
+}
+
+func AssertLinks(t *testing.T, path string, links util.Links, limit int, offset int) {
+	expectedFirstLink := fmt.Sprintf("%s/?limit=%d&offset=%d", path, limit, offset)
+	expectedLastLink := fmt.Sprintf("%s/?limit=%d&offset=%d", path, limit, limit+offset)
+	if links.First != expectedFirstLink {
+		t.Error("first link is not correct for " + path)
+	}
+
+	if links.Last != expectedLastLink {
+		t.Error("last link is not correct for " + path)
+	}
 }

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -64,7 +64,7 @@ func MetaDataList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
 }
 
 func ApplicationTypeListMetaData(c echo.Context) error {
@@ -104,7 +104,7 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
 }
 
 func MetaDataGet(c echo.Context) error {

--- a/meta_data_handlers_test.go
+++ b/meta_data_handlers_test.go
@@ -20,8 +20,8 @@ func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/:application_type_id/app_meta_data", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set("limit", 99)
-	c.Set("offset", -1)
+	c.Set("limit", 100)
+	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
 	c.Set("tenantID", int64(1))
 	c.SetParamNames("application_type_id")
@@ -42,11 +42,11 @@ func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if out.Meta.Limit != 99 {
+	if out.Meta.Limit != 100 {
 		t.Error("limit not set correctly")
 	}
 
-	if out.Meta.Offset != -1 {
+	if out.Meta.Offset != 0 {
 		t.Error("offset not set correctly")
 	}
 
@@ -65,6 +65,8 @@ func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
 			t.Error("ghosts infected the return")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestMetaDataList(t *testing.T) {
@@ -109,6 +111,8 @@ func TestMetaDataList(t *testing.T) {
 			t.Error("model did not deserialize as a application")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestMetaDataGet(t *testing.T) {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -59,7 +59,7 @@ func SourceList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
 }
 func SourceTypeListSource(c echo.Context) error {
 	sourcesDB, err := getSourceDao(c)
@@ -99,7 +99,7 @@ func SourceTypeListSource(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
 }
 
 func ApplicationTypeListSource(c echo.Context) error {
@@ -140,7 +140,7 @@ func ApplicationTypeListSource(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
 }
 
 func SourceGet(c echo.Context) error {

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -20,8 +20,8 @@ func TestSourceTypeSourceSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/source_types/1/sources", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set("limit", 99)
-	c.Set("offset", -1)
+	c.Set("limit", 100)
+	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
 	c.Set("tenantID", int64(1))
 	c.SetParamNames("source_type_id")
@@ -42,11 +42,11 @@ func TestSourceTypeSourceSubcollectionList(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if out.Meta.Limit != 99 {
+	if out.Meta.Limit != 100 {
 		t.Error("limit not set correctly")
 	}
 
-	if out.Meta.Offset != -1 {
+	if out.Meta.Offset != 0 {
 		t.Error("offset not set correctly")
 	}
 
@@ -62,14 +62,16 @@ func TestSourceTypeSourceSubcollectionList(t *testing.T) {
 		}
 
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationSourceSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/1/sources", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set("limit", 99)
-	c.Set("offset", -1)
+	c.Set("limit", 100)
+	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
 	c.Set("tenantID", int64(1))
 	c.SetParamNames("application_type_id")
@@ -90,11 +92,11 @@ func TestApplicationSourceSubcollectionList(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if out.Meta.Limit != 99 {
+	if out.Meta.Limit != 100 {
 		t.Error("limit not set correctly")
 	}
 
-	if out.Meta.Offset != -1 {
+	if out.Meta.Offset != 0 {
 		t.Error("offset not set correctly")
 	}
 
@@ -112,14 +114,16 @@ func TestApplicationSourceSubcollectionList(t *testing.T) {
 			t.Error("ghosts infected the return")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestSourceList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	c.Set("limit", 99)
-	c.Set("offset", -1)
+	c.Set("limit", 100)
+	c.Set("offset", 0)
 	c.Set("filters", []middleware.Filter{})
 	c.Set("tenantID", int64(1))
 
@@ -138,11 +142,11 @@ func TestSourceList(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if out.Meta.Limit != 99 {
+	if out.Meta.Limit != 100 {
 		t.Error("limit not set correctly")
 	}
 
-	if out.Meta.Offset != -1 {
+	if out.Meta.Offset != 0 {
 		t.Error("offset not set correctly")
 	}
 
@@ -160,6 +164,8 @@ func TestSourceList(t *testing.T) {
 			t.Error("ghosts infected the return")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }
 
 func TestSourceGet(t *testing.T) {

--- a/source_type_handlers.go
+++ b/source_type_handlers.go
@@ -47,7 +47,7 @@ func SourceTypeList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
 }
 
 func SourceTypeGet(c echo.Context) error {

--- a/source_type_handlers_test.go
+++ b/source_type_handlers_test.go
@@ -62,4 +62,6 @@ func TestSourceTypeList(t *testing.T) {
 			t.Error("ghosts infected the return")
 		}
 	}
+
+	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
 }

--- a/util/collection_response.go
+++ b/util/collection_response.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"net/url"
 )
 
 type Collection struct {
@@ -34,8 +33,8 @@ func CollectionResponse(collection []interface{}, path string, count, limit, off
 			Offset: offset,
 		},
 		Links: Links{
-			First: fmt.Sprintf("%s/?%s", path, url.QueryEscape(first)),
-			Last:  fmt.Sprintf("%s/?%s", path, url.QueryEscape(last)),
+			First: fmt.Sprintf("%s/?%s", path, first),
+			Last:  fmt.Sprintf("%s/?%s", path, last),
 		},
 	}
 }


### PR DESCRIPTION
1. Use `c.Request().RequestURI` instead of `c.Path()` in handlers's methods
    - `c.Path()` returns pattern like `/applications/:id/sources` and `c.Request().RequestURI` returns requested path


2. Remove url escaping as it is not needed in `CollectionReponse`
  - url escaping is needed for cases for example if we send data as url to server and there are no chars which needs to be escaped

---
### Before

```
GET http://localhost:8000/api/sources/v3.1/sources/2/applications

{
  "data": [
    {
      "availability_status": "available",
      "last_checked_at": "0001-01-01T00:00:00Z",
      "last_available_at": "0001-01-01T00:00:00Z",
      "paused_at": "0001-01-01T00:00:00Z",
      "id": "1",
      "created_at": "2021-09-20T11:58:50.521423Z",
      "updated_at": "2021-09-20T11:58:50.521423Z",
      "extra": {},
      "source_id": "2",
      "application_type_id": "2"
    }
  ],
  "meta": {
    "count": 1,
    "limit": 100,
    "offset": 0
  },
  "links": {
    "first": "/api/sources/v3.1/sources/:source_id/applications/?limit%3D100%26offset%3D0",
    "last": "/api/sources/v3.1/sources/:source_id/applications/?limit%3D100%26offset%3D100"
  }
}
```

### After
```
GET http://localhost:8000/api/sources/v3.1/sources/2/applications

HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Date: Thu, 23 Sep 2021 16:10:51 GMT
Content-Length: 519

{
  "data": [
    {
      "availability_status": "available",
      "last_checked_at": "0001-01-01T00:00:00Z",
      "last_available_at": "0001-01-01T00:00:00Z",
      "paused_at": "0001-01-01T00:00:00Z",
      "id": "1",
      "created_at": "2021-09-20T11:58:50.521423Z",
      "updated_at": "2021-09-20T11:58:50.521423Z",
      "extra": {},
      "source_id": "2",
      "application_type_id": "2"
    }
  ],
  "meta": {
    "count": 1,
    "limit": 100,
    "offset": 0
  },
  "links": {
    "first": "/api/sources/v3.1/sources/2/applications/?limit=100&offset=0",   
    "last": "/api/sources/v3.1/sources/2/applications/?limit=100&offset=100"
  }
}

```
---
### Links

https://issues.redhat.com/browse/RHCLOUD-16317
