### PR TITLE
ApplicationAuthentication Changes and Authentication Subcollections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ gci:
 
 vault:
 	# runs a server locally - with `root` as the token. useful for development
-	vault server -dev -dev-root-token-id root
+	docker run -it --rm --cap-add=IPC_LOCK \
+		-e 'VAULT_DEV_ROOT_TOKEN_ID=root' \
+		-e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' \
+		-p 8200:8200 vault
 
 .PHONY: setup tidy build clean run container remotedebug debug test lint gci vault

--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -75,3 +75,27 @@ func ApplicationAuthenticationGet(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, app.ToResponse())
 }
+
+func ApplicationAuthenticationListAuthentications(c echo.Context) error {
+	authDao, err := getAuthenticationDao(c)
+	if err != nil {
+		return err
+	}
+
+	id, err := strconv.ParseInt(c.Param("application_authentication_id"), 10, 64)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
+	}
+
+	auths, count, err := authDao.ListForApplicationAuthentication(id, 100, 0, nil)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
+	}
+
+	out := make([]interface{}, count)
+	for i := 0; i < int(count); i++ {
+		out[i] = auths[i].ToResponse()
+	}
+
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), 100, 0))
+}

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -124,3 +124,27 @@ func ApplicationGet(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, app.ToResponse())
 }
+
+func ApplicationListAuthentications(c echo.Context) error {
+	authDao, err := getAuthenticationDao(c)
+	if err != nil {
+		return err
+	}
+
+	appID, err := strconv.ParseInt(c.Param("application_id"), 10, 64)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
+	}
+
+	auths, count, err := authDao.ListForApplication(appID, 100, 0, nil)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
+	}
+
+	out := make([]interface{}, count)
+	for i := 0; i < int(count); i++ {
+		out[i] = auths[i].ToResponse()
+	}
+
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), 100, 0))
+}

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -89,10 +89,10 @@ func AuthenticationCreate(c echo.Context) error {
 	}
 	err = authDao.Create(auth)
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
-	return c.JSON(http.StatusOK, auth.ToResponse())
+	return c.JSON(http.StatusCreated, auth.ToResponse())
 }
 
 func AuthenticationUpdate(c echo.Context) error {

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -25,30 +25,30 @@ func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 	count := int64(0)
 	query.Count(&count)
 
-	result := query.Limit(limit).Find(&applications)
-	return applications, count, result.Error
+	result := query.Limit(limit).Find(&appAuths)
+	return appAuths, count, result.Error
 }
 
 func (a *ApplicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAuthentication, error) {
-	app := &m.ApplicationAuthentication{ID: *id}
-	result := DB.First(&app)
+	appAuth := &m.ApplicationAuthentication{ID: *id}
+	result := DB.First(&appAuth)
 
-	return app, result.Error
+	return appAuth, result.Error
 }
 
