### PR TITLE
Endpoint validation

### DIFF
--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -84,7 +84,7 @@ func (a *EndpointDaoImpl) Tenant() *int64 {
 func (a *EndpointDaoImpl) CanEndpointBeSetAsDefaultForSource(sourceId int64) bool {
 	endpoint := &m.Endpoint{}
 	// add double quotes to the "default" column to avoid any clashes with postgres' "default" keyword
-	result := DB.Where("\"default\" = true AND source_id = ?", sourceId).First(&endpoint)
+	result := DB.Where(`"default" = true AND source_id = ?`, sourceId).First(&endpoint)
 
 	return result.Error == nil
 }

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -80,3 +80,27 @@ func (a *EndpointDaoImpl) Delete(id *int64) error {
 func (a *EndpointDaoImpl) Tenant() *int64 {
 	return a.TenantID
 }
+
+func (a *EndpointDaoImpl) CanEndpointBeSetAsDefaultForSource(sourceId int64) bool {
+	endpoint := &m.Endpoint{}
+	// add double quotes to the "default" column to avoid any clashes with postgres' "default" keyword
+	result := DB.Where("\"default\" = true AND source_id = ?", sourceId).First(&endpoint)
+
+	return result.Error == nil
+}
+
+func (a *EndpointDaoImpl) IsRoleUniqueForSource(role string, sourceId int64) bool {
+	endpoint := &m.Endpoint{}
+	result := DB.Where("role = ? AND source_id = ?", role, sourceId).First(&endpoint)
+
+	// If the record doesn't exist "result.Error" will have a "record not found" error
+	return result.Error != nil
+}
+
+func (a *EndpointDaoImpl) SourceHasEndpoints(sourceId int64) bool {
+	endpoint := &m.Endpoint{}
+
+	result := DB.Where("source_id = ?", sourceId).First(&endpoint)
+
+	return result.Error == nil
+}

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -61,6 +61,13 @@ type EndpointDao interface {
 	Update(src *m.Endpoint) error
 	Delete(id *int64) error
 	Tenant() *int64
+	// CanEndpointBeSetAsDefaultForSource checks if the endpoint can be set as default, by checking if the given source
+	// id already has another endpoint marked as default.
+	CanEndpointBeSetAsDefaultForSource(sourceId int64) bool
+	// IsRoleUniqueForSource checks if the role is unique for the given source ID.
+	IsRoleUniqueForSource(role string, sourceId int64) bool
+	// SourceHasEndpoints returns true if the provided source has any associated endpoints.
+	SourceHasEndpoints(sourceId int64) bool
 }
 
 type MetaDataDao interface {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -254,3 +254,15 @@ func (m *MockEndpointDao) Tenant() *int64 {
 	tenant := int64(1)
 	return &tenant
 }
+
+func (m *MockEndpointDao) CanEndpointBeSetAsDefaultForSource(sourceId int64) bool {
+	return true
+}
+
+func (m *MockEndpointDao) IsRoleUniqueForSource(role string, sourceId int64) bool {
+	return true
+}
+
+func (m *MockEndpointDao) SourceHasEndpoints(sourceId int64) bool {
+	return true
+}

--- a/model/endpoint_http.go
+++ b/model/endpoint_http.go
@@ -27,15 +27,16 @@ type EndpointResponse struct {
 }
 
 type EndpointCreateRequest struct {
-	Default              *bool   `json:"default"`
-	ReceptorNode         *string `json:"receptor_node"`
-	Role                 *string `json:"role"`
-	Scheme               *string `json:"scheme"`
-	Host                 *string `json:"host"`
-	Port                 *int64  `json:"port"`
-	Path                 string  `json:"path"`
-	VerifySsl            *bool   `json:"verify_ssl"`
-	CertificateAuthority *string `json:"certificate_authority"`
-	AvailabilityStatus   string  `json:"availability_status"`
-	SourceID             *string `json:"source_id"`
+	Default              *bool       `json:"default"`
+	ReceptorNode         *string     `json:"receptor_node"`
+	Role                 *string     `json:"role"`
+	Scheme               *string     `json:"scheme"`
+	Host                 *string     `json:"host"`
+	Port                 *int64      `json:"port"`
+	Path                 string      `json:"path"`
+	VerifySsl            *bool       `json:"verify_ssl"`
+	CertificateAuthority *string     `json:"certificate_authority"`
+	AvailabilityStatus   string      `json:"availability_status"`
+	SourceID             int64       `json:"-"`
+	SourceIDRaw          interface{} `json:"source_id"`
 }

--- a/model/endpoint_http.go
+++ b/model/endpoint_http.go
@@ -27,16 +27,15 @@ type EndpointResponse struct {
 }
 
 type EndpointCreateRequest struct {
-	Default                 *bool   `json:"default"`
-	ReceptorNode            *string `json:"receptor_node"`
-	Role                    *string `json:"role"`
-	Scheme                  *string `json:"scheme"`
-	Host                    *string `json:"host"`
-	Port                    *int64  `json:"port"`
-	Path                    string  `json:"path"`
-	VerifySsl               *bool   `json:"verify_ssl"`
-	CertificateAuthority    *string `json:"certificate_authority"`
-	AvailabilityStatus      string  `json:"availability_status"`
-	AvailabilityStatusError string  `json:"availability_status_error"`
-	SourceID                *string `json:"source_id"`
+	Default              *bool   `json:"default"`
+	ReceptorNode         *string `json:"receptor_node"`
+	Role                 *string `json:"role"`
+	Scheme               *string `json:"scheme"`
+	Host                 *string `json:"host"`
+	Port                 *int64  `json:"port"`
+	Path                 string  `json:"path"`
+	VerifySsl            *bool   `json:"verify_ssl"`
+	CertificateAuthority *string `json:"certificate_authority"`
+	AvailabilityStatus   string  `json:"availability_status"`
+	SourceID             *string `json:"source_id"`
 }

--- a/model/endpoint_http.go
+++ b/model/endpoint_http.go
@@ -27,7 +27,7 @@ type EndpointResponse struct {
 }
 
 type EndpointCreateRequest struct {
-	Default              *bool       `json:"default"`
+	Default              bool        `json:"default"`
 	ReceptorNode         *string     `json:"receptor_node"`
 	Role                 string      `json:"role"`
 	Scheme               *string     `json:"scheme"`

--- a/model/endpoint_http.go
+++ b/model/endpoint_http.go
@@ -29,7 +29,7 @@ type EndpointResponse struct {
 type EndpointCreateRequest struct {
 	Default              *bool       `json:"default"`
 	ReceptorNode         *string     `json:"receptor_node"`
-	Role                 *string     `json:"role"`
+	Role                 string      `json:"role"`
 	Scheme               *string     `json:"scheme"`
 	Host                 *string     `json:"host"`
 	Port                 *int64      `json:"port"`

--- a/model/endpoint_http.go
+++ b/model/endpoint_http.go
@@ -31,7 +31,7 @@ type EndpointCreateRequest struct {
 	ReceptorNode         *string     `json:"receptor_node"`
 	Role                 string      `json:"role"`
 	Scheme               *string     `json:"scheme"`
-	Host                 *string     `json:"host"`
+	Host                 string      `json:"host"`
 	Port                 *int64      `json:"port"`
 	Path                 string      `json:"path"`
 	VerifySsl            *bool       `json:"verify_ssl"`

--- a/model/endpoint_http.go
+++ b/model/endpoint_http.go
@@ -25,3 +25,18 @@ type EndpointResponse struct {
 
 	SourceID string `json:"source_id"`
 }
+
+type EndpointCreateRequest struct {
+	Default                 *bool   `json:"default"`
+	ReceptorNode            *string `json:"receptor_node"`
+	Role                    *string `json:"role"`
+	Scheme                  *string `json:"scheme"`
+	Host                    *string `json:"host"`
+	Port                    *int64  `json:"port"`
+	Path                    string  `json:"path"`
+	VerifySsl               *bool   `json:"verify_ssl"`
+	CertificateAuthority    *string `json:"certificate_authority"`
+	AvailabilityStatus      string  `json:"availability_status"`
+	AvailabilityStatusError string  `json:"availability_status_error"`
+	SourceID                *string `json:"source_id"`
+}

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// hostRegexp matches a valid host. The reference RFCs consulted for this are the following ones:
+// - https://datatracker.ietf.org/doc/html/rfc1034#section-3.5
+// - https://datatracker.ietf.org/doc/html/rfc2181#section-11
+// Even though the RFC1034 states that labels "must start with a letter, end with a letter or digit, and have as
+// interior characters only letters, digits, and hyphen", there are domains which have labels that start or end with
+// digits. For example: https://github.com/opendns/public-domain-lists/blob/master/opendns-random-domains.txt . Also,
+// length validation on labels and FQDN is left to do it with "splits", to avoid complicating the regex even more.
+var fqdnRegexp = regexp.MustCompile(`^(?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?\.)+[a-zA-Z](?:[a-zA-Z\d-]*[a-zA-Z])?$`)
+
+// schemeRegexp matches a valid scheme, as per RFC 3986
+var schemeRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z\d+\-.]*$`)
+var validAvailabilityStatuses = []string{"", model.Available, model.Unavailable}
+
+const (
+	defaultScheme    = "https"
+	defaultPort      = int64(443)
+	defaultVerifySsl = true
+	maxFqdnLength    = 255 // RFC2181
+	maxLabelLength   = 63  // RFC2181
+	maxPort          = 65535
+)
+
+func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreateRequest) error {
+	sourceId, err := util.InterfaceToInt64(ecr.SourceID)
+	if err != nil {
+		return fmt.Errorf("the provided source ID is not valid")
+	}
+
+	if sourceId < 1 {
+		return fmt.Errorf("invalid source id")
+	}
+
+	if ecr.Default == nil {
+		return fmt.Errorf("default body parameter not provided")
+	}
+
+	if *ecr.Default && !dao.CanEndpointBeSetAsDefaultForSource(sourceId) {
+		return fmt.Errorf("a default endpoint already exists for the provided source")
+	}
+
+	if !dao.SourceHasEndpoints(sourceId) {
+		*ecr.Default = true
+	}
+
+	if ecr.ReceptorNode == nil || *ecr.ReceptorNode == "" {
+		return fmt.Errorf("the receptor node cannot be empty")
+	}
+
+	if ecr.Role == nil || *ecr.Role == "" {
+		return fmt.Errorf("role cannot be empty")
+	}
+
+	if !dao.IsRoleUniqueForSource(*ecr.Role, sourceId) {
+		return fmt.Errorf("the role already exists for the given source")
+	}
+
+	if ecr.Scheme == nil || !schemeRegexp.MatchString(*ecr.Scheme) {
+		tmp := defaultScheme
+		ecr.Scheme = &tmp
+	}
+
+	if ecr.Host == nil || *ecr.Host == "" {
+		return fmt.Errorf("the host cannot be empty")
+	}
+
+	if utf8.RuneCountInString(*ecr.Host) > maxFqdnLength {
+		return fmt.Errorf("the provided host is longer than %d characters", maxFqdnLength)
+	}
+
+	if !fqdnRegexp.MatchString(*ecr.Host) {
+		return fmt.Errorf("the provided host is invalid")
+	}
+
+	labels := strings.Split(*ecr.Host, ".")
+	for _, label := range labels {
+		if utf8.RuneCountInString(*ecr.Host) > maxLabelLength {
+			return fmt.Errorf("the label '%s' is greater than %d characters", label, maxLabelLength)
+		}
+	}
+
+	if ecr.Port == nil || *ecr.Port <= 0 {
+		tmp := defaultPort
+		ecr.Port = &tmp
+	}
+
+	if *ecr.Port > maxPort {
+		return fmt.Errorf("invalid port number")
+	}
+
+	if ecr.VerifySsl == nil {
+		tmp := defaultVerifySsl
+		ecr.VerifySsl = &tmp
+	}
+
+	if *ecr.VerifySsl && (ecr.CertificateAuthority == nil || *ecr.CertificateAuthority == "") {
+		return fmt.Errorf("the certificate authority cannot be empty")
+	}
+
+	if !util.SliceContainsString(validAvailabilityStatuses, ecr.AvailabilityStatus) {
+		return fmt.Errorf("invalid availability status")
+	}
+
+	return nil
+}

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -57,11 +57,7 @@ func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreat
 		*ecr.Default = true
 	}
 
-	if ecr.Role == nil || *ecr.Role == "" {
-		return fmt.Errorf("role cannot be empty")
-	}
-
-	if !dao.IsRoleUniqueForSource(*ecr.Role, sourceId) {
+	if !dao.IsRoleUniqueForSource(ecr.Role, sourceId) {
 		return fmt.Errorf("the role already exists for the given source")
 	}
 

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -34,7 +34,7 @@ const (
 )
 
 func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreateRequest) error {
-	sourceId, err := util.InterfaceToInt64(ecr.SourceID)
+	sourceId, err := util.InterfaceToInt64(ecr.SourceIDRaw)
 	if err != nil {
 		return fmt.Errorf("the provided source ID is not valid")
 	}
@@ -42,6 +42,8 @@ func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreat
 	if sourceId < 1 {
 		return fmt.Errorf("invalid source id")
 	}
+
+	ecr.SourceID = sourceId
 
 	if ecr.Default == nil {
 		return fmt.Errorf("default body parameter not provided")

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -57,10 +57,6 @@ func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreat
 		*ecr.Default = true
 	}
 
-	if ecr.ReceptorNode == nil || *ecr.ReceptorNode == "" {
-		return fmt.Errorf("the receptor node cannot be empty")
-	}
-
 	if ecr.Role == nil || *ecr.Role == "" {
 		return fmt.Errorf("role cannot be empty")
 	}

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -66,22 +66,20 @@ func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreat
 		ecr.Scheme = &tmp
 	}
 
-	if ecr.Host == nil || *ecr.Host == "" {
-		return fmt.Errorf("the host cannot be empty")
-	}
+	if ecr.Host != "" {
+		if utf8.RuneCountInString(ecr.Host) > maxFqdnLength {
+			return fmt.Errorf("the provided host is longer than %d characters", maxFqdnLength)
+		}
 
-	if utf8.RuneCountInString(*ecr.Host) > maxFqdnLength {
-		return fmt.Errorf("the provided host is longer than %d characters", maxFqdnLength)
-	}
+		if !fqdnRegexp.MatchString(ecr.Host) {
+			return fmt.Errorf("the provided host is invalid")
+		}
 
-	if !fqdnRegexp.MatchString(*ecr.Host) {
-		return fmt.Errorf("the provided host is invalid")
-	}
-
-	labels := strings.Split(*ecr.Host, ".")
-	for _, label := range labels {
-		if utf8.RuneCountInString(*ecr.Host) > maxLabelLength {
-			return fmt.Errorf("the label '%s' is greater than %d characters", label, maxLabelLength)
+		labels := strings.Split(ecr.Host, ".")
+		for _, label := range labels {
+			if utf8.RuneCountInString(ecr.Host) > maxLabelLength {
+				return fmt.Errorf("the label '%s' is greater than %d characters", label, maxLabelLength)
+			}
 		}
 	}
 

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -45,16 +45,12 @@ func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreat
 
 	ecr.SourceID = sourceId
 
-	if ecr.Default == nil {
-		return fmt.Errorf("default body parameter not provided")
-	}
-
-	if *ecr.Default && !dao.CanEndpointBeSetAsDefaultForSource(sourceId) {
+	if ecr.Default && !dao.CanEndpointBeSetAsDefaultForSource(sourceId) {
 		return fmt.Errorf("a default endpoint already exists for the provided source")
 	}
 
 	if !dao.SourceHasEndpoints(sourceId) {
-		*ecr.Default = true
+		ecr.Default = true
 	}
 
 	if !dao.IsRoleUniqueForSource(ecr.Role, sourceId) {

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -147,38 +147,6 @@ func TestDefaultIsSetBecauseSourceHasNoEndpoints(t *testing.T) {
 	}
 }
 
-// TestReceptorNodeMissing tests if an error is returned when no receptor node is provided.
-func TestReceptorNodeMissing(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
-
-	ecr := setUpEndpointCreateRequest()
-	ecr.ReceptorNode = nil
-
-	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
-	if err == nil {
-		t.Error("want error, got none")
-	}
-
-	want := "the receptor node cannot be empty"
-	if err.Error() != want {
-		t.Errorf("want '%s', got %s", want, err)
-	}
-
-	emptyString := ""
-	ecr.ReceptorNode = &emptyString
-
-	err = ValidateEndpointCreateRequest(endpointDao, &ecr)
-	if err == nil {
-		t.Error("want error, got none")
-	}
-
-	if err.Error() != want {
-		t.Errorf("want '%s', got %s", want, err)
-	}
-}
-
 // TestRoleMissing tests if an error is returned when no role has been given.
 func TestRoleMissing(t *testing.T) {
 	if !runningIntegration {

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -13,7 +13,6 @@ func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 	defaultVal := false
 	receptorNode := "receptorNode"
 	scheme := "https"
-	host := "example.com"
 	port := int64(443)
 	verifySsl := true
 	certificateAuthority := "letsEncrypt"
@@ -24,7 +23,7 @@ func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 		ReceptorNode:         &receptorNode,
 		Role:                 "role",
 		Scheme:               &scheme,
-		Host:                 &host,
+		Host:                 "example.com",
 		Port:                 &port,
 		Path:                 "/example",
 		VerifySsl:            &verifySsl,
@@ -210,34 +209,18 @@ func TestSchemeGetsDefaulted(t *testing.T) {
 	}
 }
 
-// TestEmptyHost tests if an error is returned when an empty host is given.
+// TestEmptyHost tests if no error is returned even when an empty host is given.
 func TestEmptyHost(t *testing.T) {
 	if !runningIntegration {
 		t.Skip("skipping integration tests...")
 	}
 
 	ecr := setUpEndpointCreateRequest()
-	ecr.Host = nil
+	ecr.Host = ""
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
-	if err == nil {
-		t.Error("want error, got none")
-	}
-
-	want := "the host cannot be empty"
-	if err.Error() != want {
-		t.Errorf("want '%s', got %s", want, err)
-	}
-
-	emptyString := ""
-	ecr.Host = &emptyString
-	err = ValidateEndpointCreateRequest(endpointDao, &ecr)
-	if err == nil {
-		t.Error("want error, got none")
-	}
-
-	if err.Error() != want {
-		t.Errorf("want '%s', got %s", want, err)
+	if err != nil {
+		t.Errorf("want no error, got '%s'", err)
 	}
 }
 
@@ -250,15 +233,13 @@ func TestHostFqdnTooLong(t *testing.T) {
 	ecr := setUpEndpointCreateRequest()
 
 	// The "longHostname" variable holds a 256 char hostname
-	longHostname := `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+	ecr.Host = `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
 		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
 		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
 		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
 		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
 		aaaaaa
 	`
-
-	ecr.Host = &longHostname
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 	if err == nil {
@@ -291,7 +272,7 @@ func TestValidHosts(t *testing.T) {
 	ecr := setUpEndpointCreateRequest()
 
 	for _, tt := range testValues {
-		ecr.Host = &tt
+		ecr.Host = tt
 
 		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 		if err != nil {
@@ -317,7 +298,7 @@ func TestInvalidHosts(t *testing.T) {
 
 	want := "the provided host is not valid"
 	for _, tt := range testValues {
-		ecr.Host = &tt
+		ecr.Host = tt
 
 		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 		if err == nil {
@@ -335,8 +316,7 @@ func TestLabelNamesTooLong(t *testing.T) {
 	ecr := setUpEndpointCreateRequest()
 
 	// The first label is 64 characters long
-	longLabels := `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg.example.org`
-	ecr.Host = &longLabels
+	ecr.Host = `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg.example.org`
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 	if err == nil {

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -1,0 +1,559 @@
+package service
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/model"
+)
+
+func setUpEndpointCreateRequest() model.EndpointCreateRequest {
+	defaultVal := false
+	receptorNode := "receptorNode"
+	role := "role"
+	scheme := "https"
+	host := "example.com"
+	port := int64(443)
+	verifySsl := true
+	certificateAuthority := "letsEncrypt"
+	sourceId := strconv.FormatInt(testutils.TestSourceData[0].ID, 10)
+
+	return model.EndpointCreateRequest{
+		Default:                 &defaultVal,
+		ReceptorNode:            &receptorNode,
+		Role:                    &role,
+		Scheme:                  &scheme,
+		Host:                    &host,
+		Port:                    &port,
+		Path:                    "/example",
+		VerifySsl:               &verifySsl,
+		CertificateAuthority:    &certificateAuthority,
+		AvailabilityStatus:      model.Available,
+		AvailabilityStatusError: "",
+		SourceID:                &sourceId,
+	}
+}
+
+// TestValidateEndpointCreateRequest tests that when a proper EndpointCreateRequest is given, the validator doesn't
+// complain.
+func TestValidateEndpointCreateRequest(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err != nil {
+		t.Errorf("want no errors, got '%s'", err)
+	}
+}
+
+// TestInvalidSourceIdFormat tests if an error is returned when an invalid format or string is provided for the source
+// id.
+func TestInvalidSourceIdFormat(t *testing.T) {
+	ecr := setUpEndpointCreateRequest()
+
+	invalidSourceId := "hello world"
+	ecr.SourceID = &invalidSourceId
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "the provided source ID is not valid"
+	if err.Error() != want {
+		t.Errorf("want '%s', got '%s'", want, err)
+	}
+}
+
+// TestInvalidSourceId tests if an error is returned when providing a source id lower than one.
+func TestInvalidSourceId(t *testing.T) {
+	ecr := setUpEndpointCreateRequest()
+
+	invalidSourceId := "0"
+	ecr.SourceID = &invalidSourceId
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "invalid source id"
+	if err.Error() != want {
+		t.Errorf("want '%s', got '%s'", want, err)
+	}
+}
+
+// TestMissingDefault tests if an error is returned when not providing the "default" body parameter.
+func TestMissingDefault(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	ecr.Default = nil
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "default body parameter not provided"
+	if err.Error() != want {
+		t.Errorf("want '%s', got '%s'", want, err)
+	}
+}
+
+// TestDefaultEndpointAlreadyExists tests if an error is returned when the provided endpoint is marked as default when
+// the also provided source already has a default one.
+func TestDefaultEndpointAlreadyExists(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	trueValue := true
+	ecr.Default = &trueValue
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "a default endpoint already exists for the provided source"
+	if err.Error() != want {
+		t.Errorf("want '%s' error, got '%s'", want, err)
+	}
+}
+
+// TestDefaultIsSetBecauseSourceHasNoEndpoints tests if the endpoint is defaulted when the provided source  has no
+// endpoints.
+func TestDefaultIsSetBecauseSourceHasNoEndpoints(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	nonExistingSourceId := "12345"
+	ecr.SourceID = &nonExistingSourceId
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err != nil {
+		t.Errorf("want no errors, got '%s'", err)
+	}
+
+	if *ecr.Default != true {
+		t.Error("want endpoint marked as default, got regular endpoint instead")
+	}
+}
+
+// TestReceptorNodeMissing tests if an error is returned when no receptor node is provided.
+func TestReceptorNodeMissing(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	ecr.ReceptorNode = nil
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "the receptor node cannot be empty"
+	if err.Error() != want {
+		t.Errorf("want '%s', got %s", want, err)
+	}
+
+	emptyString := ""
+	ecr.ReceptorNode = &emptyString
+
+	err = ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	if err.Error() != want {
+		t.Errorf("want '%s', got %s", want, err)
+	}
+}
+
+// TestRoleMissing tests if an error is returned when no role has been given.
+func TestRoleMissing(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	ecr.Role = nil
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "role cannot be empty"
+	if err.Error() != want {
+		t.Errorf("want '%s', got '%s'", want, err)
+	}
+
+	emptyString := ""
+	ecr.Role = &emptyString
+
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	if err.Error() != want {
+		t.Errorf("want '%s', got '%s'", want, err)
+	}
+}
+
+// TestNonUniqueRole tests if an error is returned when a role already exists for a source.
+func TestNonUniqueRole(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	role := "myRole"
+	newEndpoint := testutils.TestEndpointData[0]
+	newEndpoint.ID = 0 // set it as zero to avoid hitting
+	newEndpoint.Role = &role
+
+	err := endpointDao.Create(&newEndpoint)
+	if err != nil {
+		t.Error("could not insert new endpoint for the test")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	ecr.Role = &role
+
+	err = ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "the role already exists for the given source"
+	if err.Error() != want {
+		t.Errorf("want '%s', got %s", want, err)
+	}
+}
+
+// TestSchemeGetsDefaulted tests if the scheme gets properly defaulted when an invalid or missing scheme is provided.
+func TestSchemeGetsDefaulted(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	ecr.Scheme = nil
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+
+	if err != nil {
+		t.Errorf("want no errors, got %s", err)
+	}
+
+	if *ecr.Scheme != defaultScheme {
+		t.Errorf("want '%s', got '%s", defaultScheme, *ecr.Scheme)
+	}
+
+	invalidScheme := "/invalid"
+	ecr.Scheme = &invalidScheme
+
+	err = ValidateEndpointCreateRequest(endpointDao, &ecr)
+
+	if err != nil {
+		t.Errorf("want no errors, got %s", err)
+	}
+
+	if *ecr.Scheme != defaultScheme {
+		t.Errorf("want '%s', got '%s", defaultScheme, *ecr.Scheme)
+	}
+}
+
+// TestEmptyHost tests if an error is returned when an empty host is given.
+func TestEmptyHost(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	ecr.Host = nil
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "the host cannot be empty"
+	if err.Error() != want {
+		t.Errorf("want '%s', got %s", want, err)
+	}
+
+	emptyString := ""
+	ecr.Host = &emptyString
+	err = ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	if err.Error() != want {
+		t.Errorf("want '%s', got %s", want, err)
+	}
+}
+
+// TestHostFqdnTooLong tests if an error is returned when a host which is too long is given.
+func TestHostFqdnTooLong(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	// The "longHostname" variable holds a 256 char hostname
+	longHostname := `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaa
+	`
+
+	ecr.Host = &longHostname
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "the provided host is longer than 255 characters"
+	if err.Error() != want {
+		t.Errorf("want '%s' got '%s'", want, err)
+	}
+}
+
+// TestValidHosts tests if the validation succeeds when valid hosts are given.
+func TestValidHosts(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	testValues := []string{
+		"redhat.com",
+		"elpmaxe.example.com",
+		"exa.mp-le.com",
+		"123456789.org",
+		"123ab-ba321.org",
+		"a.org",
+		"5.com",
+		"example.xn--whatever",
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	for _, tt := range testValues {
+		ecr.Host = &tt
+
+		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+		if err != nil {
+			t.Errorf("want no errors, got '%s' for %#v", err, tt)
+		}
+	}
+}
+
+// TestInvalidHosts tests if an error is returned on invalid hosts.
+func TestInvalidHosts(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	testValues := []string{
+		"-example.com",
+		"example-.com",
+		"example.xn--",
+		"example.--xn",
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	want := "the provided host is not valid"
+	for _, tt := range testValues {
+		ecr.Host = &tt
+
+		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+		if err == nil {
+			t.Errorf("want '%s', got no error for %#v", want, tt)
+		}
+	}
+}
+
+// TestLabelNamesTooLong tests if an error is returned when the provided labels are longer than permitted.
+func TestLabelNamesTooLong(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	// The first label is 64 characters long
+	longLabels := `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg.example.org`
+	ecr.Host = &longLabels
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := fmt.Sprintf("the label '%s' is greater than %d characters", "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg", maxLabelLength)
+	if err.Error() != want {
+		t.Errorf("want '%s', got %s", want, err)
+	}
+}
+
+// TestDefaultingPortWhenMissingOrLessThanZero test if the port is given a default value if it's missing or it has been
+// given a value equal or lower than zero.
+func TestDefaultingPortWhenMissingOrLessThanZero(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	minusOne := int64(-1)
+	zero := int64(0)
+	testValues := []struct {
+		value *int64
+	}{
+		{nil},
+		{&minusOne},
+		{&zero},
+	}
+
+	for _, tt := range testValues {
+		ecr.Port = tt.value
+		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+		if err != nil {
+			t.Errorf("want no error, got %s", err)
+		}
+
+		if *ecr.Port != defaultPort {
+			t.Errorf("want %d, got %d", defaultPort, *ecr.Port)
+		}
+	}
+}
+
+// TestPortLargeValue tests if an error is returned when a port that is greater than the maximum allowed port is given.
+func TestPortLargeValue(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	largePort := int64(999999)
+	ecr.Port = &largePort
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+
+	if err == nil {
+		t.Error("want error, got none")
+	}
+
+	want := "invalid port number"
+	if err.Error() != want {
+		t.Errorf("want '%s', got '%s'", want, err)
+	}
+}
+
+// TestDefaultVerifySsl tests if the default value is set when no "VerifySSL" value is provided.
+func TestDefaultVerifySsl(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+	ecr.VerifySsl = nil
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err != nil {
+		t.Errorf("want no error, got '%s'", err)
+	}
+
+	if *ecr.VerifySsl != defaultVerifySsl {
+		t.Errorf("want %t, got %t", defaultVerifySsl, *ecr.VerifySsl)
+	}
+}
+
+// TestEmptyCertificateAuthority tests if an error is returned when ssl verification is turned on but no certificate
+// authority is given.
+func TestEmptyCertificateAuthority(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	emptyString := ""
+	testValues := []struct {
+		value *string
+	}{
+		{nil},
+		{&emptyString},
+	}
+
+	want := "the certificate authority cannot be empty"
+	for _, tt := range testValues {
+		ecr.CertificateAuthority = tt.value
+
+		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+
+		if err.Error() != want {
+			t.Errorf("want '%s', got '%s'", want, err)
+		}
+	}
+}
+
+// TestValidAvailabilityStatuses tests if no error is returned when valid availability statuses are given.
+func TestValidAvailabilityStatuses(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	testValues := []string{"", model.Available, model.Unavailable}
+	for _, tt := range testValues {
+		ecr.AvailabilityStatus = tt
+
+		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+		if err != nil {
+			t.Errorf("want no error, got '%s'", err)
+		}
+	}
+}
+
+// TestInvalidAvailabilityStatuses tests if an error is returned when passing invalid availability statuses.
+func TestInvalidAvailabilityStatuses(t *testing.T) {
+	if !runningIntegration {
+		t.Skip("skipping integration tests...")
+	}
+
+	ecr := setUpEndpointCreateRequest()
+
+	invalidValues := []string{"hello", "world", "almost", "passes", "validation"}
+	want := "invalid availability status"
+	for _, tt := range invalidValues {
+		ecr.AvailabilityStatus = tt
+
+		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+		if err.Error() != want {
+			t.Errorf("want '%s', got '%s'", want, err)
+		}
+	}
+}

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -12,7 +12,6 @@ import (
 func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 	defaultVal := false
 	receptorNode := "receptorNode"
-	role := "role"
 	scheme := "https"
 	host := "example.com"
 	port := int64(443)
@@ -23,7 +22,7 @@ func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 	return model.EndpointCreateRequest{
 		Default:              &defaultVal,
 		ReceptorNode:         &receptorNode,
-		Role:                 &role,
+		Role:                 "role",
 		Scheme:               &scheme,
 		Host:                 &host,
 		Port:                 &port,
@@ -147,37 +146,6 @@ func TestDefaultIsSetBecauseSourceHasNoEndpoints(t *testing.T) {
 	}
 }
 
-// TestRoleMissing tests if an error is returned when no role has been given.
-func TestRoleMissing(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
-
-	ecr := setUpEndpointCreateRequest()
-	ecr.Role = nil
-
-	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
-	if err == nil {
-		t.Error("want error, got none")
-	}
-
-	want := "role cannot be empty"
-	if err.Error() != want {
-		t.Errorf("want '%s', got '%s'", want, err)
-	}
-
-	emptyString := ""
-	ecr.Role = &emptyString
-
-	if err == nil {
-		t.Error("want error, got none")
-	}
-
-	if err.Error() != want {
-		t.Errorf("want '%s', got '%s'", want, err)
-	}
-}
-
 // TestNonUniqueRole tests if an error is returned when a role already exists for a source.
 func TestNonUniqueRole(t *testing.T) {
 	if !runningIntegration {
@@ -195,7 +163,7 @@ func TestNonUniqueRole(t *testing.T) {
 	}
 
 	ecr := setUpEndpointCreateRequest()
-	ecr.Role = &role
+	ecr.Role = role
 
 	err = ValidateEndpointCreateRequest(endpointDao, &ecr)
 	if err == nil {

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -31,7 +31,7 @@ func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 		VerifySsl:            &verifySsl,
 		CertificateAuthority: &certificateAuthority,
 		AvailabilityStatus:   model.Available,
-		SourceID:             &sourceId,
+		SourceIDRaw:          sourceId,
 	}
 }
 
@@ -55,8 +55,7 @@ func TestValidateEndpointCreateRequest(t *testing.T) {
 func TestInvalidSourceIdFormat(t *testing.T) {
 	ecr := setUpEndpointCreateRequest()
 
-	invalidSourceId := "hello world"
-	ecr.SourceID = &invalidSourceId
+	ecr.SourceIDRaw = "hello world"
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 	if err == nil {
@@ -73,8 +72,7 @@ func TestInvalidSourceIdFormat(t *testing.T) {
 func TestInvalidSourceId(t *testing.T) {
 	ecr := setUpEndpointCreateRequest()
 
-	invalidSourceId := "0"
-	ecr.SourceID = &invalidSourceId
+	ecr.SourceIDRaw = "0"
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 	if err == nil {
@@ -137,8 +135,7 @@ func TestDefaultIsSetBecauseSourceHasNoEndpoints(t *testing.T) {
 	}
 
 	ecr := setUpEndpointCreateRequest()
-	nonExistingSourceId := "12345"
-	ecr.SourceID = &nonExistingSourceId
+	ecr.SourceIDRaw = "12345"
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 	if err != nil {

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -21,18 +21,17 @@ func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 	sourceId := strconv.FormatInt(testutils.TestSourceData[0].ID, 10)
 
 	return model.EndpointCreateRequest{
-		Default:                 &defaultVal,
-		ReceptorNode:            &receptorNode,
-		Role:                    &role,
-		Scheme:                  &scheme,
-		Host:                    &host,
-		Port:                    &port,
-		Path:                    "/example",
-		VerifySsl:               &verifySsl,
-		CertificateAuthority:    &certificateAuthority,
-		AvailabilityStatus:      model.Available,
-		AvailabilityStatusError: "",
-		SourceID:                &sourceId,
+		Default:              &defaultVal,
+		ReceptorNode:         &receptorNode,
+		Role:                 &role,
+		Scheme:               &scheme,
+		Host:                 &host,
+		Port:                 &port,
+		Path:                 "/example",
+		VerifySsl:            &verifySsl,
+		CertificateAuthority: &certificateAuthority,
+		AvailabilityStatus:   model.Available,
+		SourceID:             &sourceId,
 	}
 }
 

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func setUpEndpointCreateRequest() model.EndpointCreateRequest {
-	defaultVal := false
 	receptorNode := "receptorNode"
 	scheme := "https"
 	port := int64(443)
@@ -19,7 +18,7 @@ func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 	sourceId := strconv.FormatInt(testutils.TestSourceData[0].ID, 10)
 
 	return model.EndpointCreateRequest{
-		Default:              &defaultVal,
+		Default:              false,
 		ReceptorNode:         &receptorNode,
 		Role:                 "role",
 		Scheme:               &scheme,
@@ -83,26 +82,6 @@ func TestInvalidSourceId(t *testing.T) {
 	}
 }
 
-// TestMissingDefault tests if an error is returned when not providing the "default" body parameter.
-func TestMissingDefault(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
-
-	ecr := setUpEndpointCreateRequest()
-	ecr.Default = nil
-
-	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
-	if err == nil {
-		t.Error("want error, got none")
-	}
-
-	want := "default body parameter not provided"
-	if err.Error() != want {
-		t.Errorf("want '%s', got '%s'", want, err)
-	}
-}
-
 // TestDefaultEndpointAlreadyExists tests if an error is returned when the provided endpoint is marked as default when
 // the also provided source already has a default one.
 func TestDefaultEndpointAlreadyExists(t *testing.T) {
@@ -111,8 +90,7 @@ func TestDefaultEndpointAlreadyExists(t *testing.T) {
 	}
 
 	ecr := setUpEndpointCreateRequest()
-	trueValue := true
-	ecr.Default = &trueValue
+	ecr.Default = true
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 	if err == nil {
@@ -140,7 +118,7 @@ func TestDefaultIsSetBecauseSourceHasNoEndpoints(t *testing.T) {
 		t.Errorf("want no errors, got '%s'", err)
 	}
 
-	if *ecr.Default != true {
+	if ecr.Default != true {
 		t.Error("want endpoint marked as default, got regular endpoint instead")
 	}
 }

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -12,7 +12,8 @@ var (
 	// runningIntegration is used to skip integration tests if we're just running unit tests.
 	runningIntegration = false
 
-	sourceDao dao.SourceDao
+	endpointDao dao.EndpointDao
+	sourceDao   dao.SourceDao
 )
 
 func TestMain(t *testing.M) {
@@ -24,9 +25,11 @@ func TestMain(t *testing.M) {
 		runningIntegration = true
 		testutils.ConnectToTestDB()
 
+		endpointDao = &dao.EndpointDaoImpl{TenantID: &testutils.TestTenantData[0].Id}
 		sourceDao = &dao.SourceDaoImpl{TenantID: &testutils.TestTenantData[0].Id}
 		testutils.CreateFixtures()
 	} else {
+		endpointDao = &dao.MockEndpointDao{}
 		sourceDao = &dao.MockSourceDao{}
 	}
 


### PR DESCRIPTION
Implements the equivalent endpoint validation of [sources-api/app/models/endpoint.rb](https://github.com/RedHatInsights/sources-api/blob/master/app/models/endpoint.rb) plus some extra validations. The validations that have been implemented are the following ones:

## Validations and defaults
- `SourceID`
    - Required, non-zero and positive number.
- `Default`
    - An endpoint can't be set as "default" if there's another endpoint for the given source marked as "default".
    - Marked as default if there aren't any other endpoints for the given source.
- `Role`
    - There must not exist another endpoint for the given source with the same role name.
- `Scheme`
    - Not required.
    - If it is `nil`, or it is not a valid scheme, it defaults to `https`
-  `Host`
    - Not required.
    - Can't be longer than 255 chars (RFC2181). Can't have labels longer than 63 chars (RFC2181).
    - Must be a valid host (RFC1034 and RFC2181)
- `Port`
    - Not required. If provided, must be lower than MAXPORT.
    - Defaults to `443`
- `VerifySsl`
    - Not required.
    - Defaults to `true`
- `CertificateAuthority`
    - Not required.
    - Must not be null if `VerifySsl` is set as `true`.
- `AvailabilityStatus`
    - Required.
    - Must be one of `("", "available", "unavailable")`.

[[RHCLOUD-16766]](https://issues.redhat.com/browse/RHCLOUD-16766)