### PR TITLE
Create a POST route, handler and DAO for the endpoint creation

### DIFF
--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -59,6 +59,8 @@ func (a *EndpointDaoImpl) GetById(id *int64) (*m.Endpoint, error) {
 }
 
 func (a *EndpointDaoImpl) Create(app *m.Endpoint) error {
+	app.TenantID = *a.TenantID
+
 	result := DB.Create(app)
 	return result.Error
 }

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -239,7 +239,7 @@ func (a *MockEndpointDao) GetById(id *int64) (*m.Endpoint, error) {
 }
 
 func (a *MockEndpointDao) Create(src *m.Endpoint) error {
-	panic("not implemented") // TODO: Implement
+	return nil
 }
 
 func (a *MockEndpointDao) Update(src *m.Endpoint) error {

--- a/model/endpoint_http.go
+++ b/model/endpoint_http.go
@@ -32,7 +32,7 @@ type EndpointCreateRequest struct {
 	Role                 string      `json:"role"`
 	Scheme               *string     `json:"scheme"`
 	Host                 string      `json:"host"`
-	Port                 *int64      `json:"port"`
+	Port                 *int        `json:"port"`
 	Path                 string      `json:"path"`
 	VerifySsl            *bool       `json:"verify_ssl"`
 	CertificateAuthority *string     `json:"certificate_authority"`

--- a/routes.go
+++ b/routes.go
@@ -72,6 +72,7 @@ func setupRoutes(e *echo.Echo) {
 
 	// Endpoints
 	v3.GET("/endpoints", EndpointList, tenancyWithListMiddleware...)
+	v3.POST("/endpoints", EndpointCreate, enforceTenancy)
 	v3.GET("/endpoints/:id", EndpointGet, enforceTenancy)
 
 	// ApplicationAuthentications

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -26,7 +26,7 @@ var validAvailabilityStatuses = []string{"", model.Available, model.Unavailable}
 
 const (
 	defaultScheme    = "https"
-	defaultPort      = int64(443)
+	defaultPort      = 443
 	defaultVerifySsl = true
 	maxFqdnLength    = 255 // RFC2181
 	maxLabelLength   = 63  // RFC2181

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -12,7 +12,7 @@ import (
 func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 	receptorNode := "receptorNode"
 	scheme := "https"
-	port := int64(443)
+	port := 443
 	verifySsl := true
 	certificateAuthority := "letsEncrypt"
 	sourceId := strconv.FormatInt(testutils.TestSourceData[0].ID, 10)
@@ -316,10 +316,10 @@ func TestDefaultingPortWhenMissingOrLessThanZero(t *testing.T) {
 
 	ecr := setUpEndpointCreateRequest()
 
-	minusOne := int64(-1)
-	zero := int64(0)
+	minusOne := -1
+	zero := 0
 	testValues := []struct {
-		value *int64
+		value *int
 	}{
 		{nil},
 		{&minusOne},
@@ -346,7 +346,7 @@ func TestPortLargeValue(t *testing.T) {
 	}
 
 	ecr := setUpEndpointCreateRequest()
-	largePort := int64(999999)
+	largePort := 999999
 	ecr.Port = &largePort
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)


### PR DESCRIPTION
- Fixes an incorrect type definition: the `EndpointCreateRequest` had an `int64` for the port, but the `Endpoint` struct expects an `int`.
- Creates the `POST /endpoints` route with `enforceTenancy`.
- Creates a handler for the endpoint creations, and connects it with the validator and the DAO.

Related to [/sources-api-go/pull/43](https://github.com/RedHatInsights/sources-api-go/pull/43) - [[RHCLOUD-16766]](https://issues.redhat.com/browse/RHCLOUD-16766)