-func (a *ApplicationAuthenticationDaoImpl) Create(app *m.ApplicationAuthentication) error {
-	result := DB.Create(app)
+func (a *ApplicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthentication) error {
+	result := DB.Create(appAuth)
 	return result.Error
 }
 
-func (a *ApplicationAuthenticationDaoImpl) Update(app *m.ApplicationAuthentication) error {
-	result := DB.Updates(app)
+func (a *ApplicationAuthenticationDaoImpl) Update(appAuth *m.ApplicationAuthentication) error {
+	result := DB.Updates(appAuth)
 	return result.Error
 }
 
 func (a *ApplicationAuthenticationDaoImpl) Delete(id *int64) error {
-	app := &m.ApplicationAuthentication{ID: *id}
-	if result := DB.Delete(app); result.RowsAffected == 0 {
+	appAuth := &m.ApplicationAuthentication{ID: *id}
+	if result := DB.Delete(appAuth); result.RowsAffected == 0 {
 		return fmt.Errorf("failed to delete application id %v", *id)
 	}
 

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -12,7 +12,7 @@ type ApplicationAuthenticationDaoImpl struct {
 }
 
 func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
-	applications := make([]m.ApplicationAuthentication, 0, limit)
+	appAuths := make([]m.ApplicationAuthentication, 0, limit)
 	query := DB.Debug().Model(&m.ApplicationAuthentication{}).
 		Offset(offset).
 		Where("tenant_id = ?", a.TenantID)

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -271,6 +271,13 @@ func authFromVault(secret *api.Secret) *m.Authentication {
 		}
 		auth.ResourceID = id
 	}
+	if data["source_id"] != nil {
+		id, err := strconv.ParseInt(data["source_id"].(string), 10, 64)
+		if err != nil {
+			return nil
+		}
+		auth.SourceID = id
+	}
 
 	return auth
 }

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -42,7 +42,7 @@ func (a *AuthenticationDaoImpl) List(limit int, offset int, filters []util.Filte
 
 	out := make([]m.Authentication, 0, len(keys))
 	for _, val := range keys[offset:end] {
-		secret, err := a.getKey(fmt.Sprintf("secret/data/%d/%s", *a.TenantID, val))
+		secret, err := a.getKey(val)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -52,6 +52,101 @@ func (a *AuthenticationDaoImpl) List(limit int, offset int, filters []util.Filte
 	count := int64(len(out))
 
 	return out, count, nil
+}
+
+func (a *AuthenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []middleware.Filter) ([]m.Authentication, int64, error) {
+	keys, err := a.listKeys()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	out := make([]m.Authentication, 0)
+
+	for _, key := range keys {
+		auth, err := a.getKey(key)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if auth.SourceID == sourceID {
+			out = append(out, *auth)
+		}
+	}
+
+	return out, int64(len(out)), nil
+}
+
+func (a *AuthenticationDaoImpl) ListForApplication(applicationID int64, _, _ int, _ []middleware.Filter) ([]m.Authentication, int64, error) {
+	app := m.Application{ID: applicationID}
+	result := DB.
+		Where("tenant_id = ?", *a.TenantID).
+		Preload("ApplicationAuthentications").
+		First(&app)
+
+	if result.Error != nil {
+		return nil, 0, result.Error
+	}
+
+	auths, err := a.getAuthsForAppAuth(app.ApplicationAuthentications)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return auths, int64(len(auths)), nil
+}
+
+func (a *AuthenticationDaoImpl) ListForApplicationAuthentication(appauthID int64, _, _ int, _ []middleware.Filter) ([]m.Authentication, int64, error) {
+	appauth := m.ApplicationAuthentication{ID: appauthID}
+	result := DB.
+		Where("tenant_id = ?", *a.TenantID).
+		First(&appauth)
+
+	if result.Error != nil {
+		return nil, 0, result.Error
+	}
+
+	auths, err := a.getAuthsForAppAuth([]m.ApplicationAuthentication{appauth})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return auths, int64(len(auths)), nil
+}
+
+func (a *AuthenticationDaoImpl) ListForEndpoint(endpointID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error) {
+	keys, err := a.listKeys()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	auths := make([]m.Authentication, 0)
+
+	for _, key := range keys {
+		if strings.HasPrefix(key, fmt.Sprintf("Endpoint_%v", endpointID)) {
+			auth, err := a.getKey(key)
+			if err != nil {
+				return nil, 0, err
+			}
+
+			auths = append(auths, *auth)
+		}
+	}
+
+	return auths, int64(len(auths)), nil
+}
+
+func (a *AuthenticationDaoImpl) getAuthsForAppAuth(appAuths []m.ApplicationAuthentication) ([]m.Authentication, error) {
+	out := make([]m.Authentication, len(appAuths))
+	for i, appAuth := range appAuths {
+		auth, err := a.getKey(appAuth.VaultPath)
+		if err != nil {
+			return nil, err
+		}
+
+		out[i] = *auth
+	}
+
+	return out, nil
 }
 
 /*
@@ -78,10 +173,35 @@ func (a *AuthenticationDaoImpl) GetById(uid string) (*m.Authentication, error) {
 		return nil, fmt.Errorf("authentication not found")
 	}
 
-	return a.getKey(fmt.Sprintf("secret/data/%d/%s", *a.TenantID, fullKey))
+	return a.getKey(fullKey)
 }
 
 func (a *AuthenticationDaoImpl) Create(auth *m.Authentication) error {
+	query := DB.Select("source_id").Where("tenant_id = ?", *a.TenantID)
+
+	switch auth.ResourceType {
+	case "Application":
+		app := m.Application{ID: auth.ResourceID}
+		result := query.Model(&app).First(&app)
+		if result.Error != nil {
+			return fmt.Errorf("resource not found with type [%v], id [%v]", auth.ResourceType, auth.ResourceID)
+		}
+
+		auth.SourceID = app.SourceID
+	case "Endpoint":
+		endpoint := m.Endpoint{ID: auth.ResourceID}
+		result := query.Model(&endpoint).First(&endpoint)
+		if result.Error != nil {
+			return fmt.Errorf("resource not found with type [%v], id [%v]", auth.ResourceType, auth.ResourceID)
+		}
+
+		auth.SourceID = endpoint.SourceID
+	case "Source":
+		auth.SourceID = auth.ResourceID
+	default:
+		return fmt.Errorf("bad resource type, supported types are [Application, Endpoint, Source]")
+	}
+
 	auth.ID = uuid.New().String()
 	path := fmt.Sprintf("secret/data/%d/%s_%v_%s", *a.TenantID, auth.ResourceType, auth.ResourceID, auth.ID)
 
@@ -173,11 +293,7 @@ func (a *AuthenticationDaoImpl) listKeys() ([]string, error) {
 	Fetch a key from Vault (full path, type and id included)
 */
 func (a *AuthenticationDaoImpl) getKey(path string) (*m.Authentication, error) {
-	paths := strings.Split(path, "_")
-	// the uid is the last part of the path, e.g. Source_2_435-bnsd-4362
-	uid := paths[len(paths)-1]
-
-	secret, err := Vault.Read(path)
+	secret, err := Vault.Read(fmt.Sprintf("secret/data/%d/%s", *a.TenantID, path))
 	if err != nil || secret == nil {
 		return nil, fmt.Errorf("authentication not found")
 	}
@@ -189,6 +305,9 @@ func (a *AuthenticationDaoImpl) getKey(path string) (*m.Authentication, error) {
 		return nil, fmt.Errorf("failed to deserialize secret from vault")
 	}
 
+	paths := strings.Split(path, "_")
+	// the uid is the last part of the path, e.g. Source_2_435-bnsd-4362
+	uid := paths[len(paths)-1]
 	auth.ID = uid
 	return auth, nil
 }

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -54,7 +54,7 @@ func (a *AuthenticationDaoImpl) List(limit int, offset int, filters []util.Filte
 	return out, count, nil
 }
 
-func (a *AuthenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []middleware.Filter) ([]m.Authentication, int64, error) {
+func (a *AuthenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	keys, err := a.listKeys()
 	if err != nil {
 		return nil, 0, err
@@ -76,7 +76,7 @@ func (a *AuthenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []midd
 	return out, int64(len(out)), nil
 }
 
-func (a *AuthenticationDaoImpl) ListForApplication(applicationID int64, _, _ int, _ []middleware.Filter) ([]m.Authentication, int64, error) {
+func (a *AuthenticationDaoImpl) ListForApplication(applicationID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	app := m.Application{ID: applicationID}
 	result := DB.
 		Where("tenant_id = ?", *a.TenantID).
@@ -95,7 +95,7 @@ func (a *AuthenticationDaoImpl) ListForApplication(applicationID int64, _, _ int
 	return auths, int64(len(auths)), nil
 }
 
-func (a *AuthenticationDaoImpl) ListForApplicationAuthentication(appauthID int64, _, _ int, _ []middleware.Filter) ([]m.Authentication, int64, error) {
+func (a *AuthenticationDaoImpl) ListForApplicationAuthentication(appauthID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	appauth := m.ApplicationAuthentication{ID: appauthID}
 	result := DB.
 		Where("tenant_id = ?", *a.TenantID).
@@ -113,7 +113,7 @@ func (a *AuthenticationDaoImpl) ListForApplicationAuthentication(appauthID int64
 	return auths, int64(len(auths)), nil
 }
 
-func (a *AuthenticationDaoImpl) ListForEndpoint(endpointID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error) {
+func (a *AuthenticationDaoImpl) ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
 	keys, err := a.listKeys()
 	if err != nil {
 		return nil, 0, err

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -29,6 +29,10 @@ type ApplicationDao interface {
 type AuthenticationDao interface {
 	List(limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
 	GetById(id string) (*m.Authentication, error)
+	ListForSource(sourceID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
+	ListForApplication(applicationID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
+	ListForApplicationAuthentication(appAuthID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
+	ListForEndpoint(endpointID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
 	Create(src *m.Authentication) error
 	Update(src *m.Authentication) error
 	Delete(id string) error

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -29,10 +29,10 @@ type ApplicationDao interface {
 type AuthenticationDao interface {
 	List(limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
 	GetById(id string) (*m.Authentication, error)
-	ListForSource(sourceID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
-	ListForApplication(applicationID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
-	ListForApplicationAuthentication(appAuthID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
-	ListForEndpoint(endpointID int64, limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
+	ListForSource(sourceID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
+	ListForApplication(applicationID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
+	ListForApplicationAuthentication(appAuthID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
+	ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
 	Create(src *m.Authentication) error
 	Update(src *m.Authentication) error
 	Delete(id string) error

--- a/model/application.go
+++ b/model/application.go
@@ -28,6 +28,8 @@ type Application struct {
 
 	ApplicationTypeID int64 `json:"application_type_id"`
 	ApplicationType   ApplicationType
+
+	ApplicationAuthentications []ApplicationAuthentication
 }
 
 func (app *Application) ToEvent() *ApplicationEvent {

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -14,6 +14,8 @@ type ApplicationAuthentication struct {
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
+	VaultPath string `json:"vault_path"`
+
 	TenantID int64
 	Tenant   Tenant
 
@@ -21,7 +23,8 @@ type ApplicationAuthentication struct {
 	Application   Application
 	// TODO: fix correctly PR#40
 	AuthenticationID int64 `json:"authentication_id"`
-	//Authentication   Authentication
+
+	AuthenticationUID string `json:"-"`
 }
 
 func (aa *ApplicationAuthentication) ToEvent() *ApplicationAuthenticationEvent {
@@ -44,10 +47,11 @@ func (aa *ApplicationAuthentication) ToResponse() *ApplicationAuthenticationResp
 	authId := strconv.FormatInt(aa.AuthenticationID, 10)
 
 	return &ApplicationAuthenticationResponse{
-		ID:               id,
-		CreatedAt:        aa.CreatedAt,
-		UpdatedAt:        aa.UpdatedAt,
-		ApplicationID:    appId,
-		AuthenticationID: authId,
+		ID:                id,
+		AuthenticationUID: aa.AuthenticationUID,
+		CreatedAt:         aa.CreatedAt,
+		UpdatedAt:         aa.UpdatedAt,
+		ApplicationID:     appId,
+		AuthenticationID:  authId,
 	}
 }

--- a/model/application_authentication_http.go
+++ b/model/application_authentication_http.go
@@ -9,6 +9,7 @@ type ApplicationAuthenticationResponse struct {
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
-	ApplicationID    string `json:"application_id"`
-	AuthenticationID string `json:"authentication_id"`
+	ApplicationID     string `json:"application_id"`
+	AuthenticationID  string `json:"authentication_id"`
+	AuthenticationUID string `json:"authentication_uid"`
 }

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -20,6 +20,7 @@ type Authentication struct {
 
 	SourceID int64 `json:"source_id"`
 	Source   Source
+
 	TenantID int64 `json:"tenant_id"`
 	Tenant   Tenant
 

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -77,6 +77,7 @@ func (auth *Authentication) ToVaultMap() (map[string]interface{}, error) {
 		"availability_status_error": auth.AvailabilityStatusError,
 		"resource_type":             auth.ResourceType,
 		"resource_id":               strconv.FormatInt(auth.ResourceID, 10),
+		"source_id":                 strconv.FormatInt(auth.SourceID, 10),
 	}
 
 	// Vault requires the hash to be wrapped in a "data" object in order to be accepted.

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -31,6 +31,7 @@ type AuthenticationCreateRequest struct {
 
 	ResourceType string `json:"resource_type"`
 	ResourceID   int64  `json:"resource_id"`
+	SourceID     int64  `json:"source_id"`
 }
 
 type AuthenticationEditRequest struct {

--- a/routes.go
+++ b/routes.go
@@ -49,10 +49,12 @@ func setupRoutes(e *echo.Echo) {
 	v3.GET("/sources/:source_id/application_types", SourceListApplicationTypes, tenancyWithListMiddleware...)
 	v3.GET("/sources/:source_id/applications", SourceListApplications, tenancyWithListMiddleware...)
 	v3.GET("/sources/:source_id/endpoints", SourceListEndpoint, tenancyWithListMiddleware...)
+	v3.GET("/sources/:source_id/authentications", SourceListAuthentications, tenancyWithListMiddleware...)
 
 	// Applications
 	v3.GET("/applications", ApplicationList, tenancyWithListMiddleware...)
 	v3.GET("/applications/:id", ApplicationGet, middleware.Tenancy)
+	v3.GET("/applications/:application_id/authentications", ApplicationListAuthentications, tenancyWithListMiddleware...)
 
 	// Authentications
 	v3.GET("/authentications", AuthenticationList, tenancyWithListMiddleware...)
@@ -70,10 +72,12 @@ func setupRoutes(e *echo.Echo) {
 	v3.GET("/endpoints", EndpointList, tenancyWithListMiddleware...)
 	v3.POST("/endpoints", EndpointCreate, permissionMiddleware...)
 	v3.GET("/endpoints/:id", EndpointGet, middleware.Tenancy)
+	v3.GET("/endpoints/:endpoint_id", EndpointListAuthentications, tenancyWithListMiddleware...)
 
 	// ApplicationAuthentications
 	v3.GET("/application_authentications", ApplicationAuthenticationList, tenancyWithListMiddleware...)
 	v3.GET("/application_authentications/:id", ApplicationAuthenticationGet, middleware.Tenancy)
+	v3.GET("/application_authentications/:application_authentication_id/authentications", ApplicationAuthenticationListAuthentications, tenancyWithListMiddleware...)
 
 	// AppMetaData
 	v3.GET("/app_meta_data", MetaDataList, listMiddleware...)

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -253,3 +253,28 @@ func SourceDelete(c echo.Context) (err error) {
 
 	return c.NoContent(http.StatusNoContent)
 }
+
+func SourceListAuthentications(c echo.Context) error {
+	authDao, err := getAuthenticationDao(c)
+	if err != nil {
+		return err
+	}
+
+	sourceID, err := strconv.ParseInt(c.Param("source_id"), 10, 64)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
+	}
+
+	auths, count, err := authDao.ListForSource(sourceID, 100, 0, nil)
+	if err != nil {
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
+	}
+
+	out := make([]interface{}, count)
+	for i := 0; i < int(count); i++ {
+		out[i] = auths[i].ToResponse()
+	}
+
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), 100, 0))
+
+}


### PR DESCRIPTION
[RHCLOUD-16566](https://issues.redhat.com/browse/RHCLOUD-16566)

Used the ApplicationAuthentication stuff as a reason to work on the subcollections for Authentications. It's kind of large - but the changes largely boil down to:
1. Update some model fields to set up the relations between ApplicationAuthentications and others that weren't working
2. Add `source_id` to the vault store - since that was missing in my initial pass
3. Subcollections for /source, /applications, /endpoints, /application_authentications which involve either abusing the ApplicationAuthentication's new `VaultPath` field OR just searching the keys

\# TODO: 
~- [ ] tests. lots of them.~ eventually. not this time. 