### PR TITLE
Improve logging for failing requests

### DIFF
--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -43,8 +43,10 @@ func ApplicationAuthenticationList(c echo.Context) error {
 
 	applications, count, err := applicationDB.List(limit, offset, filters)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
+
 	c.Logger().Infof("tenant: %v", *applicationDB.Tenant())
 
 	out := make([]interface{}, len(applications))

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -55,7 +55,8 @@ func SourceListApplications(c echo.Context) error {
 	applications, count, err = applicationDB.SubCollectionList(m.Source{ID: id}, limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 	c.Logger().Infof("tenant: %v", *applicationDB.Tenant())
 
@@ -91,7 +92,8 @@ func ApplicationList(c echo.Context) error {
 	applications, count, err = applicationDB.List(limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 
 	c.Logger().Infof("tenant: %v", *applicationDB.Tenant())

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -61,7 +61,8 @@ func SourceListApplicationTypes(c echo.Context) error {
 	apptypes, count, err = applicationTypeDB.SubCollectionList(m.Source{ID: id}, limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 
 	// converting the objects to the interface type so the collection response can process it

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -109,13 +109,16 @@ func AuthenticationUpdate(c echo.Context) error {
 
 	auth, err := authDao.GetById(c.Param("uid"))
 	if err != nil {
-		return c.JSON(http.StatusNotFound, util.ErrorDoc(fmt.Sprintf("Authentication %v not found", c.Param("uid")), "404"))
+		message := fmt.Sprintf("Authentication %v not found", c.Param("uid"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error(), Message: message, Status: "404"}
+		return c.JSON(http.StatusNotFound, errorLog.ErrorDocument())
 	}
 
 	auth.UpdateFromRequest(updateRequest)
 	err = authDao.Update(auth)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 
 	return c.JSON(http.StatusOK, auth.ToResponse())

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -55,7 +55,8 @@ func SourceListEndpoint(c echo.Context) error {
 	endpoints, count, err = endpointDB.SubCollectionList(m.Source{ID: id}, limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 	c.Logger().Infof("tenant: %v", *endpointDB.Tenant())
 
@@ -91,7 +92,8 @@ func EndpointList(c echo.Context) error {
 	endpoints, count, err = endpointDB.List(limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 	c.Logger().Infof("tenant: %v", *endpointDB.Tenant())
 

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -55,7 +55,8 @@ func MetaDataList(c echo.Context) error {
 	metaDatas, count, err = applicationDB.List(limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 
 	out := make([]interface{}, len(metaDatas))
@@ -95,7 +96,8 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 	metaDatas, count, err = applicationDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 
 	out := make([]interface{}, len(metaDatas))

--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -12,9 +12,11 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		err := next(c)
 		if err != nil {
+			errorLog := util.ErrorLog{Logger: c.Logger(), Status: "500"}
+			errorLog.Message = fmt.Sprintf("Internal Server Error: %v", err.Error())
 			return c.JSON(
 				http.StatusInternalServerError,
-				util.ErrorDoc(fmt.Sprintf("Internal Server Error: %v", err.Error()), "500"),
+				errorLog.ErrorDocument(),
 			)
 		}
 		return err

--- a/middleware/pagination.go
+++ b/middleware/pagination.go
@@ -23,7 +23,8 @@ func parsePaginationIntoContext(c echo.Context) error {
 	if c.QueryParam("limit") != "" {
 		val, err := strconv.Atoi(c.QueryParam("limit"))
 		if err != nil {
-			return c.JSON(http.StatusBadRequest, util.ErrorDoc("error parsing limit", "400"))
+			errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error(), Message: "error parsing limit"}
+			return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 		}
 
 		c.Set("limit", val)
@@ -34,7 +35,8 @@ func parsePaginationIntoContext(c echo.Context) error {
 	if c.QueryParam("offset") != "" {
 		val, err := strconv.Atoi(c.QueryParam("offset"))
 		if err != nil {
-			return c.JSON(http.StatusBadRequest, util.ErrorDoc("error parsing offset", "400"))
+			errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error(), Message: "error parsing offset"}
+			return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 		}
 
 		c.Set("offset", val)

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -50,7 +50,8 @@ func SourceList(c echo.Context) error {
 	sources, count, err = sourcesDB.List(limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
 
@@ -90,7 +91,8 @@ func SourceTypeListSource(c echo.Context) error {
 	sources, count, err = sourcesDB.SubCollectionList(m.SourceType{Id: id}, limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
 
@@ -131,7 +133,8 @@ func ApplicationTypeListSource(c echo.Context) error {
 	sources, count, err = sourcesDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
 
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc("Bad Request", "400"))
+		errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()}
+		return c.JSON(http.StatusBadRequest, errorLog.ErrorDocument())
 	}
 	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
 

--- a/util/error_document.go
+++ b/util/error_document.go
@@ -8,11 +8,44 @@ type ErrorDocument struct {
 	Errors []Error `json:"errors"`
 }
 
-func ErrorDoc(message, status string) *ErrorDocument {
+func (e *Error) ErrorDocument(message, status string) *ErrorDocument {
 	return &ErrorDocument{
 		[]Error{{
 			Detail: message,
 			Status: status,
 		}},
 	}
+}
+
+type Logger interface {
+	Error(i ...interface{})
+}
+
+type ErrorLog struct {
+	LogMessage string
+	Logger     Logger
+	Message    string
+	Status     string
+}
+
+func (e *ErrorLog) ErrorDocument() *ErrorDocument {
+	logMessage := e.LogMessage
+	if logMessage == "" {
+		if e.Message == "" {
+			logMessage = "Bad Request"
+		} else {
+			logMessage = e.Message
+		}
+	}
+
+	if logMessage != "" && e.Logger != nil {
+		e.Logger.Error(e.LogMessage)
+	}
+
+	status := e.Status
+	if status == "" {
+		status = "400"
+	}
+
+	return (&Error{}).ErrorDocument(e.Message, status)
 }


### PR DESCRIPTION
This adds logging for error messages - it improves to determine sources of issues.

it changes
```
util.ErrorDoc("Bad Request", "400")
```
to 

```
errorLog := util.ErrorLog{Logger: c.Logger(), LogMessage: err.Error()
errorLog.ErrorDocument()
```

`ErrorLog` can be initialised with status, message (which is returned in API response) and LogMessage(which is visible in logs).
if `LogMessage` is empty it takes message. There are also some defaults values in `(e *ErrorLog) ErrorDocument()`
