### PR TITLE
Update handling of errors in handlers to return 400/404 instead of 500

### DIFF
--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -63,14 +63,14 @@ func ApplicationAuthenticationGet(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	c.Logger().Infof("Getting ApplicationAuthentication ID %v", id)
 
 	app, err := applicationDB.GetById(&id)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 
 	return c.JSON(http.StatusOK, app.ToResponse())

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -49,7 +49,7 @@ func SourceListApplications(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("source_id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	applications, count, err = applicationDB.SubCollectionList(m.Source{ID: id}, limit, offset, filters)
@@ -112,14 +112,14 @@ func ApplicationGet(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	c.Logger().Infof("Getting Application ID %v", id)
 
 	app, err := applicationDB.GetById(&id)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 
 	return c.JSON(http.StatusOK, app.ToResponse())

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -159,3 +159,21 @@ func TestApplicationGet(t *testing.T) {
 		t.Error("ghosts infected the return")
 	}
 }
+
+func TestApplicationGetNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/applications/9843762095", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("9843762095")
+	c.Set("tenantID", int64(1))
+
+	err := ApplicationGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 404 {
+		t.Error("Did not return 404")
+	}
+}

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -55,7 +55,7 @@ func SourceListApplicationTypes(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("source_id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	apptypes, count, err = applicationTypeDB.SubCollectionList(m.Source{ID: id}, limit, offset, filters)
@@ -119,12 +119,12 @@ func ApplicationTypeGet(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	appType, err := applicationTypeDB.GetById(&id)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 
 	return c.JSON(http.StatusOK, appType.ToResponse())

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -142,3 +142,20 @@ func TestApplicationTypeGet(t *testing.T) {
 		t.Error("ghosts infected the return")
 	}
 }
+
+func TestApplicationTypeGetNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/123", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("123")
+
+	err := ApplicationTypeGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 404 {
+		t.Error("Did not return 404")
+	}
+}

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -61,7 +61,7 @@ func AuthenticationGet(c echo.Context) error {
 
 	auth, err := authDao.GetById(c.Param("uid"))
 	if err != nil {
-		return err
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 	return c.JSON(http.StatusOK, auth.ToResponse())
 }

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -49,7 +49,7 @@ func SourceListEndpoint(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("source_id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	endpoints, count, err = endpointDB.SubCollectionList(m.Source{ID: id}, limit, offset, filters)
@@ -111,14 +111,14 @@ func EndpointGet(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	c.Logger().Infof("Getting Endpoint ID %v", id)
 
 	app, err := endpointDB.GetById(&id)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 
 	return c.JSON(http.StatusOK, app.ToResponse())

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -138,3 +138,21 @@ func TestEndpointGet(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 }
+
+func TestEndpointGetNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/endpoints/970283452983", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("970283452983")
+	c.Set("tenantID", int64(1))
+
+	err := EndpointGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 404 {
+		t.Error("Did not return 404")
+	}
+}

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -84,7 +84,7 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("application_type_id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	var (
@@ -114,14 +114,14 @@ func MetaDataGet(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	c.Logger().Infof("Getting MetaData ID %v", id)
 
 	app, err := metaDataDB.GetById(&id)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 
 	return c.JSON(http.StatusOK, app.ToResponse())

--- a/meta_data_handlers_test.go
+++ b/meta_data_handlers_test.go
@@ -138,3 +138,21 @@ func TestMetaDataGet(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 }
+
+func TestMetaDataGetNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/app_meta_data/1234", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("1234")
+	c.Set("tenantID", int64(1))
+
+	err := MetaDataGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 404 {
+		t.Error("Did not return 404")
+	}
+}

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -61,6 +61,7 @@ func SourceList(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
+
 func SourceTypeListSource(c echo.Context) error {
 	sourcesDB, err := getSourceDao(c)
 	if err != nil {
@@ -84,7 +85,7 @@ func SourceTypeListSource(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("source_type_id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	sources, count, err = sourcesDB.SubCollectionList(m.SourceType{Id: id}, limit, offset, filters)
@@ -125,7 +126,7 @@ func ApplicationTypeListSource(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("application_type_id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	sources, count, err = sourcesDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
@@ -151,14 +152,14 @@ func SourceGet(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	c.Logger().Infof("Getting Source Id %v", id)
 
 	s, err := sourcesDB.GetById(&id)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 
 	return c.JSON(http.StatusOK, s.ToResponse())

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -195,3 +195,21 @@ func TestSourceGet(t *testing.T) {
 		t.Error("ghosts infected the return")
 	}
 }
+
+func TestSourceGetNotFound(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/9872034520975", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("id")
+	c.SetParamValues("9872034520975")
+	c.Set("tenantID", int64(1))
+
+	err := SourceGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 404 {
+		t.Error("Did not return 404")
+	}
+}

--- a/source_type_handlers.go
+++ b/source_type_handlers.go
@@ -58,12 +58,12 @@ func SourceTypeGet(c echo.Context) error {
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
 	sourceType, err := SourceTypeDB.GetById(&id)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 
 	return c.JSON(http.StatusOK, sourceType.ToResponse())


### PR DESCRIPTION
Inspired by @lpichler 's recent changes regarding error handling and since the RDU2 datacenter is down - I went through and updated some of the handlers to return 400 when failing to parse the ID and a 404 if we fail to find specific records. 

cc @MikelAlejoBR you're not showing up in the list so i can't add you as a reviewer - but have a looksee. 