### PR TITLE
Remove MAINTAINER from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.4 as build
-MAINTAINER jlindgre@redhat.com
 
 RUN mkdir /build
 WORKDIR /build


### PR DESCRIPTION
MAINTAINER is deprecated per https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
