### PR TITLE
Refactor: use a struct for the test flags

### DIFF
--- a/internal/testutils/parser.go
+++ b/internal/testutils/parser.go
@@ -2,14 +2,22 @@ package testutils
 
 import "flag"
 
+// Flags holds the flags to control what the tests should be doing.
+type Flags struct {
+	CreateDb    bool
+	Integration bool
+}
+
 // ParseFlags parses the flags for the "go test" command. The "-createdb" indicates that a test database should be
 // created, whilst the "-integration" flag indicates that integration tests should be run along with the unit tests.
-// It returns a (bool, bool) which represents the status of ("-createdb", "-integration") accordingly.
-func ParseFlags() (bool, bool) {
+func ParseFlags() Flags {
 	createDb := flag.Bool("createdb", false, "create the test database")
 	integration := flag.Bool("integration", false, "run unit or integration tests")
 
 	flag.Parse()
 
-	return *createDb, *integration
+	return Flags{
+		CreateDb:    *createDb,
+		Integration: *integration,
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -24,11 +24,11 @@ var (
 func TestMain(t *testing.M) {
 	l.InitLogger(conf)
 
-	createDb, integration := testutils.ParseFlags()
+	flags := testutils.ParseFlags()
 
-	if createDb {
+	if flags.CreateDb {
 		testutils.CreateTestDB()
-	} else if integration {
+	} else if flags.Integration {
 		testutils.ConnectToTestDB()
 		getSourceDao = getSourceDaoWithTenant
 		getApplicationDao = getApplicationDaoWithTenant
@@ -58,7 +58,7 @@ func TestMain(t *testing.M) {
 
 	code := t.Run()
 
-	if integration {
+	if flags.Integration {
 		testutils.DropSchema()
 	}
 

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -16,11 +16,11 @@ var (
 )
 
 func TestMain(t *testing.M) {
-	createDb, integration := testutils.ParseFlags()
+	flags := testutils.ParseFlags()
 
-	if createDb {
+	if flags.CreateDb {
 		testutils.CreateTestDB()
-	} else if integration {
+	} else if flags.Integration {
 		runningIntegration = true
 		testutils.ConnectToTestDB()
 
@@ -32,7 +32,7 @@ func TestMain(t *testing.M) {
 
 	code := t.Run()
 
-	if integration {
+	if flags.Integration {
 		testutils.DropSchema()
 	}
 


### PR DESCRIPTION
Related to [!39](https://github.com/RedHatInsights/sources-api-go/pull/39) and [[RHCLOUD-16574]](https://issues.redhat.com/browse/RHCLOUD-16574).

I forgot to push this commit which addresses returning a `struct` for the `.Parse` function, so that it is easier to check which flags were passed to the `go test` command.

Sorry about the noise 😅