### PR TITLE
Use one instance of logger between gorm/echo

### DIFF
--- a/dao/db.go
+++ b/dao/db.go
@@ -8,7 +8,6 @@ import (
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	vault "github.com/hashicorp/vault/api"
 	_ "github.com/jackc/pgx/v4/stdlib"
-	"github.com/sirupsen/logrus"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -23,18 +22,9 @@ var (
 )
 
 func Init() {
-	logger := &logrus.Logger{
-		Out:       logging.LogOutputFrom(conf.LogHandler),
-		Level:     logging.LogrusLogLevelFrom(conf.LogLevel),
-		Formatter: logging.NewCustomLoggerFormatter(conf, true),
-		Hooks:     make(logrus.LevelHooks),
-	}
-
-	logging.AddHooksTo(logger, conf)
-
 	l := &logging.CustomGORMLogger{
 		SkipErrorRecordNotFound: true,
-		Logger:                  logger,
+		Logger:                  logging.Log,
 		SlowThreshold:           time.Duration(conf.SlowSQLThreshold) * time.Second,
 		LogLevelForSqlLogs:      conf.LogLevelForSqlLogs,
 	}

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -218,7 +218,7 @@ func LogOutputFrom(logHandler string) *os.File {
 	return logOutput
 }
 
-func InitLogger(config *appconf.SourcesApiConfig) *logrus.Logger {
+func InitLogger(config *appconf.SourcesApiConfig) {
 	Log = &logrus.Logger{
 		Out:          LogOutputFrom(config.LogHandler),
 		Level:        LogrusLogLevelFrom(config.LogLevel),
@@ -228,6 +228,4 @@ func InitLogger(config *appconf.SourcesApiConfig) *logrus.Logger {
 	}
 
 	AddHooksTo(Log, config)
-
-	return Log
 }

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var conf = config.Get()
 func main() {
 	e := echo.New()
 
-	log := logging.InitLogger(conf)
+	logging.InitLogger(conf)
 	logging.InitEchoLogger(e, conf)
 
 	dao.Init()
@@ -24,7 +24,7 @@ func main() {
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		Format: logging.FormatForMiddleware(conf),
 		Output: &logging.LogWriter{Output: logging.LogOutputFrom(conf.LogHandler),
-			Logger:   log,
+			Logger:   logging.Log,
 			LogLevel: conf.LogLevelForMiddlewareLogs},
 	}))
 


### PR DESCRIPTION
Found we were instantiating 2 instances of logrus.Logger - we can just use the single one from the `logging` package that we initialize first. 

cc @MikelAlejoBR 