### PR TITLE
Refactor: extract common test code to a testutils package

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -3,22 +3,27 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestSourceApplicationSubcollectionList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/applications", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/1/applications",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("source_id")
 	c.SetParamValues("1")
 
@@ -61,18 +66,21 @@ func TestSourceApplicationSubcollectionList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationList(t *testing.T) {
-	path := "/api/sources/v3.1/applications"
-	req := httptest.NewRequest(http.MethodGet, path, nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/applications",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
 
 	err := ApplicationList(c)
 	if err != nil {
@@ -112,16 +120,21 @@ func TestApplicationList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationGet(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/applications/1", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/applications/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("1")
-	c.Set("tenantID", int64(1))
 
 	err := ApplicationGet(c)
 	if err != nil {
@@ -144,12 +157,17 @@ func TestApplicationGet(t *testing.T) {
 }
 
 func TestApplicationGetNotFound(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/applications/9843762095", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/applications/9843762095",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("9843762095")
-	c.Set("tenantID", int64(1))
 
 	err := ApplicationGet(c)
 	if err != nil {

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -9,24 +9,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
-	"gorm.io/datatypes"
 )
-
-var testApplicationData = []m.Application{
-	{ID: 1, Extra: datatypes.JSON(getExtraValue("{\"extra\": true}")), ApplicationTypeID: 1, SourceID: 1, TenantID: 1},
-	{ID: 2, Extra: datatypes.JSON(getExtraValue("{\"extra\": false}")), ApplicationTypeID: 1, SourceID: 1, TenantID: 1},
-}
-
-func getExtraValue(val string) json.RawMessage {
-	var out json.RawMessage
-
-	err := json.Unmarshal([]byte(val), &out)
-	if err != nil {
-		panic(err)
-	}
-
-	return out
-}
 
 func TestSourceApplicationSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/applications", nil)

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-var testApplicationTypeData = []m.ApplicationType{
-	{Id: 1, DisplayName: "test app type"},
-}
-
 func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/application_types", nil)
 	rec := httptest.NewRecorder()

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -3,22 +3,27 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/application_types", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/1/application_types",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("source_id")
 	c.SetParamValues("1")
 
@@ -60,16 +65,20 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationTypeList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types",
+		nil,
+		map[string]interface{}{
+			"limit":   100,
+			"offset":  0,
+			"filters": []middleware.Filter{},
+		},
+	)
 
 	err := ApplicationTypeList(c)
 	if err != nil {
@@ -109,13 +118,17 @@ func TestApplicationTypeList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationTypeGet(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/1", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types/1",
+		nil,
+		map[string]interface{}{},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 
@@ -140,9 +153,13 @@ func TestApplicationTypeGet(t *testing.T) {
 }
 
 func TestApplicationTypeGetNotFound(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/123", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types/123",
+		nil,
+		map[string]interface{}{},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("123")
 

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-var testEndpointData = []m.Endpoint{
-	{ID: 1, SourceID: 1, TenantID: 1},
-	{ID: 2, SourceID: 1, TenantID: 1},
-}
-
 func TestSourceEndpointSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/endpoints", nil)
 	rec := httptest.NewRecorder()

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -3,22 +3,27 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestSourceEndpointSubcollectionList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1/endpoints", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/1/endpoints",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("source_id")
 	c.SetParamValues("1")
 
@@ -61,17 +66,21 @@ func TestSourceEndpointSubcollectionList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestEndpointList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/endpoints", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/endpoints",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
 
 	err := EndpointList(c)
 	if err != nil {
@@ -107,16 +116,21 @@ func TestEndpointList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestEndpointGet(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/endpoints/1", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/endpoints/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("1")
-	c.Set("tenantID", int64(1))
 
 	err := EndpointGet(c)
 	if err != nil {
@@ -135,12 +149,17 @@ func TestEndpointGet(t *testing.T) {
 }
 
 func TestEndpointGetNotFound(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/endpoints/970283452983", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/endpoints/970283452983",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("970283452983")
-	c.Set("tenantID", int64(1))
 
 	err := EndpointGet(c)
 	if err != nil {

--- a/internal/testutils/database.go
+++ b/internal/testutils/database.go
@@ -50,13 +50,25 @@ func CreateTestDB() {
 
 // DropSchema drops the database schema entirely.
 func DropSchema() {
-	dao.DB.Exec("DROP TABLE endpoints")
-	dao.DB.Exec("DROP TABLE meta_data")
-	dao.DB.Exec("DROP TABLE applications")
-	dao.DB.Exec("DROP TABLE application_types")
-	dao.DB.Exec("DROP TABLE sources")
-	dao.DB.Exec("DROP TABLE source_types")
-	dao.DB.Exec("DROP TABLE tenants")
+	tables := []string{
+		"endpoints",
+		"meta_data",
+		"applications",
+		"application_types",
+		"sources",
+		"source_types",
+		"tenants",
+	}
+
+	for _, table := range tables {
+		if result := dao.DB.Exec(fmt.Sprintf("DROP table %s", table)); result.Error != nil {
+			log.Fatalf(
+				"Error dropping table '%s'. Please manually delete the tables. Error: %s",
+				table,
+				result.Error,
+			)
+		}
+	}
 }
 
 // MigrateSchema migrates all the models.

--- a/internal/testutils/database.go
+++ b/internal/testutils/database.go
@@ -2,12 +2,13 @@ package testutils
 
 import (
 	"fmt"
+
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/labstack/gommon/log"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"os"
 )
 
 var testDbName = "sources_api_test_go"
@@ -16,13 +17,12 @@ var testDbName = "sources_api_test_go"
 func ConnectToTestDB() {
 	db, err := gorm.Open(postgres.Open(testDbString(testDbName)), &gorm.Config{})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "db must not exist - create the database '%v' first with '-createdb'.", testDbName)
-		panic(err)
+		log.Fatalf("db must not exist - create the database '%s' first with '-createdb'. Error: %s", testDbName, err)
 	}
 
 	rawDB, err := db.DB()
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 	rawDB.SetMaxOpenConns(20)
 
@@ -36,7 +36,7 @@ func ConnectToTestDB() {
 func CreateTestDB() error {
 	db, err := gorm.Open(postgres.Open(testDbString("postgres")), &gorm.Config{})
 	if err != nil {
-		panic(err)
+		log.Fatalf("Error opening the database connection: %s", err)
 	}
 
 	out := db.Exec(fmt.Sprintf("CREATE DATABASE %v", testDbName))
@@ -69,8 +69,7 @@ func MigrateSchema() {
 	)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error automigrating the schema: %v", err)
-		os.Exit(1)
+		log.Fatalf("Error automigrating the schema: %s", err)
 	}
 }
 

--- a/internal/testutils/database.go
+++ b/internal/testutils/database.go
@@ -59,6 +59,7 @@ func CreateFixtures() {
 // CreateTestDB creates a test database. The function terminates the program with a code 0 if the creating is
 // successful.
 func CreateTestDB() {
+	fmt.Printf("Creating database '%s'...", testDbName)
 	db, err := gorm.Open(postgres.Open(testDbString("postgres")), &gorm.Config{})
 	if err != nil {
 		log.Fatalf("Error opening the database connection: %s", err)

--- a/internal/testutils/database.go
+++ b/internal/testutils/database.go
@@ -73,7 +73,6 @@ func DropSchema() {
 
 // MigrateSchema migrates all the models.
 func MigrateSchema() {
-	// migrate all the models.
 	err := dao.DB.AutoMigrate(
 		&m.SourceType{},
 		&m.ApplicationType{},

--- a/internal/testutils/database.go
+++ b/internal/testutils/database.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
@@ -32,15 +33,19 @@ func ConnectToTestDB() {
 	MigrateSchema()
 }
 
-// CreateTestDB creates a test database.
-func CreateTestDB() error {
+// CreateTestDB creates a test database. The function terminates the program with a code 0 if the creating is
+// successful.
+func CreateTestDB() {
 	db, err := gorm.Open(postgres.Open(testDbString("postgres")), &gorm.Config{})
 	if err != nil {
 		log.Fatalf("Error opening the database connection: %s", err)
 	}
 
-	out := db.Exec(fmt.Sprintf("CREATE DATABASE %v", testDbName))
-	return out.Error
+	if out := db.Exec(fmt.Sprintf("CREATE DATABASE %v", testDbName)); out.Error != nil {
+		log.Fatalf("Error creating the test database: %s", out.Error)
+	}
+
+	os.Exit(0)
 }
 
 // DropSchema drops the database schema entirely.

--- a/internal/testutils/database.go
+++ b/internal/testutils/database.go
@@ -1,0 +1,87 @@
+package testutils
+
+import (
+	"fmt"
+	"github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/dao"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"os"
+)
+
+var testDbName = "sources_api_test_go"
+
+// ConnectToTestDB connects to the test database, populates the "dao.DB" member, and runs a schema migration.
+func ConnectToTestDB() {
+	db, err := gorm.Open(postgres.Open(testDbString(testDbName)), &gorm.Config{})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "db must not exist - create the database '%v' first with '-createdb'.", testDbName)
+		panic(err)
+	}
+
+	rawDB, err := db.DB()
+	if err != nil {
+		panic(err)
+	}
+	rawDB.SetMaxOpenConns(20)
+
+	// Set the dao.DB in case any tests want to use it
+	dao.DB = db
+	// Migrate the schema for the first time
+	MigrateSchema()
+}
+
+// CreateTestDB creates a test database.
+func CreateTestDB() error {
+	db, err := gorm.Open(postgres.Open(testDbString("postgres")), &gorm.Config{})
+	if err != nil {
+		panic(err)
+	}
+
+	out := db.Exec(fmt.Sprintf("CREATE DATABASE %v", testDbName))
+	return out.Error
+}
+
+// DropSchema drops the database schema entirely.
+func DropSchema() {
+	dao.DB.Exec("DROP TABLE endpoints")
+	dao.DB.Exec("DROP TABLE meta_data")
+	dao.DB.Exec("DROP TABLE applications")
+	dao.DB.Exec("DROP TABLE application_types")
+	dao.DB.Exec("DROP TABLE sources")
+	dao.DB.Exec("DROP TABLE source_types")
+	dao.DB.Exec("DROP TABLE tenants")
+}
+
+// MigrateSchema migrates all the models.
+func MigrateSchema() {
+	// migrate all the models.
+	err := dao.DB.AutoMigrate(
+		&m.SourceType{},
+		&m.ApplicationType{},
+
+		&m.Source{},
+		&m.Application{},
+
+		&m.Endpoint{},
+		&m.MetaData{},
+	)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error automigrating the schema: %v", err)
+		os.Exit(1)
+	}
+}
+
+// testDbString returns a properly formatted database string ready to be passed to Gorm.
+func testDbString(dbname string) string {
+	return fmt.Sprintf(
+		"user=%s password=%s dbname=%s host=%s port=%d sslmode=disable",
+		config.Get().DatabaseUser,
+		config.Get().DatabasePassword,
+		dbname,
+		config.Get().DatabaseHost,
+		config.Get().DatabasePort,
+	)
+}

--- a/internal/testutils/fixtures.go
+++ b/internal/testutils/fixtures.go
@@ -1,0 +1,38 @@
+package testutils
+
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"gorm.io/datatypes"
+)
+
+var TestTenantData = []m.Tenant{
+	{Id: 1},
+}
+
+var TestSourceTypeData = []m.SourceType{
+	{Id: 1, Name: "amazon"},
+}
+
+var TestApplicationTypeData = []m.ApplicationType{
+	{Id: 1, DisplayName: "test app type"},
+}
+
+var TestSourceData = []m.Source{
+	{ID: 1, Name: "Source1", SourceTypeID: 1, TenantID: 1},
+	{ID: 2, Name: "Source2", SourceTypeID: 1, TenantID: 1},
+}
+
+var TestApplicationData = []m.Application{
+	{ID: 1, Extra: datatypes.JSON("{\"extra\": true}"), ApplicationTypeID: 1, SourceID: 1, TenantID: 1},
+	{ID: 2, Extra: datatypes.JSON("{\"extra\": false}"), ApplicationTypeID: 1, SourceID: 1, TenantID: 1},
+}
+
+var TestEndpointData = []m.Endpoint{
+	{ID: 1, SourceID: 1, TenantID: 1},
+	{ID: 2, SourceID: 1, TenantID: 1},
+}
+
+var TestMetaDataData = []m.MetaData{
+	{ID: 1, ApplicationTypeID: 1, Type: "AppMetaData"},
+	{ID: 2, ApplicationTypeID: 1, Type: "AppMetaData"},
+}

--- a/internal/testutils/parser.go
+++ b/internal/testutils/parser.go
@@ -1,0 +1,15 @@
+package testutils
+
+import "flag"
+
+// ParseFlags parses the flags for the "go test" command. The "-createdb" indicates that a test database should be
+// created, whilst the "-integration" flag indicates that integration tests should be run along with the unit tests.
+// It returns a (bool, bool) which represents the status of ("-createdb", "-integration") accordingly.
+func ParseFlags() (bool, bool) {
+	createDb := flag.Bool("createdb", false, "create the test database")
+	integration := flag.Bool("integration", false, "run unit or integration tests")
+
+	flag.Parse()
+
+	return *createDb, *integration
+}

--- a/internal/testutils/request.go
+++ b/internal/testutils/request.go
@@ -1,0 +1,24 @@
+package testutils
+
+import (
+	"io"
+	"net/http/httptest"
+
+	"github.com/labstack/echo/v4"
+)
+
+var echoInstance = echo.New()
+
+// CreateTestContext sets up a new echo context with the parameters given, and returns the context itself and the
+// response recorder.
+func CreateTestContext(method string, path string, body io.Reader, context map[string]interface{}) (echo.Context, *httptest.ResponseRecorder) {
+	request := httptest.NewRequest(method, path, body)
+	recorder := httptest.NewRecorder()
+	echoContext := echoInstance.NewContext(request, recorder)
+
+	for k, v := range context {
+		echoContext.Set(k, v)
+	}
+
+	return echoContext, recorder
+}

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	l "github.com/RedHatInsights/sources-api-go/logger"
-	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
@@ -42,16 +41,7 @@ func TestMain(t *testing.M) {
 		getSourceTypeDao = getSourceTypeDaoWithoutTenant
 		getMetaDataDao = getMetaDataDaoWithTenant
 
-		dao.DB.Create(&m.Tenant{Id: 1})
-
-		dao.DB.Create(testutils.TestSourceTypeData)
-		dao.DB.Create(testutils.TestApplicationTypeData)
-
-		dao.DB.Create(testutils.TestSourceData)
-		dao.DB.Create(testutils.TestApplicationData)
-		dao.DB.Create(testutils.TestEndpointData)
-
-		dao.DB.Create(testutils.TestMetaDataData)
+		testutils.CreateFixtures()
 	} else {
 		mockSourceDao = &dao.MockSourceDao{Sources: testutils.TestSourceData}
 		mockApplicationDao = &dao.MockApplicationDao{Applications: testutils.TestApplicationData}

--- a/main_test.go
+++ b/main_test.go
@@ -19,8 +19,6 @@ var (
 	mockSourceTypeDao      dao.SourceTypeDao
 	mockApplicationDao     dao.ApplicationDao
 	mockMetaDataDao        dao.MetaDataDao
-
-	testDbName = "sources_api_test_go"
 )
 
 func TestMain(t *testing.M) {
@@ -29,7 +27,6 @@ func TestMain(t *testing.M) {
 	createDb, integration := testutils.ParseFlags()
 
 	if createDb {
-		fmt.Fprintf(os.Stderr, "creating database %v...", testDbName)
 		testutils.CreateTestDB()
 	} else if integration {
 		testutils.ConnectToTestDB()

--- a/main_test.go
+++ b/main_test.go
@@ -44,21 +44,21 @@ func TestMain(t *testing.M) {
 
 		dao.DB.Create(&m.Tenant{Id: 1})
 
-		dao.DB.Create(testSourceTypeData)
-		dao.DB.Create(testApplicationTypeData)
+		dao.DB.Create(testutils.TestSourceTypeData)
+		dao.DB.Create(testutils.TestApplicationTypeData)
 
-		dao.DB.Create(testSourceData)
-		dao.DB.Create(testApplicationData)
-		dao.DB.Create(testEndpointData)
+		dao.DB.Create(testutils.TestSourceData)
+		dao.DB.Create(testutils.TestApplicationData)
+		dao.DB.Create(testutils.TestEndpointData)
 
-		dao.DB.Create(testMetaData)
+		dao.DB.Create(testutils.TestMetaDataData)
 	} else {
-		mockSourceDao = &dao.MockSourceDao{Sources: testSourceData}
-		mockApplicationDao = &dao.MockApplicationDao{Applications: testApplicationData}
-		mockEndpointDao = &dao.MockEndpointDao{Endpoints: testEndpointData}
-		mockSourceTypeDao = &dao.MockSourceTypeDao{SourceTypes: testSourceTypeData}
-		mockApplicationTypeDao = &dao.MockApplicationTypeDao{ApplicationTypes: testApplicationTypeData}
-		mockMetaDataDao = &dao.MockMetaDataDao{MetaDatas: testMetaData}
+		mockSourceDao = &dao.MockSourceDao{Sources: testutils.TestSourceData}
+		mockApplicationDao = &dao.MockApplicationDao{Applications: testutils.TestApplicationData}
+		mockEndpointDao = &dao.MockEndpointDao{Endpoints: testutils.TestEndpointData}
+		mockSourceTypeDao = &dao.MockSourceTypeDao{SourceTypes: testutils.TestSourceTypeData}
+		mockApplicationTypeDao = &dao.MockApplicationTypeDao{ApplicationTypes: testutils.TestApplicationTypeData}
+		mockMetaDataDao = &dao.MockMetaDataDao{MetaDatas: testutils.TestMetaDataData}
 
 		getSourceDao = func(c echo.Context) (dao.SourceDao, error) { return mockSourceDao, nil }
 		getApplicationDao = func(c echo.Context) (dao.ApplicationDao, error) { return mockApplicationDao, nil }

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	e                      *echo.Echo
 	mockSourceDao          dao.SourceDao
 	mockApplicationTypeDao dao.ApplicationTypeDao
 	mockEndpointDao        dao.EndpointDao
@@ -60,7 +59,6 @@ func TestMain(t *testing.M) {
 
 	}
 
-	e = echo.New()
 	code := t.Run()
 
 	if integration {

--- a/main_test.go
+++ b/main_test.go
@@ -36,13 +36,7 @@ func TestMain(t *testing.M) {
 
 	if *createdb {
 		fmt.Fprintf(os.Stderr, "creating database %v...", testDbName)
-		err := testutils.CreateTestDB()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error creating test DB: %v", err)
-			os.Exit(1)
-		}
-
-		os.Exit(0)
+		testutils.CreateTestDB()
 	} else if *integration {
 		testutils.ConnectToTestDB()
 		getSourceDao = getSourceDaoWithTenant

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -27,17 +26,14 @@ var (
 )
 
 func TestMain(t *testing.M) {
-	// flag to control running unit tests or connecting to a real db, usage:
-	// go test -integration
-	integration := flag.Bool("integration", false, "run unit or integration tests")
-	createdb := flag.Bool("createdb", false, "create the test database")
-	flag.Parse()
 	l.InitLogger(conf)
 
-	if *createdb {
+	createDb, integration := testutils.ParseFlags()
+
+	if createDb {
 		fmt.Fprintf(os.Stderr, "creating database %v...", testDbName)
 		testutils.CreateTestDB()
-	} else if *integration {
+	} else if integration {
 		testutils.ConnectToTestDB()
 		getSourceDao = getSourceDaoWithTenant
 		getApplicationDao = getApplicationDaoWithTenant
@@ -77,7 +73,7 @@ func TestMain(t *testing.M) {
 	e = echo.New()
 	code := t.Run()
 
-	if *integration {
+	if integration {
 		testutils.DropSchema()
 	}
 

--- a/meta_data_handlers_test.go
+++ b/meta_data_handlers_test.go
@@ -3,22 +3,27 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/:application_type_id/app_meta_data", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types/:application_type_id/app_meta_data",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("application_type_id")
 	c.SetParamValues("1")
 
@@ -61,17 +66,21 @@ func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestMetaDataList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/app_meta_data", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/app_meta_data",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
 
 	err := MetaDataList(c)
 	if err != nil {
@@ -107,16 +116,21 @@ func TestMetaDataList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestMetaDataGet(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/app_meta_data/1", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/app_meta_data/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("1")
-	c.Set("tenantID", int64(1))
 
 	err := MetaDataGet(c)
 	if err != nil {
@@ -135,12 +149,17 @@ func TestMetaDataGet(t *testing.T) {
 }
 
 func TestMetaDataGetNotFound(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/app_meta_data/1234", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/app_meta_data/1234",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("1234")
-	c.Set("tenantID", int64(1))
 
 	err := MetaDataGet(c)
 	if err != nil {

--- a/meta_data_handlers_test.go
+++ b/meta_data_handlers_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-var testMetaData = []m.MetaData{
-	{ID: 1, ApplicationTypeID: 1, Type: "AppMetaData"},
-	{ID: 2, ApplicationTypeID: 1, Type: "AppMetaData"},
-}
-
 func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/:application_type_id/app_meta_data", nil)
 	rec := httptest.NewRecorder()

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -3,22 +3,27 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestSourceTypeSourceSubcollectionList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/source_types/1/sources", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/source_types/1/sources",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("source_type_id")
 	c.SetParamValues("1")
 
@@ -58,17 +63,22 @@ func TestSourceTypeSourceSubcollectionList(t *testing.T) {
 
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestApplicationSourceSubcollectionList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/application_types/1/sources", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/source_types/1/sources",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("application_type_id")
 	c.SetParamValues("1")
 
@@ -110,17 +120,20 @@ func TestApplicationSourceSubcollectionList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestSourceList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
-	c.Set("tenantID", int64(1))
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []middleware.Filter{},
+			"tenantID": int64(1),
+		})
 
 	err := SourceList(c)
 	if err != nil {
@@ -160,16 +173,20 @@ func TestSourceList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestSourceGet(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/1", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		})
+
 	c.SetParamNames("id")
 	c.SetParamValues("1")
-	c.Set("tenantID", int64(1))
 
 	err := SourceGet(c)
 	if err != nil {
@@ -192,12 +209,17 @@ func TestSourceGet(t *testing.T) {
 }
 
 func TestSourceGetNotFound(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources/9872034520975", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/9872034520975",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
 	c.SetParamNames("id")
 	c.SetParamValues("9872034520975")
-	c.Set("tenantID", int64(1))
 
 	err := SourceGet(c)
 	if err != nil {

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -11,11 +11,6 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-var testSourceData = []m.Source{
-	{ID: 1, Name: "Source1", SourceTypeID: 1, TenantID: 1},
-	{ID: 2, Name: "Source2", SourceTypeID: 1, TenantID: 1},
-}
-
 func TestSourceTypeSourceSubcollectionList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/source_types/1/sources", nil)
 	rec := httptest.NewRecorder()

--- a/source_type_handlers_test.go
+++ b/source_type_handlers_test.go
@@ -3,20 +3,24 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestSourceTypeList(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/source_types", nil)
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.Set("limit", 100)
-	c.Set("offset", 0)
-	c.Set("filters", []middleware.Filter{})
+	c, rec := testutils.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/source_types",
+		nil,
+		map[string]interface{}{
+			"limit":   100,
+			"offset":  0,
+			"filters": []middleware.Filter{},
+		},
+	)
 
 	err := SourceTypeList(c)
 
@@ -58,5 +62,5 @@ func TestSourceTypeList(t *testing.T) {
 		}
 	}
 
-	AssertLinks(t, req.RequestURI, out.Links, 100, 0)
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }

--- a/source_type_handlers_test.go
+++ b/source_type_handlers_test.go
@@ -7,13 +7,8 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/middleware"
-	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
-
-var testSourceTypeData = []m.SourceType{
-	{Id: 1, Name: "amazon"},
-}
 
 func TestSourceTypeList(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/source_types", nil)


### PR DESCRIPTION
The reason for this change is that otherwise these functions would have to be rewritten over and over again for each package. The idea is to place the code under the `internal/` directory so it doesn't get exported —which wouldn't make sense anyway as these settings apply specifically to this project—.

Basically:

- It self-contains the errors that can be thrown from the database functions. We were only doing an `if err != nil { log & exit }` for the errors, which made the callers have to do that when there's usually no other recovery than manually checking what's up with the database.
- It extracts the test data or fixtures to a file and exports them, to make importing from other packages easier.
- Replaces some common request and context set up with a helper function.

### Discussions
1. I replaced the `Fprintf & Exit 1` calls with `log.Fprintf` calls, which combine the former calls in one. The output ends up being formatted as JSON, as the rest of the logs of the APP. I guess that's why you were using the two calls, but anyway I'd like to ask: should I keep the two calls?
2. I initially thought of the `ParseFlags` function as one function that would have the following signature: `func ParseFlags() bool`. It'd directly create the database if `-createdb`is passed, and return a `bool` indicating whether the tests should include the integration ones. That would spare us from having an `if createDb` on every test package. The only "problem" is that I don't like having a function called `ParseFlags` which also takes care of initializing the database. Any suggestions around this? :thinking: 

[[RHCLOUD-16574]](https://issues.redhat.com/browse/RHCLOUD-16574)