### PR TITLE
Change CollectionResponse to generate links based on query parameters

### DIFF
--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -52,7 +52,7 @@ func ApplicationAuthenticationList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func ApplicationAuthenticationGet(c echo.Context) error {

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -64,7 +64,7 @@ func SourceListApplications(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
 }
 
 func ApplicationList(c echo.Context) error {
@@ -101,7 +101,7 @@ func ApplicationList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func ApplicationGet(c echo.Context) error {

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -44,7 +44,7 @@ func SourceListApplications(c echo.Context) error {
 
 	var (
 		applications []m.Application
-		count        *int64
+		count        int64
 	)
 
 	id, err := strconv.ParseInt(c.Param("source_id"), 10, 64)
@@ -64,7 +64,7 @@ func SourceListApplications(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func ApplicationList(c echo.Context) error {

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -71,7 +71,7 @@ func SourceListApplicationTypes(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
 }
 
 func ApplicationTypeList(c echo.Context) error {
@@ -108,7 +108,7 @@ func ApplicationTypeList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func ApplicationTypeGet(c echo.Context) error {

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -50,7 +50,7 @@ func SourceListApplicationTypes(c echo.Context) error {
 
 	var (
 		apptypes []m.ApplicationType
-		count    *int64
+		count    int64
 	)
 
 	id, err := strconv.ParseInt(c.Param("source_id"), 10, 64)
@@ -71,7 +71,7 @@ func SourceListApplicationTypes(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func ApplicationTypeList(c echo.Context) error {

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -50,7 +50,7 @@ func AuthenticationList(c echo.Context) error {
 		out = append(out, *auth.ToResponse())
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Path(), int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func AuthenticationGet(c echo.Context) error {

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -11,25 +11,25 @@ type ApplicationDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.Application, *int64, error) {
+func (a *ApplicationDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
 	applications := make([]m.Application, 0, limit)
 	sourceType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	query := sourceType.HasMany(&m.Application{}, DB.Debug())
 
 	query, err = applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	count := int64(0)
 	query.Model(&m.Application{}).Count(&count)
 
 	result := query.Limit(limit).Offset(offset).Find(&applications)
-	return applications, &count, result.Error
+	return applications, count, result.Error
 }
 
 func (a *ApplicationDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -9,14 +9,14 @@ type ApplicationTypeDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, *int64, error) {
+func (a *ApplicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {
 	// allocating a slice of application types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	applicationTypes := make([]m.ApplicationType, 0, limit)
 
 	applicationType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 	query := applicationType.HasMany(&m.ApplicationType{}, DB.Debug())
 
@@ -27,7 +27,7 @@ func (a *ApplicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}
 	// limiting + running the actual query.
 	result := query.Limit(limit).Offset(offset).Find(&applicationTypes)
 
-	return applicationTypes, &count, result.Error
+	return applicationTypes, count, result.Error
 }
 
 func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -11,26 +11,26 @@ type EndpointDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *EndpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, *int64, error) {
+func (a *EndpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
 
 	sourceType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 	query := sourceType.HasMany(&m.Endpoint{}, DB.Debug())
 	query = query.Where("endpoints.tenant_id = ?", a.TenantID)
 
 	query, err = applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	count := int64(0)
 	query.Model(&m.Endpoint{}).Count(&count)
 
 	result := query.Limit(limit).Offset(offset).Find(&endpoints)
-	return endpoints, &count, result.Error
+	return endpoints, count, result.Error
 }
 
 func (a *EndpointDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -7,7 +7,7 @@ import (
 
 type SourceDao interface {
 	List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, *int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error)
 	GetById(id *int64) (*m.Source, error)
 	Create(src *m.Source) error
 	Update(src *m.Source) error
@@ -17,7 +17,7 @@ type SourceDao interface {
 
 type ApplicationDao interface {
 	List(limit, offset int, filters []middleware.Filter) ([]m.Application, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Application, *int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Application, int64, error)
 	GetById(id *int64) (*m.Application, error)
 	Create(src *m.Application) error
 	Update(src *m.Application) error
@@ -45,7 +45,7 @@ type ApplicationAuthenticationDao interface {
 
 type ApplicationTypeDao interface {
 	List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, *int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error)
 	GetById(id *int64) (*m.ApplicationType, error)
 	Create(src *m.ApplicationType) error
 	Update(src *m.ApplicationType) error
@@ -54,7 +54,7 @@ type ApplicationTypeDao interface {
 
 type EndpointDao interface {
 	List(limit, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Endpoint, *int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error)
 	GetById(id *int64) (*m.Endpoint, error)
 	Create(src *m.Endpoint) error
 	Update(src *m.Endpoint) error
@@ -64,7 +64,7 @@ type EndpointDao interface {
 
 type MetaDataDao interface {
 	List(limit, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.MetaData, *int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error)
 	GetById(id *int64) (*m.MetaData, error)
 	Create(src *m.MetaData) error
 	Update(src *m.MetaData) error

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -11,11 +11,11 @@ type MetaDataDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.MetaData, *int64, error) {
+func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
 	metadatas := make([]m.MetaData, 0, limit)
 	collection, err := m.NewRelationObject(primaryCollection, -1, DB.Debug())
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	query := collection.HasMany(&m.MetaData{}, DB.Debug())
@@ -23,14 +23,14 @@ func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit
 
 	query, err = applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	count := int64(0)
 	query.Model(&m.MetaData{}).Count(&count)
 
 	result := query.Limit(limit).Offset(offset).Find(&metadatas)
-	return metadatas, &count, result.Error
+	return metadatas, count, result.Error
 }
 
 func (a *MetaDataDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -34,7 +34,7 @@ type MockMetaDataDao struct {
 	MetaDatas []m.MetaData
 }
 
-func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, *int64, error) {
+func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
 	count := int64(1)
 
 	var sources []m.Source
@@ -53,7 +53,7 @@ func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit
 
 	}
 
-	return sources, &count, nil
+	return sources, count, nil
 }
 
 func (src *MockSourceDao) List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
@@ -108,9 +108,9 @@ func (a *MockMetaDataDao) List(limit int, offset int, filters []middleware.Filte
 	return a.MetaDatas, count, nil
 }
 
-func (a *MockMetaDataDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.MetaData, *int64, error) {
+func (a *MockMetaDataDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
 	count := int64(len(a.MetaDatas))
-	return a.MetaDatas, &count, nil
+	return a.MetaDatas, count, nil
 }
 
 func (a *MockMetaDataDao) GetById(id *int64) (*m.MetaData, error) {
@@ -146,10 +146,10 @@ func (a *MockApplicationTypeDao) Update(src *m.ApplicationType) error {
 func (a *MockApplicationTypeDao) Delete(id *int64) error {
 	panic("not implemented") // TODO: Implement
 }
-func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, *int64, error) {
+func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {
 	count := int64(1) // ApplicationType ID=1
 
-	return []m.ApplicationType{a.ApplicationTypes[0]}, &count, nil
+	return []m.ApplicationType{a.ApplicationTypes[0]}, count, nil
 }
 
 func (a *MockSourceTypeDao) List(limit int, offset int, filters []middleware.Filter) ([]m.SourceType, int64, error) {
@@ -179,9 +179,9 @@ func (a *MockSourceTypeDao) Delete(id *int64) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *MockApplicationDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Application, *int64, error) {
+func (a *MockApplicationDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
 	count := int64(len(a.Applications))
-	return a.Applications, &count, nil
+	return a.Applications, count, nil
 }
 
 func (a *MockApplicationDao) List(limit int, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
@@ -216,9 +216,9 @@ func (a *MockApplicationDao) Tenant() *int64 {
 	return &tenant
 }
 
-func (a *MockEndpointDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Endpoint, *int64, error) {
+func (a *MockEndpointDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {
 	count := int64(len(a.Endpoints))
-	return a.Endpoints, &count, nil
+	return a.Endpoints, count, nil
 }
 
 func (a *MockEndpointDao) List(limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -11,14 +11,14 @@ type SourceDaoImpl struct {
 	TenantID *int64
 }
 
-func (s *SourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, *int64, error) {
+func (s *SourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
 	// allocating a slice of source types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	sources := make([]m.Source, 0, limit)
 
 	sourceType, err := m.NewRelationObject(primaryCollection, *s.TenantID, DB.Debug())
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 	query := sourceType.HasMany(&m.Source{}, DB.Debug())
 
@@ -26,7 +26,7 @@ func (s *SourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 
 	query, err = applyFilters(query, filters)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 
 	// getting the total count (filters included) for pagination
@@ -36,7 +36,7 @@ func (s *SourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 	// limiting + running the actual query.
 	result := query.Limit(limit).Offset(offset).Find(&sources)
 
-	return sources, &count, result.Error
+	return sources, count, result.Error
 }
 
 func (s *SourceDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -64,7 +64,7 @@ func SourceListEndpoint(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
 }
 
 func EndpointList(c echo.Context) error {
@@ -100,7 +100,7 @@ func EndpointList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func EndpointGet(c echo.Context) error {

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -44,7 +44,7 @@ func SourceListEndpoint(c echo.Context) error {
 
 	var (
 		endpoints []m.Endpoint
-		count     *int64
+		count     int64
 	)
 
 	id, err := strconv.ParseInt(c.Param("source_id"), 10, 64)
@@ -64,7 +64,7 @@ func SourceListEndpoint(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func EndpointList(c echo.Context) error {

--- a/main_test.go
+++ b/main_test.go
@@ -163,8 +163,8 @@ func testDbString(dbname string) string {
 }
 
 func AssertLinks(t *testing.T, path string, links util.Links, limit int, offset int) {
-	expectedFirstLink := fmt.Sprintf("%s/?limit=%d&offset=%d", path, limit, offset)
-	expectedLastLink := fmt.Sprintf("%s/?limit=%d&offset=%d", path, limit, limit+offset)
+	expectedFirstLink := fmt.Sprintf("%s?limit=%d&offset=%d", path, limit, offset)
+	expectedLastLink := fmt.Sprintf("%s?limit=%d&offset=%d", path, limit, limit+offset)
 	if links.First != expectedFirstLink {
 		t.Error("first link is not correct for " + path)
 	}

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -63,7 +63,7 @@ func MetaDataList(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func ApplicationTypeListMetaData(c echo.Context) error {
@@ -103,7 +103,7 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
 }
 
 func MetaDataGet(c echo.Context) error {

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -89,7 +89,7 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 
 	var (
 		metaDatas []m.MetaData
-		count     *int64
+		count     int64
 	)
 
 	metaDatas, count, err = applicationDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
@@ -103,7 +103,7 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 		out[i] = *a.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func MetaDataGet(c echo.Context) error {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -59,7 +59,7 @@ func SourceList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 func SourceTypeListSource(c echo.Context) error {
 	sourcesDB, err := getSourceDao(c)
@@ -99,7 +99,7 @@ func SourceTypeListSource(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
 }
 
 func ApplicationTypeListSource(c echo.Context) error {
@@ -140,7 +140,7 @@ func ApplicationTypeListSource(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
 }
 
 func SourceGet(c echo.Context) error {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -79,7 +79,7 @@ func SourceTypeListSource(c echo.Context) error {
 
 	var (
 		sources []m.Source
-		count   *int64
+		count   int64
 	)
 
 	id, err := strconv.ParseInt(c.Param("source_type_id"), 10, 64)
@@ -99,7 +99,7 @@ func SourceTypeListSource(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func ApplicationTypeListSource(c echo.Context) error {
@@ -120,7 +120,7 @@ func ApplicationTypeListSource(c echo.Context) error {
 
 	var (
 		sources []m.Source
-		count   *int64
+		count   int64
 	)
 
 	id, err := strconv.ParseInt(c.Param("application_type_id"), 10, 64)
@@ -140,7 +140,7 @@ func ApplicationTypeListSource(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(*count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func SourceGet(c echo.Context) error {

--- a/source_type_handlers.go
+++ b/source_type_handlers.go
@@ -47,7 +47,7 @@ func SourceTypeList(c echo.Context) error {
 		out[i] = *s.ToResponse()
 	}
 
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request().RequestURI, int(count), limit, offset))
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func SourceTypeGet(c echo.Context) error {


### PR DESCRIPTION
A few changes in this PR (probably best to review by commit):

1. Fixing the links as mentioned in #14 but wanted to do a follow-up.
2. Went through and changed out the `SubCollectionList` count return type from *int64 -> int64. Mikel's PR changing the return types went in while this was in review.