### PR TITLE
Availability Status Listener

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,3 +147,12 @@ func Get() *SourcesApiConfig {
 
 	return parsedConfig
 }
+
+func (sourceConfig *SourcesApiConfig) KafkaTopic(requestedTopic string) string {
+	topic, found := sourceConfig.KafkaTopics[requestedTopic]
+	if !found {
+		topic = requestedTopic
+	}
+
+	return topic
+}

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -93,12 +93,12 @@ func (a *ApplicationDaoImpl) BulkMessage(id *int64) (map[string]interface{}, err
 }
 
 func (a *ApplicationDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {
-	src, err := a.GetById(id)
-	if err == nil {
-		err = DB.Model(src).Updates(updateAttributes).Error
+	result := DB.Model(&m.Application{ID: *id}).Updates(updateAttributes)
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("application not found %v", id)
 	}
 
-	return err
+	return nil
 }
 
 func (a *ApplicationDaoImpl) FindWithTenant(id *int64) (*m.Application, error) {

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -89,7 +89,7 @@ func (a *ApplicationDaoImpl) BulkMessage(id *int64) (map[string]interface{}, err
 		return nil, resource.Error
 	}
 
-	return BulkMessageFrom(&application.Source)
+	return BulkMessageFromSource(&application.Source)
 }
 
 func (a *ApplicationDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -83,33 +83,13 @@ func (a *ApplicationDaoImpl) Tenant() *int64 {
 
 func (a *ApplicationDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error) {
 	application := &m.Application{ID: *id}
-	resource := DB.Preload("Source.Tenant").Preload("Source.Applications.Tenant").Preload("Source.Endpoints.Tenant").Find(&application)
+	resource := DB.Preload("Source").Find(&application)
 
 	if resource.Error != nil {
 		return nil, resource.Error
 	}
 
-	bulkMessage := map[string]interface{}{}
-	bulkMessage["source"] = application.Source.ToEvent()
-
-	endpoints := make([]m.EndpointEvent, len(application.Source.Endpoints))
-	for i, endpoint := range application.Source.Endpoints {
-		endpoints[i] = *endpoint.ToEvent()
-	}
-
-	bulkMessage["endpoints"] = endpoints
-
-	applications := make([]m.ApplicationEvent, len(application.Source.Applications))
-	for i, application := range application.Source.Applications {
-		applications[i] = *application.ToEvent()
-	}
-
-	bulkMessage["applications"] = applications
-
-	bulkMessage["authentications"] = []m.Authentication{}
-	bulkMessage["application_authentications"] = []m.ApplicationAuthenticationEvent{}
-
-	return bulkMessage, nil
+	return BulkMessageFrom(&application.Source)
 }
 
 func (a *ApplicationDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -114,7 +114,7 @@ func (a *ApplicationDaoImpl) BulkMessage(id *int64) (map[string]interface{}, err
 
 func (a *ApplicationDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {
 	src, err := a.GetById(id)
-	if err != nil {
+	if err == nil {
 		err = DB.Model(src).Updates(updateAttributes).Error
 	}
 

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/RedHatInsights/sources-api-go/middleware"
@@ -78,4 +79,58 @@ func (a *ApplicationDaoImpl) Delete(id *int64) error {
 
 func (a *ApplicationDaoImpl) Tenant() *int64 {
 	return a.TenantID
+}
+
+func (a *ApplicationDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error) {
+	application := &m.Application{ID: *id}
+	resource := DB.Preload("Source.Tenant").Preload("Source.Applications.Tenant").Preload("Source.Endpoints.Tenant").Find(&application)
+
+	if resource.Error != nil {
+		return nil, resource.Error
+	}
+
+	bulkMessage := map[string]interface{}{}
+	bulkMessage["source"] = application.Source.ToEvent()
+
+	endpoints := make([]m.EndpointEvent, len(application.Source.Endpoints))
+	for i, endpoint := range application.Source.Endpoints {
+		endpoints[i] = *endpoint.ToEvent()
+	}
+
+	bulkMessage["endpoints"] = endpoints
+
+	applications := make([]m.ApplicationEvent, len(application.Source.Applications))
+	for i, application := range application.Source.Applications {
+		applications[i] = *application.ToEvent()
+	}
+
+	bulkMessage["applications"] = applications
+
+	bulkMessage["authentications"] = []m.Authentication{}
+	bulkMessage["application_authentications"] = []m.ApplicationAuthenticationEvent{}
+
+	return bulkMessage, nil
+}
+
+func (a *ApplicationDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {
+	src, err := a.GetById(id)
+	if err != nil {
+		err = DB.Model(src).Updates(updateAttributes).Error
+	}
+
+	return err
+}
+
+func (a *ApplicationDaoImpl) FindWithTenant(id *int64) (*m.Application, error) {
+	app := &m.Application{ID: *id}
+	result := DB.Preload("Tenant").Find(&app)
+
+	return app, result.Error
+}
+
+func (a *ApplicationDaoImpl) ToEventJSON(id *int64) ([]byte, error) {
+	app, err := a.FindWithTenant(id)
+	data, _ := json.Marshal(app.ToEvent())
+
+	return data, err
 }

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -274,3 +274,31 @@ func authFromVault(secret *api.Secret) *m.Authentication {
 
 	return auth
 }
+
+func (a *AuthenticationDaoImpl) BulkMessage(_ *int64) (map[string]interface{}, error) {
+	bulkMessage := map[string]interface{}{}
+
+	bulkMessage["source"] = m.Source{}
+	bulkMessage["endpoints"] = []m.Endpoint{}
+	bulkMessage["endpoints"] = []m.Application{}
+	bulkMessage["authentications"] = []m.Authentication{}
+	bulkMessage["application_authentications"] = []m.ApplicationAuthenticationEvent{}
+
+	return bulkMessage, nil
+}
+
+func (a *AuthenticationDaoImpl) FetchAndUpdateBy(_ *int64, _ map[string]interface{}) error {
+	/*
+		TODO
+	*/
+	return nil
+}
+
+func (a *AuthenticationDaoImpl) ToEventJSON(_ *int64) ([]byte, error) {
+	/*
+		TODO: we need to obtain uid
+		app, err := a.GetById(uid)
+		data, _ := json.Marshal(app.ToEvent())
+	*/
+	return []byte{}, nil
+}

--- a/dao/common.go
+++ b/dao/common.go
@@ -25,7 +25,11 @@ func GetFrom(resourceType string) (*m.EventModelDao, error) {
 }
 
 func BulkMessageFrom(source *m.Source) (map[string]interface{}, error) {
-	result := DB.Preload("Tenant").Preload("Applications.Tenant").Preload("Endpoints.Tenant").Find(&source)
+	result := DB.
+		Preload("Tenant").
+		Preload("Applications.Tenant").
+		Preload("Endpoints.Tenant").
+		Find(&source)
 
 	if result.Error != nil {
 		return nil, result.Error

--- a/dao/common.go
+++ b/dao/common.go
@@ -1,0 +1,25 @@
+package dao
+
+import (
+	"fmt"
+
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
+
+func GetFrom(resourceType string) (*m.EventModelDao, error) {
+	var resource m.EventModelDao
+	switch resourceType {
+	case "Source":
+		resource = &SourceDaoImpl{}
+	case "Endpoint":
+		resource = &EndpointDaoImpl{}
+	case "Application":
+		resource = &ApplicationDaoImpl{}
+	case "Authentication":
+		resource = &AuthenticationDaoImpl{}
+	default:
+		return nil, fmt.Errorf("invalid resource_type (%s) to get DAO instance", resourceType)
+	}
+
+	return &resource, nil
+}

--- a/dao/common.go
+++ b/dao/common.go
@@ -6,7 +6,7 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 )
 
-func GetFrom(resourceType string) (*m.EventModelDao, error) {
+func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	var resource m.EventModelDao
 	switch resourceType {
 	case "Source":

--- a/dao/common.go
+++ b/dao/common.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"fmt"
+
 	m "github.com/RedHatInsights/sources-api-go/model"
 )
 

--- a/dao/common.go
+++ b/dao/common.go
@@ -24,7 +24,7 @@ func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	return &resource, nil
 }
 
-func BulkMessageFrom(source *m.Source) (map[string]interface{}, error) {
+func BulkMessageFromSource(source *m.Source) (map[string]interface{}, error) {
 	result := DB.
 		Preload("Tenant").
 		Preload("Applications.Tenant").

--- a/dao/common.go
+++ b/dao/common.go
@@ -2,7 +2,6 @@ package dao
 
 import (
 	"fmt"
-
 	m "github.com/RedHatInsights/sources-api-go/model"
 )
 
@@ -22,4 +21,34 @@ func GetFrom(resourceType string) (*m.EventModelDao, error) {
 	}
 
 	return &resource, nil
+}
+
+func BulkMessageFrom(source *m.Source) (map[string]interface{}, error) {
+	result := DB.Preload("Tenant").Preload("Applications.Tenant").Preload("Endpoints.Tenant").Find(&source)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	bulkMessage := map[string]interface{}{}
+	bulkMessage["source"] = source.ToEvent()
+
+	endpoints := make([]m.EndpointEvent, len(source.Endpoints))
+	for i, endpoint := range source.Endpoints {
+		endpoints[i] = *endpoint.ToEvent()
+	}
+
+	bulkMessage["endpoints"] = endpoints
+
+	applications := make([]m.ApplicationEvent, len(source.Applications))
+	for i, application := range source.Applications {
+		applications[i] = *application.ToEvent()
+	}
+
+	bulkMessage["applications"] = applications
+
+	bulkMessage["authentications"] = []m.Authentication{}
+	bulkMessage["application_authentications"] = []m.ApplicationAuthenticationEvent{}
+
+	return bulkMessage, nil
 }

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -120,12 +120,12 @@ func (a *EndpointDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error)
 }
 
 func (a *EndpointDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {
-	endpoint, err := a.GetById(id)
-	if err == nil {
-		err = DB.Model(endpoint).Updates(updateAttributes).Error
+	result := DB.Model(&m.Endpoint{ID: *id}).Updates(updateAttributes)
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("endpoint not found %v", id)
 	}
 
-	return err
+	return nil
 }
 
 func (a *EndpointDaoImpl) FindWithTenant(id *int64) (*m.Endpoint, error) {

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -116,7 +116,7 @@ func (a *EndpointDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error)
 		return nil, resource.Error
 	}
 
-	return BulkMessageFrom(&endpoint.Source)
+	return BulkMessageFromSource(&endpoint.Source)
 }
 
 func (a *EndpointDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -110,33 +110,13 @@ func (a *EndpointDaoImpl) SourceHasEndpoints(sourceId int64) bool {
 
 func (a *EndpointDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error) {
 	endpoint := &m.Endpoint{ID: *id}
-	resource := DB.Preload("Source.Tenant").Preload("Source.Applications.Tenant").Preload("Source.Endpoints.Tenant").Find(&endpoint)
+	resource := DB.Preload("Source").Find(&endpoint)
 
 	if resource.Error != nil {
 		return nil, resource.Error
 	}
 
-	bulkMessage := map[string]interface{}{}
-	bulkMessage["source"] = endpoint.Source.ToEvent()
-
-	endpoints := make([]m.EndpointEvent, len(endpoint.Source.Endpoints))
-	for i, endpoint := range endpoint.Source.Endpoints {
-		endpoints[i] = *endpoint.ToEvent()
-	}
-
-	bulkMessage["endpoints"] = endpoints
-
-	applications := make([]m.ApplicationEvent, len(endpoint.Source.Applications))
-	for i, application := range endpoint.Source.Applications {
-		applications[i] = *application.ToEvent()
-	}
-
-	bulkMessage["applications"] = applications
-
-	bulkMessage["authentications"] = []m.Authentication{}
-	bulkMessage["application_authentications"] = []m.ApplicationAuthenticationEvent{}
-
-	return bulkMessage, nil
+	return BulkMessageFrom(&endpoint.Source)
 }
 
 func (a *EndpointDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -101,36 +101,13 @@ func (s *SourceDaoImpl) NameExistsInCurrentTenant(name string) bool {
 }
 
 func (s *SourceDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error) {
-	src := &m.Source{ID: *id}
-
-	resource := DB.Preload("Tenant").Preload("Applications.Tenant").Preload("Endpoints.Tenant").Find(&src)
-	if resource.Error != nil {
-		return nil, resource.Error
+	src := m.Source{ID: *id}
+	result := DB.Find(&src)
+	if result.Error != nil {
+		return nil, result.Error
 	}
 
-	bulkMessage := map[string]interface{}{}
-
-	bulkMessage["source"] = *src.ToEvent()
-
-	applications := make([]m.ApplicationEvent, len(src.Applications))
-	applicationsIDs := make([]int64, len(src.Applications))
-	for i, application := range src.Applications {
-		applications[i] = *application.ToEvent()
-		applicationsIDs[i] = application.ID
-	}
-
-	bulkMessage["applications"] = applications
-
-	endpoints := make([]m.EndpointEvent, len(src.Endpoints))
-	for i, endpoint := range src.Endpoints {
-		endpoints[i] = *endpoint.ToEvent()
-	}
-
-	bulkMessage["endpoints"] = endpoints
-	bulkMessage["authentications"] = []m.Authentication{}
-	bulkMessage["application_authentications"] = []m.ApplicationAuthentication{}
-
-	return bulkMessage, nil
+	return BulkMessageFrom(&src)
 }
 
 func (s *SourceDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -128,17 +128,7 @@ func (s *SourceDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error) {
 
 	bulkMessage["endpoints"] = endpoints
 	bulkMessage["authentications"] = []m.Authentication{}
-
-	var appAuths []m.ApplicationAuthentication
-
-	DB.Model(&m.ApplicationAuthentication{}).Preload("Tenant").Where("application_id IN ?", applicationsIDs).Find(&appAuths)
-
-	applicationAuthentications := make([]m.ApplicationAuthenticationEvent, len(appAuths))
-	for i, applicationAuthentication := range appAuths {
-		applicationAuthentications[i] = *applicationAuthentication.ToEvent()
-	}
-
-	bulkMessage["application_authentications"] = applicationAuthentications
+	bulkMessage["application_authentications"] = []m.ApplicationAuthentication{}
 
 	return bulkMessage, nil
 }

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -145,7 +145,7 @@ func (s *SourceDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error) {
 
 func (s *SourceDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {
 	src, err := s.GetById(id)
-	if err != nil {
+	if err == nil {
 		err = DB.Model(src).Updates(updateAttributes).Error
 	}
 

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -111,12 +111,12 @@ func (s *SourceDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error) {
 }
 
 func (s *SourceDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {
-	src, err := s.GetById(id)
-	if err == nil {
-		err = DB.Model(src).Updates(updateAttributes).Error
+	result := DB.Model(&m.Source{ID: *id}).Updates(updateAttributes)
+	if result.RowsAffected == 0 {
+		return fmt.Errorf("source not found %v", id)
 	}
 
-	return err
+	return nil
 }
 
 func (s *SourceDaoImpl) FindWithTenant(id *int64) (*m.Source, error) {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -107,7 +107,7 @@ func (s *SourceDaoImpl) BulkMessage(id *int64) (map[string]interface{}, error) {
 		return nil, result.Error
 	}
 
-	return BulkMessageFrom(&src)
+	return BulkMessageFromSource(&src)
 }
 
 func (s *SourceDaoImpl) FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error {

--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -25,7 +25,7 @@ type EventStreamSender struct {
 }
 
 func (esp *EventStreamSender) RaiseEvent(eventType string, payload []byte, headers []kafka.Header) error {
-	logging.Log.Debugf("\"publishing message to topic \"platform.sources.event-stream\"...")
+	logging.Log.Debugf("publishing message to topic %q...", EventStreamTopic)
 
 	producerConfig := kafka.ProducerConfig{Topic: config.KafkaTopic(EventStreamTopic)}
 	kafkaConfig := kafka.Config{KafkaBrokers: config.KafkaBrokers, ProducerConfig: producerConfig}
@@ -41,7 +41,7 @@ func (esp *EventStreamSender) RaiseEvent(eventType string, payload []byte, heade
 		return err
 	}
 
-	logging.Log.Debugf("\"publishing message to topic \"platform.sources.event-stream\"...Complete")
+	logging.Log.Debugf("publishing message to topic %q...Complete", EventStreamTopic)
 
 	return nil
 }

--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -32,7 +32,15 @@ func (esp *EventStreamSender) RaiseEvent(eventType string, payload []byte, heade
 	kf := &kafka.Manager{Config: kafkaConfig}
 
 	m := &kafka.Message{}
-	headers = append(headers, kafka.Header{Key: "event_type", Value: []byte(eventType)})
+
+	for index, header := range headers {
+		if header.Key == "event_type" {
+			headers[index] = kafka.Header{Key: "event_type", Value: []byte(eventType)}
+			break
+		}
+	}
+	headers = append(headers, kafka.Header{Key: "encoding", Value: []byte("json")})
+
 	m.AddHeaders(headers)
 	m.AddValue(payload)
 

--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -69,9 +69,9 @@ func (esp *EventStreamProducer) RaiseEventForUpdate(resourceID int64, resourceTy
 		return err
 	}
 
-	resourceJSON, errEvent := (*eventModelDao).ToEventJSON(&resourceID)
-	if errEvent != nil {
-		return errEvent
+	resourceJSON, err := (*eventModelDao).ToEventJSON(&resourceID)
+	if err != nil {
+		return err
 	}
 
 	err = esp.RaiseEventIf(allowed, resourceType+".update", resourceJSON, headers)
@@ -79,9 +79,9 @@ func (esp *EventStreamProducer) RaiseEventForUpdate(resourceID int64, resourceTy
 		return err
 	}
 
-	message, errMessage := m.UpdateMessage(eventModelDao, resourceID, resourceType, updateAttributes)
-	if errMessage != nil {
-		return errMessage
+	message, err := m.UpdateMessage(eventModelDao, resourceID, resourceType, updateAttributes)
+	if err != nil {
+		return err
 	}
 
 	err = esp.RaiseEventIf(allowed, "Records.update", message, headers)

--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -64,7 +64,7 @@ func (esp *EventStreamProducer) RaiseEventIf(allowed bool, eventType string, pay
 
 func (esp *EventStreamProducer) RaiseEventForUpdate(resourceID int64, resourceType string, updateAttributes []string, headers []kafka.Header) error {
 	allowed := esp.RaiseEventAllowed(resourceType, updateAttributes)
-	eventModelDao, err := dao.GetFrom(resourceType)
+	eventModelDao, err := dao.GetFromResourceType(resourceType)
 	if err != nil {
 		return err
 	}

--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -1,0 +1,82 @@
+package events
+
+import (
+	c "github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+const EventStreamTopic = "platform.sources.event-stream"
+
+var config = c.Get()
+
+func raiseEvent(eventType string, payload []byte, headers []kafka.Header) error {
+	logging.Log.Debugf("\"publishing message to topic \"platform.sources.event-stream\"...")
+
+	producerConfig := kafka.ProducerConfig{Topic: config.KafkaTopic(EventStreamTopic)}
+	kafkaConfig := kafka.Config{KafkaBrokers: config.KafkaBrokers, ProducerConfig: producerConfig}
+	kf := &kafka.Manager{Config: kafkaConfig}
+
+	m := &kafka.Message{}
+	headers = append(headers, kafka.Header{Key: "event_type", Value: []byte(eventType)})
+	m.AddHeaders(headers)
+	m.AddValue(payload)
+
+	err := kf.Produce(m)
+	if err != nil {
+		return err
+	}
+
+	logging.Log.Debugf("\"publishing message to topic \"platform.sources.event-stream\"...Complete")
+
+	return nil
+}
+
+func raiseEventIf(allowed bool, eventType string, payload []byte, headers []kafka.Header) error {
+	if allowed {
+		return raiseEvent(eventType, payload, headers)
+	}
+
+	return nil
+}
+
+func RaiseEventForUpdate(resourceID int64, resourceType string, updateAttributes []string, headers []kafka.Header) error {
+	allowed := RaiseEventAllowed(resourceType, updateAttributes)
+	eventModelDao, err := dao.GetFrom(resourceType)
+	if err != nil {
+		return err
+	}
+
+	resourceJSON, errEvent := (*eventModelDao).ToEventJSON(&resourceID)
+	if errEvent != nil {
+		return errEvent
+	}
+
+	err = raiseEventIf(allowed, resourceType+".update", resourceJSON, headers)
+	if err != nil {
+		return err
+	}
+
+	message, errMessage := m.UpdateMessage(eventModelDao, resourceID, resourceType, updateAttributes)
+	if errMessage != nil {
+		return errMessage
+	}
+
+	err = raiseEventIf(allowed, "Records.update", message, headers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func RaiseEventAllowed(resourceType string, attributes []string) bool {
+	if resourceType != "Application" {
+		return true
+	}
+
+	return !util.SliceContainsString(attributes, "_superkey")
+}

--- a/internal/testutils/database/database.go
+++ b/internal/testutils/database/database.go
@@ -77,7 +77,11 @@ func CreateTestDB() {
 
 // DropSchema drops the database schema entirely.
 func DropSchema(dbSchema string) {
-	dao.DB.Exec(fmt.Sprintf("DROP SCHEMA %s CASCADE", dbSchema))
+	result := dao.DB.Exec(fmt.Sprintf("DROP SCHEMA %s CASCADE", dbSchema))
+	if result.Error != nil {
+		log.Fatalf("Error in drop schema %s %s: ", dbSchema, result.Error.Error())
+	}
+
 }
 
 // MigrateSchema migrates all the models.

--- a/internal/testutils/fixtures.go
+++ b/internal/testutils/fixtures.go
@@ -20,6 +20,7 @@ var (
 	host2               = "tower.example.com"
 	path2               = "/"
 )
+
 var TestTenantData = []m.Tenant{
 	{Id: 1, ExternalTenant: "12345"},
 }

--- a/internal/testutils/fixtures.go
+++ b/internal/testutils/fixtures.go
@@ -1,0 +1,56 @@
+package testutils
+
+import (
+	"time"
+
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"gorm.io/datatypes"
+)
+
+var (
+	CreatedAt, _        = time.Parse("2006-01-02T15:04:05.999Z", "2021-11-26 18:47:19 CET")
+	UpdatedAt           = CreatedAt
+	port                = 80
+	defaultValueSource1 = true
+	defaultValueSource2 = false
+	scheme1             = "http"
+	host1               = "openshift.example.com"
+	path1               = "/"
+	scheme2             = "https"
+	host2               = "tower.example.com"
+	path2               = "/"
+)
+var TestTenantData = []m.Tenant{
+	{Id: 1, ExternalTenant: "12345"},
+}
+
+var TestSourceTypeData = []m.SourceType{
+	{Id: 1, Name: "amazon"},
+}
+
+var TestApplicationTypeData = []m.ApplicationType{
+	{Id: 1, DisplayName: "test app type"},
+}
+
+var uid1 = "5eebe172-7baa-4280-823f-19e597d091e9"
+var uid2 = "31b5338b-685d-4056-ba39-d00b4d7f19cc"
+
+var TestSourceData = []m.Source{
+	{ID: 1, Name: "Source1", SourceTypeID: 1, TenantID: 1, Uid: &uid1, CreatedAt: CreatedAt, UpdatedAt: UpdatedAt},
+	{ID: 2, Name: "Source2", SourceTypeID: 1, TenantID: 1, Uid: &uid2, CreatedAt: CreatedAt, UpdatedAt: UpdatedAt},
+}
+
+var TestApplicationData = []m.Application{
+	{ID: 1, Extra: datatypes.JSON("{\"extra\": true}"), ApplicationTypeID: 1, SourceID: 1, TenantID: 1, CreatedAt: CreatedAt, UpdatedAt: UpdatedAt},
+	{ID: 2, Extra: datatypes.JSON("{\"extra\": false}"), ApplicationTypeID: 1, SourceID: 1, TenantID: 1, CreatedAt: CreatedAt, UpdatedAt: UpdatedAt},
+}
+
+var TestEndpointData = []m.Endpoint{
+	{ID: 1, SourceID: 1, TenantID: 1, Port: &port, Default: &defaultValueSource1, Scheme: &scheme1, Host: &host1, Path: &path1, CreatedAt: CreatedAt, UpdatedAt: UpdatedAt},
+	{ID: 2, SourceID: 1, TenantID: 1, Port: &port, Default: &defaultValueSource2, Scheme: &scheme2, Host: &host2, Path: &path2, CreatedAt: CreatedAt, UpdatedAt: UpdatedAt},
+}
+
+var TestMetaDataData = []m.MetaData{
+	{ID: 1, ApplicationTypeID: 1, Type: "AppMetaData"},
+	{ID: 2, ApplicationTypeID: 1, Type: "AppMetaData"},
+}

--- a/internal/testutils/fixtures/source.go
+++ b/internal/testutils/fixtures/source.go
@@ -1,6 +1,13 @@
 package fixtures
 
-import m "github.com/RedHatInsights/sources-api-go/model"
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
+
+var (
+	uid1 = "5eebe172-7baa-4280-823f-19e597d091e9"
+	uid2 = "31b5338b-685d-4056-ba39-d00b4d7f19cc"
+)
 
 var TestSourceData = []m.Source{
 	{
@@ -8,11 +15,13 @@ var TestSourceData = []m.Source{
 		Name:         "Source1",
 		SourceTypeID: 1,
 		TenantID:     1,
+		Uid:          &uid1,
 	},
 	{
 		ID:           2,
 		Name:         "Source2",
 		SourceTypeID: 1,
 		TenantID:     1,
+		Uid:          &uid2,
 	},
 }

--- a/internal/testutils/fixtures/tenant.go
+++ b/internal/testutils/fixtures/tenant.go
@@ -4,6 +4,7 @@ import m "github.com/RedHatInsights/sources-api-go/model"
 
 var TestTenantData = []m.Tenant{
 	{
-		Id: 1,
+		Id:             1,
+		ExternalTenant: "12345",
 	},
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/marketplace"
 	"github.com/RedHatInsights/sources-api-go/redis"
+	"github.com/RedHatInsights/sources-api-go/statuslistener"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
@@ -13,13 +16,24 @@ import (
 var conf = config.Get()
 
 func main() {
-	e := echo.New()
-
 	logging.InitLogger(conf)
-	logging.InitEchoLogger(e, conf)
 
 	dao.Init()
 	redis.Init()
+
+	availabilityListener := flag.Bool("listener", false, "run unit or integration tests")
+	flag.Parse()
+
+	if *availabilityListener {
+		statuslistener.Run()
+	} else {
+		runServer()
+	}
+}
+
+func runServer() {
+	e := echo.New()
+	logging.InitEchoLogger(e, conf)
 
 	e.Use(middleware.Recover())
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 	dao.Init()
 	redis.Init()
 
-	availabilityListener := flag.Bool("listener", false, "run unit or integration tests")
+	availabilityListener := flag.Bool("listener", false, "run availability status listener")
 	flag.Parse()
 
 	if *availabilityListener {

--- a/model/application.go
+++ b/model/application.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/RedHatInsights/sources-api-go/util"
 	"gorm.io/datatypes"
 )
 
@@ -27,6 +28,27 @@ type Application struct {
 
 	ApplicationTypeID int64 `json:"application_type_id"`
 	ApplicationType   ApplicationType
+}
+
+func (app *Application) ToEvent() *ApplicationEvent {
+	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(app.AvailabilityStatus.AvailabilityStatus),
+		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(app.LastAvailableAt, "2006-01-02 15:04:05 MST")),
+		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(app.LastCheckedAt, "2006-01-02 15:04:05 MST"))}
+
+	appEvent := &ApplicationEvent{
+		AvailabilityStatusEvent: asEvent,
+		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(app.PausedAt, "2006-01-02 15:04:05 MST"))},
+		Extra:                   app.Extra,
+		ID:                      app.ID,
+		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(app.CreatedAt, "2006-01-02 15:04:05 MST")),
+		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(app.UpdatedAt, "2006-01-02 15:04:05 MST")),
+		ApplicationTypeID:       app.ApplicationTypeID,
+		AvailabilityStatusError: util.StringValueOrNil(app.AvailabilityStatusError),
+		SourceID:                app.SourceID,
+		Tenant:                  &app.Tenant.ExternalTenant,
+	}
+
+	return appEvent
 }
 
 func (app *Application) ToResponse() *ApplicationResponse {

--- a/model/application.go
+++ b/model/application.go
@@ -32,16 +32,16 @@ type Application struct {
 
 func (app *Application) ToEvent() *ApplicationEvent {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(app.AvailabilityStatus.AvailabilityStatus),
-		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(app.LastAvailableAt, util.RecordDateTimeFormat)),
-		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(app.LastCheckedAt, util.RecordDateTimeFormat))}
+		LastAvailableAt: util.DateTimeToRecordFormat(app.LastAvailableAt),
+		LastCheckedAt:   util.DateTimeToRecordFormat(app.LastCheckedAt)}
 
 	appEvent := &ApplicationEvent{
 		AvailabilityStatusEvent: asEvent,
-		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(app.PausedAt, util.RecordDateTimeFormat))},
+		PauseEvent:              PauseEvent{PausedAt: util.DateTimeToRecordFormat(app.PausedAt)},
 		Extra:                   app.Extra,
 		ID:                      app.ID,
-		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(app.CreatedAt, util.RecordDateTimeFormat)),
-		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(app.UpdatedAt, util.RecordDateTimeFormat)),
+		CreatedAt:               util.DateTimeToRecordFormat(app.CreatedAt),
+		UpdatedAt:               util.DateTimeToRecordFormat(app.UpdatedAt),
 		ApplicationTypeID:       app.ApplicationTypeID,
 		AvailabilityStatusError: util.StringValueOrNil(app.AvailabilityStatusError),
 		SourceID:                app.SourceID,

--- a/model/application.go
+++ b/model/application.go
@@ -32,16 +32,16 @@ type Application struct {
 
 func (app *Application) ToEvent() *ApplicationEvent {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(app.AvailabilityStatus.AvailabilityStatus),
-		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(app.LastAvailableAt, "2006-01-02 15:04:05 MST")),
-		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(app.LastCheckedAt, "2006-01-02 15:04:05 MST"))}
+		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(app.LastAvailableAt, util.RecordDateTimeFormat)),
+		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(app.LastCheckedAt, util.RecordDateTimeFormat))}
 
 	appEvent := &ApplicationEvent{
 		AvailabilityStatusEvent: asEvent,
-		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(app.PausedAt, "2006-01-02 15:04:05 MST"))},
+		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(app.PausedAt, util.RecordDateTimeFormat))},
 		Extra:                   app.Extra,
 		ID:                      app.ID,
-		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(app.CreatedAt, "2006-01-02 15:04:05 MST")),
-		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(app.UpdatedAt, "2006-01-02 15:04:05 MST")),
+		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(app.CreatedAt, util.RecordDateTimeFormat)),
+		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(app.UpdatedAt, util.RecordDateTimeFormat)),
 		ApplicationTypeID:       app.ApplicationTypeID,
 		AvailabilityStatusError: util.StringValueOrNil(app.AvailabilityStatusError),
 		SourceID:                app.SourceID,

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -27,9 +27,9 @@ type ApplicationAuthentication struct {
 func (aa *ApplicationAuthentication) ToEvent() *ApplicationAuthenticationEvent {
 	aaEvent := &ApplicationAuthenticationEvent{
 		ID:               aa.ID,
-		PauseEvent:       PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(aa.PausedAt, "2006-01-02 15:04:05 MST"))},
-		CreatedAt:        util.StringValueOrNil(util.FormatTimeToString(aa.CreatedAt, "2006-01-02 15:04:05 MST")),
-		UpdatedAt:        util.StringValueOrNil(util.FormatTimeToString(aa.UpdatedAt, "2006-01-02 15:04:05 MST")),
+		PauseEvent:       PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(aa.PausedAt, util.RecordDateTimeFormat))},
+		CreatedAt:        util.StringValueOrNil(util.FormatTimeToString(aa.CreatedAt, util.RecordDateTimeFormat)),
+		UpdatedAt:        util.StringValueOrNil(util.FormatTimeToString(aa.UpdatedAt, util.RecordDateTimeFormat)),
 		ApplicationID:    aa.ApplicationID,
 		AuthenticationID: aa.AuthenticationID,
 		Tenant:           &aa.Tenant.ExternalTenant,

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -27,9 +27,9 @@ type ApplicationAuthentication struct {
 func (aa *ApplicationAuthentication) ToEvent() *ApplicationAuthenticationEvent {
 	aaEvent := &ApplicationAuthenticationEvent{
 		ID:               aa.ID,
-		PauseEvent:       PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(aa.PausedAt, util.RecordDateTimeFormat))},
-		CreatedAt:        util.StringValueOrNil(util.FormatTimeToString(aa.CreatedAt, util.RecordDateTimeFormat)),
-		UpdatedAt:        util.StringValueOrNil(util.FormatTimeToString(aa.UpdatedAt, util.RecordDateTimeFormat)),
+		PauseEvent:       PauseEvent{PausedAt: util.DateTimeToRecordFormat(aa.PausedAt)},
+		CreatedAt:        util.DateTimeToRecordFormat(aa.CreatedAt),
+		UpdatedAt:        util.DateTimeToRecordFormat(aa.UpdatedAt),
 		ApplicationID:    aa.ApplicationID,
 		AuthenticationID: aa.AuthenticationID,
 		Tenant:           &aa.Tenant.ExternalTenant,

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -3,9 +3,13 @@ package model
 import (
 	"strconv"
 	"time"
+
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type ApplicationAuthentication struct {
+	Pause
+
 	ID        int64     `gorm:"primarykey" json:"id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
@@ -13,10 +17,25 @@ type ApplicationAuthentication struct {
 	TenantID int64
 	Tenant   Tenant
 
-	ApplicationID    int64 `json:"application_id"`
-	Application      Application
+	ApplicationID int64 `json:"application_id"`
+	Application   Application
+	// TODO: fix correctly PR#40
 	AuthenticationID int64 `json:"authentication_id"`
-	Authentication   Authentication
+	//Authentication   Authentication
+}
+
+func (aa *ApplicationAuthentication) ToEvent() *ApplicationAuthenticationEvent {
+	aaEvent := &ApplicationAuthenticationEvent{
+		ID:               aa.ID,
+		PauseEvent:       PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(aa.PausedAt, "2006-01-02 15:04:05 MST"))},
+		CreatedAt:        util.StringValueOrNil(util.FormatTimeToString(aa.CreatedAt, "2006-01-02 15:04:05 MST")),
+		UpdatedAt:        util.StringValueOrNil(util.FormatTimeToString(aa.UpdatedAt, "2006-01-02 15:04:05 MST")),
+		ApplicationID:    aa.ApplicationID,
+		AuthenticationID: aa.AuthenticationID,
+		Tenant:           &aa.Tenant.ExternalTenant,
+	}
+
+	return aaEvent
 }
 
 func (aa *ApplicationAuthentication) ToResponse() *ApplicationAuthenticationResponse {

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -29,6 +29,17 @@ type Authentication struct {
 	ApplicationAuthentications []ApplicationAuthentication
 }
 
+func (auth *Authentication) BulkMessage() map[string]interface{} {
+	bulkMessage := map[string]interface{}{}
+	bulkMessage["applications"] = auth.Source.Applications
+	bulkMessage["authentications"] = nil
+	bulkMessage["application_authentications"] = nil
+	bulkMessage["endpoints"] = auth.Source.Endpoints
+	bulkMessage["source"] = auth.Source
+
+	return bulkMessage
+}
+
 func (auth *Authentication) ToResponse() *AuthenticationResponse {
 	resourceID := strconv.FormatInt(auth.ResourceID, 10)
 	return &AuthenticationResponse{

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -35,12 +35,12 @@ type Endpoint struct {
 
 func (endpoint *Endpoint) ToEvent() *EndpointEvent {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(endpoint.AvailabilityStatus.AvailabilityStatus),
-		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(endpoint.LastAvailableAt, "2006-01-02 15:04:05 MST")),
-		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(endpoint.LastCheckedAt, "2006-01-02 15:04:05 MST"))}
+		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(endpoint.LastAvailableAt, util.RecordDateTimeFormat)),
+		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(endpoint.LastCheckedAt, util.RecordDateTimeFormat))}
 
 	endpointEvent := &EndpointEvent{
 		AvailabilityStatusEvent: asEvent,
-		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(endpoint.PausedAt, "2006-01-02 15:04:05 MST"))},
+		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(endpoint.PausedAt, util.RecordDateTimeFormat))},
 		ID:                      endpoint.ID,
 		CertificateAuthority:    endpoint.CertificateAuthority,
 		Host:                    endpoint.Host,
@@ -52,8 +52,8 @@ func (endpoint *Endpoint) ToEvent() *EndpointEvent {
 		VerifySsl:               endpoint.VerifySsl,
 		Default:                 endpoint.Default,
 		Path:                    endpoint.Path,
-		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(endpoint.CreatedAt, "2006-01-02 15:04:05 MST")),
-		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(endpoint.UpdatedAt, "2006-01-02 15:04:05 MST")),
+		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(endpoint.CreatedAt, util.RecordDateTimeFormat)),
+		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(endpoint.UpdatedAt, util.RecordDateTimeFormat)),
 		AvailabilityStatusError: util.StringValueOrNil(endpoint.AvailabilityStatusError),
 		Tenant:                  &endpoint.Tenant.ExternalTenant,
 	}

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -3,6 +3,8 @@ package model
 import (
 	"strconv"
 	"time"
+
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type Endpoint struct {
@@ -29,6 +31,34 @@ type Endpoint struct {
 
 	TenantID int64
 	Tenant   Tenant
+}
+
+func (endpoint *Endpoint) ToEvent() *EndpointEvent {
+	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(endpoint.AvailabilityStatus.AvailabilityStatus),
+		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(endpoint.LastAvailableAt, "2006-01-02 15:04:05 MST")),
+		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(endpoint.LastCheckedAt, "2006-01-02 15:04:05 MST"))}
+
+	endpointEvent := &EndpointEvent{
+		AvailabilityStatusEvent: asEvent,
+		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(endpoint.PausedAt, "2006-01-02 15:04:05 MST"))},
+		ID:                      endpoint.ID,
+		CertificateAuthority:    endpoint.CertificateAuthority,
+		Host:                    endpoint.Host,
+		Port:                    endpoint.Port,
+		ReceptorNode:            endpoint.ReceptorNode,
+		Role:                    endpoint.Role,
+		Scheme:                  endpoint.Scheme,
+		SourceID:                endpoint.SourceID,
+		VerifySsl:               endpoint.VerifySsl,
+		Default:                 endpoint.Default,
+		Path:                    endpoint.Path,
+		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(endpoint.CreatedAt, "2006-01-02 15:04:05 MST")),
+		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(endpoint.UpdatedAt, "2006-01-02 15:04:05 MST")),
+		AvailabilityStatusError: util.StringValueOrNil(endpoint.AvailabilityStatusError),
+		Tenant:                  &endpoint.Tenant.ExternalTenant,
+	}
+
+	return endpointEvent
 }
 
 func (endpoint *Endpoint) ToResponse() *EndpointResponse {

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -35,12 +35,12 @@ type Endpoint struct {
 
 func (endpoint *Endpoint) ToEvent() *EndpointEvent {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(endpoint.AvailabilityStatus.AvailabilityStatus),
-		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(endpoint.LastAvailableAt, util.RecordDateTimeFormat)),
-		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(endpoint.LastCheckedAt, util.RecordDateTimeFormat))}
+		LastAvailableAt: util.DateTimeToRecordFormat(endpoint.LastAvailableAt),
+		LastCheckedAt:   util.DateTimeToRecordFormat(endpoint.LastCheckedAt)}
 
 	endpointEvent := &EndpointEvent{
 		AvailabilityStatusEvent: asEvent,
-		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(endpoint.PausedAt, util.RecordDateTimeFormat))},
+		PauseEvent:              PauseEvent{PausedAt: util.DateTimeToRecordFormat(endpoint.PausedAt)},
 		ID:                      endpoint.ID,
 		CertificateAuthority:    endpoint.CertificateAuthority,
 		Host:                    endpoint.Host,
@@ -52,8 +52,8 @@ func (endpoint *Endpoint) ToEvent() *EndpointEvent {
 		VerifySsl:               endpoint.VerifySsl,
 		Default:                 endpoint.Default,
 		Path:                    endpoint.Path,
-		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(endpoint.CreatedAt, util.RecordDateTimeFormat)),
-		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(endpoint.UpdatedAt, util.RecordDateTimeFormat)),
+		CreatedAt:               util.DateTimeToRecordFormat(endpoint.CreatedAt),
+		UpdatedAt:               util.DateTimeToRecordFormat(endpoint.UpdatedAt),
 		AvailabilityStatusError: util.StringValueOrNil(endpoint.AvailabilityStatusError),
 		Tenant:                  &endpoint.Tenant.ExternalTenant,
 	}

--- a/model/event_models.go
+++ b/model/event_models.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"time"
+
+	"gorm.io/datatypes"
+)
+
+type PauseEvent struct {
+	PausedAt *string `json:"paused_at"`
+}
+
+type AvailabilityStatusEvent struct {
+	AvailabilityStatus *string `json:"availability_status"`
+	LastCheckedAt      *string `json:"last_checked_at"`
+	LastAvailableAt    *string `json:"last_available_at"`
+}
+
+type ApplicationEvent struct {
+	AvailabilityStatusEvent
+	PauseEvent
+
+	ID        int64   `json:"id"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+
+	AvailabilityStatusError *string        `json:"availability_status_error"`
+	Extra                   datatypes.JSON `json:"extra"`
+	SuperkeyData            datatypes.JSON `json:"superkey_data"`
+
+	SourceID          int64   `json:"source_id"`
+	ApplicationTypeID int64   `json:"application_type_id"`
+	Tenant            *string `json:"tenant"`
+}
+
+type AuthenticationEvent struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+
+	Name                    string                 `json:"name"`
+	AuthType                string                 `json:"authtype"`
+	Username                string                 `json:"username"`
+	Password                string                 `json:"password"`
+	Extra                   map[string]interface{} `json:"extra"`
+	Version                 string                 `json:"version"`
+	AvailabilityStatus      string                 `json:"availability_status"`
+	AvailabilityStatusError string                 `json:"availability_status_error"`
+
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id"`
+}
+
+type ApplicationAuthenticationEvent struct {
+	PauseEvent
+
+	ID        int64   `json:"id"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+
+	ApplicationID    int64 `json:"application_id"`
+	AuthenticationID int64 `json:"authentication_id"`
+
+	Tenant *string `json:"tenant"`
+}
+
+type EndpointEvent struct {
+	AvailabilityStatusEvent
+	PauseEvent
+
+	ID        int64   `json:"id"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
+
+	Role                    *string `json:"role"`
+	Port                    *int    `json:"port"`
+	Default                 *bool   `json:"default"`
+	Scheme                  *string `json:"scheme"`
+	Host                    *string `json:"host"`
+	Path                    *string `json:"path"`
+	VerifySsl               *bool   `json:"verify_ssl"`
+	CertificateAuthority    *string `json:"certificate_authority"`
+	ReceptorNode            *string `json:"receptor_node"`
+	AvailabilityStatusError *string `json:"availability_status_error"`
+
+	SourceID int64   `json:"source_id"`
+	Tenant   *string `json:"tenant"`
+}
+
+type SourceEvent struct {
+	AvailabilityStatusEvent
+	PauseEvent
+
+	ID                  *int64  `json:"id"`
+	CreatedAt           *string `json:"created_at"`
+	UpdatedAt           *string `json:"updated_at"`
+	Name                *string `json:"name"`
+	UID                 *string `json:"uid"`
+	Version             *string `json:"version"`
+	Imported            *string `json:"imported"`
+	SourceRef           *string `json:"source_ref"`
+	AppCreationWorkflow *string `json:"app_creation_workflow"`
+	SourceTypeID        *int64  `json:"source_type_id"`
+	Tenant              *string `json:"tenant"`
+}

--- a/model/event_models.go
+++ b/model/event_models.go
@@ -40,14 +40,12 @@ type AuthenticationEvent struct {
 	Name                    string                 `json:"name"`
 	AuthType                string                 `json:"authtype"`
 	Username                string                 `json:"username"`
-	Password                string                 `json:"password"`
 	Extra                   map[string]interface{} `json:"extra"`
 	Version                 string                 `json:"version"`
 	AvailabilityStatus      string                 `json:"availability_status"`
 	AvailabilityStatusError string                 `json:"availability_status_error"`
-
-	ResourceType string `json:"resource_type"`
-	ResourceID   string `json:"resource_id"`
+	ResourceType            string                 `json:"resource_type"`
+	ResourceID              string                 `json:"resource_id"`
 }
 
 type ApplicationAuthenticationEvent struct {

--- a/model/events.go
+++ b/model/events.go
@@ -16,9 +16,9 @@ func UpdateMessage(eventObject *EventModelDao, resourceID int64, resourceType st
 	updatedAttributes := map[string]interface{}{}
 	updatedAttributes["updated"] = map[string]interface{}{resourceType: map[string]interface{}{strconv.Itoa(int(resourceID)): attributes}}
 
-	bulkMessage, errorBulkMessage := (*eventObject).BulkMessage(&resourceID)
-	if errorBulkMessage != nil {
-		return nil, fmt.Errorf("error in BulkMessage: %s", errorBulkMessage.Error())
+	bulkMessage, err := (*eventObject).BulkMessage(&resourceID)
+	if err != nil {
+		return nil, fmt.Errorf("error in BulkMessage: %s", err.Error())
 	}
 	for k, m := range bulkMessage {
 		updatedAttributes[k] = m

--- a/model/events.go
+++ b/model/events.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type EventModelDao interface {
+	BulkMessage(id *int64) (map[string]interface{}, error)
+	FetchAndUpdateBy(id *int64, updateAttributes map[string]interface{}) error
+	ToEventJSON(id *int64) ([]byte, error)
+}
+
+func UpdateMessage(eventObject *EventModelDao, resourceID int64, resourceType string, attributes []string) ([]byte, error) {
+	updatedAttributes := map[string]interface{}{}
+	updatedAttributes["updated"] = map[string]interface{}{resourceType: map[string]interface{}{strconv.Itoa(int(resourceID)): attributes}}
+
+	bulkMessage, errorBulkMessage := (*eventObject).BulkMessage(&resourceID)
+	if errorBulkMessage != nil {
+		return nil, fmt.Errorf("error in BulkMessage: %s", errorBulkMessage.Error())
+	}
+	for k, m := range bulkMessage {
+		updatedAttributes[k] = m
+	}
+
+	data, err := json.Marshal(updatedAttributes)
+	if err != nil {
+		return nil, fmt.Errorf("error in parsing update attributes: %s", err.Error())
+	}
+
+	return data, nil
+}

--- a/model/source.go
+++ b/model/source.go
@@ -3,6 +3,8 @@ package model
 import (
 	"strconv"
 	"time"
+
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 // App creation workflow's constants
@@ -39,6 +41,34 @@ type Source struct {
 	ApplicationTypes []*ApplicationType `gorm:"many2many:applications"`
 	Applications     []Application
 	Endpoints        []Endpoint
+}
+
+func (src *Source) AsJSON() []byte {
+	return []byte{}
+}
+
+func (src *Source) ToEvent() *SourceEvent {
+	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(src.AvailabilityStatus.AvailabilityStatus),
+		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(src.LastAvailableAt, "2006-01-02 15:04:05 MST")),
+		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(src.LastCheckedAt, "2006-01-02 15:04:05 MST"))}
+
+	sourceEvent := &SourceEvent{
+		AvailabilityStatusEvent: asEvent,
+		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(src.PausedAt, "2006-01-02 15:04:05 MST"))},
+		ID:                      &src.ID,
+		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(src.CreatedAt, "2006-01-02 15:04:05 MST")),
+		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(src.UpdatedAt, "2006-01-02 15:04:05 MST")),
+		Name:                    &src.Name,
+		UID:                     src.Uid,
+		Version:                 src.Version,
+		Imported:                src.Imported,
+		SourceRef:               src.SourceRef,
+		AppCreationWorkflow:     &src.AppCreationWorkflow,
+		SourceTypeID:            &src.SourceTypeID,
+		Tenant:                  &src.Tenant.ExternalTenant,
+	}
+
+	return sourceEvent
 }
 
 func (src *Source) ToResponse() *SourceResponse {

--- a/model/source.go
+++ b/model/source.go
@@ -43,10 +43,6 @@ type Source struct {
 	Endpoints        []Endpoint
 }
 
-func (src *Source) AsJSON() []byte {
-	return []byte{}
-}
-
 func (src *Source) ToEvent() *SourceEvent {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(src.AvailabilityStatus.AvailabilityStatus),
 		LastAvailableAt: util.DateTimeToRecordFormat(src.LastAvailableAt),

--- a/model/source.go
+++ b/model/source.go
@@ -49,15 +49,15 @@ func (src *Source) AsJSON() []byte {
 
 func (src *Source) ToEvent() *SourceEvent {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(src.AvailabilityStatus.AvailabilityStatus),
-		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(src.LastAvailableAt, "2006-01-02 15:04:05 MST")),
-		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(src.LastCheckedAt, "2006-01-02 15:04:05 MST"))}
+		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(src.LastAvailableAt, util.RecordDateTimeFormat)),
+		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(src.LastCheckedAt, util.RecordDateTimeFormat))}
 
 	sourceEvent := &SourceEvent{
 		AvailabilityStatusEvent: asEvent,
-		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(src.PausedAt, "2006-01-02 15:04:05 MST"))},
+		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(src.PausedAt, util.RecordDateTimeFormat))},
 		ID:                      &src.ID,
-		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(src.CreatedAt, "2006-01-02 15:04:05 MST")),
-		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(src.UpdatedAt, "2006-01-02 15:04:05 MST")),
+		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(src.CreatedAt, util.RecordDateTimeFormat)),
+		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(src.UpdatedAt, util.RecordDateTimeFormat)),
 		Name:                    &src.Name,
 		UID:                     src.Uid,
 		Version:                 src.Version,

--- a/model/source.go
+++ b/model/source.go
@@ -49,15 +49,15 @@ func (src *Source) AsJSON() []byte {
 
 func (src *Source) ToEvent() *SourceEvent {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(src.AvailabilityStatus.AvailabilityStatus),
-		LastAvailableAt: util.StringValueOrNil(util.FormatTimeToString(src.LastAvailableAt, util.RecordDateTimeFormat)),
-		LastCheckedAt:   util.StringValueOrNil(util.FormatTimeToString(src.LastCheckedAt, util.RecordDateTimeFormat))}
+		LastAvailableAt: util.DateTimeToRecordFormat(src.LastAvailableAt),
+		LastCheckedAt:   util.DateTimeToRecordFormat(src.LastCheckedAt)}
 
 	sourceEvent := &SourceEvent{
 		AvailabilityStatusEvent: asEvent,
-		PauseEvent:              PauseEvent{PausedAt: util.StringValueOrNil(util.FormatTimeToString(src.PausedAt, util.RecordDateTimeFormat))},
+		PauseEvent:              PauseEvent{PausedAt: util.DateTimeToRecordFormat(src.PausedAt)},
 		ID:                      &src.ID,
-		CreatedAt:               util.StringValueOrNil(util.FormatTimeToString(src.CreatedAt, util.RecordDateTimeFormat)),
-		UpdatedAt:               util.StringValueOrNil(util.FormatTimeToString(src.UpdatedAt, util.RecordDateTimeFormat)),
+		CreatedAt:               util.DateTimeToRecordFormat(src.CreatedAt),
+		UpdatedAt:               util.DateTimeToRecordFormat(src.UpdatedAt),
 		Name:                    &src.Name,
 		UID:                     src.Uid,
 		Version:                 src.Version,

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -40,7 +40,9 @@ export DATABASE_PASSWORD=toor
 export DATABASE_NAME=sources_api_test_go
 
 echo "Running tests...here we go"
+
 go test ./... --integration
+
 OUT_CODE=$?
 
 echo "Killing DB Container..."

--- a/statuslistener/main_test.go
+++ b/statuslistener/main_test.go
@@ -1,30 +1,30 @@
 package statuslistener
 
 import (
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"os"
 	"testing"
-
-	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 )
 
 // runningIntegration is used to skip integration tests if we're just running unit tests.
 var runningIntegration = false
 
 func TestMain(t *testing.M) {
-	flags := testutils.ParseFlags()
+	flags := parser.ParseFlags()
 
 	if flags.CreateDb {
-		testutils.CreateTestDB()
+		database.CreateTestDB()
 	} else if flags.Integration {
 		runningIntegration = true
-		testutils.ConnectAndMigrateDB("status_listener")
-		testutils.CreateFixtures()
+		database.ConnectAndMigrateDB("status_listener")
+		database.CreateFixtures()
 	}
 
 	code := t.Run()
 
 	if flags.Integration {
-		testutils.DropSchema("status_listener")
+		database.DropSchema("status_listener")
 	}
 
 	os.Exit(code)

--- a/statuslistener/main_test.go
+++ b/statuslistener/main_test.go
@@ -1,10 +1,11 @@
 package statuslistener
 
 import (
-	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
-	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"os"
 	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 )
 
 // runningIntegration is used to skip integration tests if we're just running unit tests.

--- a/statuslistener/main_test.go
+++ b/statuslistener/main_test.go
@@ -24,6 +24,7 @@ func TestMain(t *testing.M) {
 	} else if flags.Integration {
 		runningIntegration = true
 		testutils.ConnectAndMigrateDB("status_listener")
+		testutils.CreateFixtures()
 	}
 
 	code := t.Run()

--- a/statuslistener/main_test.go
+++ b/statuslistener/main_test.go
@@ -4,17 +4,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 )
 
-var (
-	// runningIntegration is used to skip integration tests if we're just running unit tests.
-	runningIntegration = false
-
-	endpointDao dao.EndpointDao
-	sourceDao   dao.SourceDao
-)
+// runningIntegration is used to skip integration tests if we're just running unit tests.
+var runningIntegration = false
 
 func TestMain(t *testing.M) {
 	flags := testutils.ParseFlags()

--- a/statuslistener/main_test.go
+++ b/statuslistener/main_test.go
@@ -1,0 +1,36 @@
+package statuslistener
+
+import (
+	"os"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+)
+
+var (
+	// runningIntegration is used to skip integration tests if we're just running unit tests.
+	runningIntegration = false
+
+	endpointDao dao.EndpointDao
+	sourceDao   dao.SourceDao
+)
+
+func TestMain(t *testing.M) {
+	flags := testutils.ParseFlags()
+
+	if flags.CreateDb {
+		testutils.CreateTestDB()
+	} else if flags.Integration {
+		runningIntegration = true
+		testutils.ConnectAndMigrateDB("status_listener")
+	}
+
+	code := t.Run()
+
+	if flags.Integration {
+		testutils.DropSchema("status_listener")
+	}
+
+	os.Exit(code)
+}

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -111,9 +111,9 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage StatusMessage,
 	}
 
 	updateAttributes := avs.attributesForUpdate(statusMessage)
-	modelEventDao, errorDao := dao.GetFrom(statusMessage.ResourceType)
+	modelEventDao, err := dao.GetFrom(statusMessage.ResourceType)
 	if err != nil {
-		logging.Log.Error(errorDao.Error())
+		logging.Log.Error(err.Error())
 		return
 	}
 

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -108,7 +108,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage StatusMessage,
 	}
 
 	updateAttributes := avs.attributesForUpdate(statusMessage)
-	modelEventDao, err := dao.GetFrom(statusMessage.ResourceType)
+	modelEventDao, err := dao.GetFromResourceType(statusMessage.ResourceType)
 	if err != nil {
 		logging.Log.Error(err.Error())
 		return

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -1,0 +1,140 @@
+package statuslistener
+
+import (
+	"time"
+
+	c "github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/internal/events"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+const (
+	SourcesStatusTopic      = "platform.sources.status"
+	GroupID                 = "sources-api-status-worker"
+	EventAvailabilityStatus = "availability_status"
+)
+
+var config = c.Get()
+
+func Run() {
+	subscribeToAvailabilityStatus()
+}
+
+func subscribeToAvailabilityStatus() {
+	if logging.Log == nil {
+		panic("logging is not initialized")
+	}
+
+	consumerConfig := kafka.ConsumerConfig{Topic: config.KafkaTopic(SourcesStatusTopic), GroupID: GroupID}
+	kafkaConfig := kafka.Config{KafkaBrokers: config.KafkaBrokers, ConsumerConfig: consumerConfig}
+
+	kf := &kafka.Manager{Config: kafkaConfig}
+
+	errorConsume := kf.Consume(func(message kafka.Message) {
+		var statusMessage StatusMessage
+		err := message.ParseTo(&statusMessage)
+		if err != nil {
+			logging.Log.Errorf("Error in parsing status message %s", err.Error())
+			return
+		}
+		et := eventType(message)
+		if et != EventAvailabilityStatus {
+			return
+		}
+
+		logging.Log.Infof("Kafka message %s, %s received with payload: %s", message.Headers, message.Key, message.Value)
+
+		headers := headersWithoutEventType(message)
+
+		processEvent(statusMessage, headers)
+	})
+
+	if errorConsume != nil {
+		logging.Log.Errorf("Consumer kafka message error: %s", errorConsume.Error())
+	}
+}
+
+func headersWithoutEventType(message kafka.Message) []kafka.Header {
+	if len(message.Headers) <= 1 {
+		return []kafka.Header{}
+	}
+
+	headers := make([]kafka.Header, len(message.Headers)-1)
+	for index, header := range headers {
+		if header.Key != "event_type" {
+			headers[index] = header
+		}
+	}
+
+	return headers
+}
+
+func eventType(message kafka.Message) string {
+	for _, header := range message.Headers {
+		if header.Key == "event_type" {
+			return string(header.Value)
+		}
+	}
+
+	return ""
+}
+
+func processEvent(statusMessage StatusMessage, headers []kafka.Header) {
+	resourceID, err := util.InterfaceToInt64(statusMessage.ResourceID)
+	if err != nil {
+		logging.Log.Errorf("Error parsing resource_id: %s", err.Error())
+		return
+	}
+
+	if !util.SliceContainsString(m.AvailabilityStatuses, statusMessage.Status) {
+		logging.Log.Errorf("Invalid Status: %s", statusMessage.Status)
+		return
+	}
+
+	updateAttributes := attributesForUpdate(statusMessage)
+	modelEventDao, errorDao := dao.GetFrom(statusMessage.ResourceType)
+	if err != nil {
+		logging.Log.Error(errorDao.Error())
+		return
+	}
+
+	err = (*modelEventDao).FetchAndUpdateBy(&resourceID, updateAttributes)
+	if err != nil {
+		logging.Log.Errorf("Update error in status availability: %s", err)
+		return
+	}
+
+	updateAttributeKeys := make([]string, len(updateAttributes))
+	i := 0
+	for k := range updateAttributes {
+		updateAttributeKeys[i] = k
+		i++
+	}
+
+	err = events.RaiseEventForUpdate(resourceID, statusMessage.ResourceType, updateAttributeKeys, headers)
+	if err != nil {
+		logging.Log.Errorf("Error in raising event for update: %s, resource: %s(%s)", err.Error(), statusMessage.ResourceType, statusMessage.ResourceID)
+	}
+}
+
+func attributesForUpdate(statusMessage StatusMessage) map[string]interface{} {
+	updateAttributes := make(map[string]interface{})
+
+	updateAttributes["last_checked_at"] = time.Now().Format("2006-01-02T15:04:05.999Z")
+	updateAttributes["availability_status"] = statusMessage.Status
+
+	statusErrorModels := []string{"Application", "Authentication", "Endpoint"}
+	if util.SliceContainsString(statusErrorModels, statusMessage.ResourceType) {
+		updateAttributes["availability_status_error"] = statusMessage.Error
+	}
+
+	if statusMessage.Status == "available" {
+		updateAttributes["last_available_at"] = updateAttributes["last_checked_at"]
+	}
+
+	return updateAttributes
+}

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -60,8 +60,7 @@ func (avs *AvailabilityStatusListener) ConsumeStatusMessage(message kafka.Messag
 		return
 	}
 
-	et := avs.eventType(message)
-	if et != eventAvailabilityStatus {
+	if message.GetHeader("event_type") != eventAvailabilityStatus {
 		return
 	}
 
@@ -83,16 +82,6 @@ func (avs *AvailabilityStatusListener) headersFrom(message kafka.Message) []kafk
 	}
 
 	return headers
-}
-
-func (avs *AvailabilityStatusListener) eventType(message kafka.Message) string {
-	for _, header := range message.Headers {
-		if header.Key == "event_type" {
-			return string(header.Value)
-		}
-	}
-
-	return ""
 }
 
 func (avs *AvailabilityStatusListener) processEvent(statusMessage StatusMessage, headers []kafka.Header) {

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -99,7 +99,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage StatusMessage,
 	updateAttributes := avs.attributesForUpdate(statusMessage)
 	modelEventDao, err := dao.GetFromResourceType(statusMessage.ResourceType)
 	if err != nil {
-		logging.Log.Error(err.Error())
+		logging.Log.Error(err)
 		return
 	}
 

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -56,7 +56,7 @@ func (avs *AvailabilityStatusListener) ConsumeStatusMessage(message kafka.Messag
 	var statusMessage StatusMessage
 	err := message.ParseTo(&statusMessage)
 	if err != nil {
-		logging.Log.Errorf("Error in parsing status message %s", err.Error())
+		logging.Log.Errorf("Error in parsing status message %v", err)
 		return
 	}
 

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -1,6 +1,7 @@
 package statuslistener
 
 import (
+	"sort"
 	"time"
 
 	c "github.com/RedHatInsights/sources-api-go/config"
@@ -20,11 +21,21 @@ const (
 
 var config = c.Get()
 
-func Run() {
-	subscribeToAvailabilityStatus()
+type AvailabilityStatusListener struct {
+	*events.EventStreamProducer
 }
 
-func subscribeToAvailabilityStatus() {
+func Run() {
+	avs := AvailabilityStatusListener{EventStreamProducer: NewEventStreamProducer()}
+	avs.subscribeToAvailabilityStatus()
+}
+
+func NewEventStreamProducer() *events.EventStreamProducer {
+	sender := &events.EventStreamSender{}
+	return &events.EventStreamProducer{Sender: sender}
+}
+
+func (avs *AvailabilityStatusListener) subscribeToAvailabilityStatus() {
 	if logging.Log == nil {
 		panic("logging is not initialized")
 	}
@@ -34,46 +45,50 @@ func subscribeToAvailabilityStatus() {
 
 	kf := &kafka.Manager{Config: kafkaConfig}
 
-	errorConsume := kf.Consume(func(message kafka.Message) {
-		var statusMessage StatusMessage
-		err := message.ParseTo(&statusMessage)
-		if err != nil {
-			logging.Log.Errorf("Error in parsing status message %s", err.Error())
-			return
-		}
-		et := eventType(message)
-		if et != EventAvailabilityStatus {
-			return
-		}
-
-		logging.Log.Infof("Kafka message %s, %s received with payload: %s", message.Headers, message.Key, message.Value)
-
-		headers := headersWithoutEventType(message)
-
-		processEvent(statusMessage, headers)
-	})
+	errorConsume := kf.Consume(avs.ConsumeStatusMessage)
 
 	if errorConsume != nil {
 		logging.Log.Errorf("Consumer kafka message error: %s", errorConsume.Error())
 	}
 }
 
-func headersWithoutEventType(message kafka.Message) []kafka.Header {
-	if len(message.Headers) <= 1 {
+func (avs *AvailabilityStatusListener) ConsumeStatusMessage(message kafka.Message) {
+	var statusMessage StatusMessage
+	err := message.ParseTo(&statusMessage)
+	if err != nil {
+		logging.Log.Errorf("Error in parsing status message %s", err.Error())
+		return
+	}
+
+	et := avs.eventType(message)
+	if et != EventAvailabilityStatus {
+		return
+	}
+
+	logging.Log.Infof("Kafka message %s, %s received with payload: %s", message.Headers, message.Key, message.Value)
+
+	headers := avs.headersWithoutEventType(message)
+
+	avs.processEvent(statusMessage, headers)
+}
+
+func (avs *AvailabilityStatusListener) headersWithoutEventType(message kafka.Message) []kafka.Header {
+	if len(message.Headers) < 1 {
 		return []kafka.Header{}
 	}
 
-	headers := make([]kafka.Header, len(message.Headers)-1)
-	for index, header := range headers {
+	//headers := make([]kafka.Header, len(message.Headers))
+	var headers []kafka.Header
+	for _, header := range message.Headers {
 		if header.Key != "event_type" {
-			headers[index] = header
+			headers = append(headers, kafka.Header(header))
 		}
 	}
 
 	return headers
 }
 
-func eventType(message kafka.Message) string {
+func (avs *AvailabilityStatusListener) eventType(message kafka.Message) string {
 	for _, header := range message.Headers {
 		if header.Key == "event_type" {
 			return string(header.Value)
@@ -83,7 +98,7 @@ func eventType(message kafka.Message) string {
 	return ""
 }
 
-func processEvent(statusMessage StatusMessage, headers []kafka.Header) {
+func (avs *AvailabilityStatusListener) processEvent(statusMessage StatusMessage, headers []kafka.Header) {
 	resourceID, err := util.InterfaceToInt64(statusMessage.ResourceID)
 	if err != nil {
 		logging.Log.Errorf("Error parsing resource_id: %s", err.Error())
@@ -95,7 +110,7 @@ func processEvent(statusMessage StatusMessage, headers []kafka.Header) {
 		return
 	}
 
-	updateAttributes := attributesForUpdate(statusMessage)
+	updateAttributes := avs.attributesForUpdate(statusMessage)
 	modelEventDao, errorDao := dao.GetFrom(statusMessage.ResourceType)
 	if err != nil {
 		logging.Log.Error(errorDao.Error())
@@ -114,14 +129,15 @@ func processEvent(statusMessage StatusMessage, headers []kafka.Header) {
 		updateAttributeKeys[i] = k
 		i++
 	}
+	sort.Strings(updateAttributeKeys)
 
-	err = events.RaiseEventForUpdate(resourceID, statusMessage.ResourceType, updateAttributeKeys, headers)
+	err = avs.EventStreamProducer.RaiseEventForUpdate(resourceID, statusMessage.ResourceType, updateAttributeKeys, headers)
 	if err != nil {
 		logging.Log.Errorf("Error in raising event for update: %s, resource: %s(%s)", err.Error(), statusMessage.ResourceType, statusMessage.ResourceID)
 	}
 }
 
-func attributesForUpdate(statusMessage StatusMessage) map[string]interface{} {
+func (avs *AvailabilityStatusListener) attributesForUpdate(statusMessage StatusMessage) map[string]interface{} {
 	updateAttributes := make(map[string]interface{})
 
 	updateAttributes["last_checked_at"] = time.Now().Format("2006-01-02T15:04:05.999Z")

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -67,22 +67,19 @@ func (avs *AvailabilityStatusListener) ConsumeStatusMessage(message kafka.Messag
 
 	logging.Log.Infof("Kafka message %s, %s received with payload: %s", message.Headers, message.Key, message.Value)
 
-	headers := avs.headersWithoutEventType(message)
+	headers := avs.headersFrom(message)
 
 	avs.processEvent(statusMessage, headers)
 }
 
-func (avs *AvailabilityStatusListener) headersWithoutEventType(message kafka.Message) []kafka.Header {
+func (avs *AvailabilityStatusListener) headersFrom(message kafka.Message) []kafka.Header {
 	if len(message.Headers) < 1 {
 		return []kafka.Header{}
 	}
 
-	//headers := make([]kafka.Header, len(message.Headers))
-	var headers []kafka.Header
-	for _, header := range message.Headers {
-		if header.Key != "event_type" {
-			headers = append(headers, kafka.Header(header))
-		}
+	headers := make([]kafka.Header, len(message.Headers))
+	for index, header := range message.Headers {
+		headers[index] = kafka.Header{Key: header.Key, Value: header.Value}
 	}
 
 	return headers

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -45,10 +45,10 @@ func (avs *AvailabilityStatusListener) subscribeToAvailabilityStatus() {
 
 	kf := &kafka.Manager{Config: kafkaConfig}
 
-	errorConsume := kf.Consume(avs.ConsumeStatusMessage)
+	err := kf.Consume(avs.ConsumeStatusMessage)
 
-	if errorConsume != nil {
-		logging.Log.Errorf("Consumer kafka message error: %s", errorConsume.Error())
+	if err != nil {
+		logging.Log.Errorf("Consumer kafka message error: %s", err.Error())
 	}
 }
 

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -14,9 +14,9 @@ import (
 )
 
 const (
-	SourcesStatusTopic      = "platform.sources.status"
-	GroupID                 = "sources-api-status-worker"
-	EventAvailabilityStatus = "availability_status"
+	sourcesStatusTopic      = "platform.sources.status"
+	groupID                 = "sources-api-status-worker"
+	eventAvailabilityStatus = "availability_status"
 )
 
 var config = c.Get()
@@ -40,7 +40,7 @@ func (avs *AvailabilityStatusListener) subscribeToAvailabilityStatus() {
 		panic("logging is not initialized")
 	}
 
-	consumerConfig := kafka.ConsumerConfig{Topic: config.KafkaTopic(SourcesStatusTopic), GroupID: GroupID}
+	consumerConfig := kafka.ConsumerConfig{Topic: config.KafkaTopic(sourcesStatusTopic), GroupID: groupID}
 	kafkaConfig := kafka.Config{KafkaBrokers: config.KafkaBrokers, ConsumerConfig: consumerConfig}
 
 	kf := &kafka.Manager{Config: kafkaConfig}
@@ -61,7 +61,7 @@ func (avs *AvailabilityStatusListener) ConsumeStatusMessage(message kafka.Messag
 	}
 
 	et := avs.eventType(message)
-	if et != EventAvailabilityStatus {
+	if et != eventAvailabilityStatus {
 		return
 	}
 

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -307,15 +307,11 @@ type TestData struct {
 }
 
 func TestConsumeStatusMessage(t *testing.T) {
-	flags := testutils.ParseFlags()
-
-	if !flags.Integration {
+	if !runningIntegration {
 		return
 	}
 
-	testutils.ConnectToTestDB()
-	testutils.DropSchema()
-	testutils.MigrateSchema()
+	testutils.ConnectAndMigrateDB("status_listener")
 	testutils.CreateFixtures()
 
 	log := logrus.Logger{
@@ -373,5 +369,5 @@ func TestConsumeStatusMessage(t *testing.T) {
 		}
 	}
 
-	testutils.DropSchema()
+	testutils.DropSchema("status_listener")
 }

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -307,6 +307,12 @@ type TestData struct {
 }
 
 func TestConsumeStatusMessage(t *testing.T) {
+	flags := testutils.ParseFlags()
+
+	if !flags.Integration {
+		return
+	}
+
 	testutils.ConnectToTestDB()
 	testutils.DropSchema()
 	testutils.MigrateSchema()

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/events"
-	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
@@ -311,9 +310,6 @@ func TestConsumeStatusMessage(t *testing.T) {
 		return
 	}
 
-	testutils.ConnectAndMigrateDB("status_listener")
-	testutils.CreateFixtures()
-
 	log := logrus.Logger{
 		Out:          os.Stdout,
 		Level:        logrus.DebugLevel,
@@ -368,6 +364,4 @@ func TestConsumeStatusMessage(t *testing.T) {
 			sender.TestSuite.Errorf("RaiseEvent was%scalled while it was%sexpected", wasOrWasNot, wasOrWasNotExpected)
 		}
 	}
-
-	testutils.DropSchema("status_listener")
 }

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -1,0 +1,374 @@
+package statuslistener
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/internal/events"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+	kafkaGo "github.com/segmentio/kafka-go"
+	"github.com/sirupsen/logrus"
+)
+
+var testData []TestData
+
+type MockFormatter struct {
+	Hostname              string
+	AppName               string
+	InjectedToOtherLogger bool
+}
+
+func (m MockFormatter) Format(_ *logrus.Entry) ([]byte, error) {
+	return []byte{}, nil
+}
+
+type MockEventStreamSender struct {
+	events.EventStreamSender
+	TestSuite *testing.T
+	StatusMessage
+
+	RaiseEventCalled bool
+}
+
+func LoadJSONContentFrom(resourceType string, resourceID string, prefix string) []byte {
+	fileName := "./test_data/" + prefix + resourceType + "_" + resourceID + ".json"
+	fileContent, err := os.ReadFile(fileName)
+
+	if err != nil {
+		panic(fmt.Errorf("unable to read file %s because of %s", fileName, err.Error()))
+	}
+
+	return fileContent
+}
+
+func BulkMessageFor(resourceType string, resourceID string) []byte {
+	bulkMessage := LoadJSONContentFrom(resourceType, resourceID, "bulk_message_")
+	return TransformDateFieldsInJSONForBulkMessage(resourceType, resourceID, bulkMessage)
+}
+
+type DateFields struct {
+	CreatedAt       time.Time
+	LastAvailableAt time.Time
+	LastCheckedAt   time.Time
+	UpdatedAt       time.Time
+}
+
+func UpdateDateFieldsTo(fieldsMap map[string]interface{}, dateFields DateFields) map[string]interface{} {
+	if !dateFields.CreatedAt.IsZero() {
+		fieldsMap["created_at"] = util.FormatTimeToString(dateFields.CreatedAt, "2006-01-02 15:04:05 MST")
+	}
+
+	if !dateFields.LastAvailableAt.IsZero() {
+		fieldsMap["last_available_at"] = util.FormatTimeToString(dateFields.LastAvailableAt, "2006-01-02 15:04:05 MST")
+	}
+
+	if !dateFields.LastCheckedAt.IsZero() {
+		fieldsMap["last_checked_at"] = util.FormatTimeToString(dateFields.LastCheckedAt, "2006-01-02 15:04:05 MST")
+	}
+
+	if !dateFields.UpdatedAt.IsZero() {
+		fieldsMap["updated_at"] = util.FormatTimeToString(dateFields.UpdatedAt, "2006-01-02 15:04:05 MST")
+	}
+
+	return fieldsMap
+}
+
+func PopulateDateFieldsFrom(resource interface{}) DateFields {
+	dateFields := DateFields{}
+
+	switch typedResource := resource.(type) {
+	case *m.Source:
+		dateFields.CreatedAt = typedResource.CreatedAt
+		dateFields.LastAvailableAt = typedResource.LastAvailableAt
+		dateFields.LastCheckedAt = typedResource.LastCheckedAt
+		dateFields.UpdatedAt = typedResource.UpdatedAt
+	case *m.Application:
+		dateFields.CreatedAt = typedResource.CreatedAt
+		dateFields.LastAvailableAt = typedResource.LastAvailableAt
+		dateFields.LastCheckedAt = typedResource.LastCheckedAt
+		dateFields.UpdatedAt = typedResource.UpdatedAt
+	case *m.Endpoint:
+		dateFields.CreatedAt = typedResource.CreatedAt
+		dateFields.LastAvailableAt = typedResource.LastAvailableAt
+		dateFields.LastCheckedAt = typedResource.LastCheckedAt
+		dateFields.UpdatedAt = typedResource.UpdatedAt
+	default:
+		panic("unable to find type")
+	}
+
+	return dateFields
+}
+
+func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (interface{}, map[string]interface{}) {
+	id, err := util.InterfaceToInt64(resourceID)
+	if err != nil {
+		panic("conversion error + " + err.Error())
+	}
+
+	var src interface{}
+	res := dao.DB
+
+	bulkMessage := map[string]interface{}{}
+
+	switch resourceType {
+	case "Source":
+		source := &m.Source{ID: id}
+		if forBulkMessage {
+			res = dao.DB.Preload("Applications").Preload("Endpoints")
+		}
+		res = res.Find(source)
+		bulkMessage["applications"] = source.Applications
+		bulkMessage["endpoints"] = source.Endpoints
+		src = source
+	case "Application":
+		application := &m.Application{ID: id}
+		if forBulkMessage {
+			res = dao.DB.Preload("Source").Preload("Source.Applications").Preload("Source.Endpoints")
+		}
+
+		res = res.Find(application)
+		bulkMessage["applications"] = application.Source.Applications
+		bulkMessage["endpoints"] = application.Source.Endpoints
+		src = application
+	case "Endpoint":
+		endpoint := &m.Endpoint{ID: id}
+		if forBulkMessage {
+			res = dao.DB.Preload("Source").Preload("Source.Applications").Preload("Source.Endpoints")
+		}
+		res = res.Find(endpoint)
+		bulkMessage["applications"] = endpoint.Source.Applications
+		bulkMessage["endpoints"] = endpoint.Source.Endpoints
+		src = endpoint
+	default:
+		panic("can't find resource type")
+	}
+
+	err = res.Error
+
+	if err != nil {
+		panic("Error fetch record " + resourceID)
+	}
+
+	return src, bulkMessage
+}
+
+func TransformDateFieldsInJSONForBulkMessage(resourceType string, resourceID string, content []byte) []byte {
+	resource, bulkMessage := FetchDataFor(resourceType, resourceID, true)
+
+	contentMap := make(map[string]interface{})
+	err := json.Unmarshal(content, &contentMap)
+	if err != nil {
+		panic("unmarshalling error + " + err.Error())
+	}
+
+	dateFields := PopulateDateFieldsFrom(resource)
+	contentMap["source"] = UpdateDateFieldsTo(contentMap["source"].(map[string]interface{}), dateFields)
+
+	var applications []interface{}
+
+	apps, success := bulkMessage["applications"].([]m.Application)
+	if !success {
+		panic("type assertion error: + " + err.Error())
+	}
+
+	for index, application := range apps {
+		dateFields = PopulateDateFieldsFrom(&application)
+		ap, success := contentMap["applications"].([]interface{})
+		if !success {
+			panic("type assertion error: + " + err.Error())
+		}
+
+		upd := UpdateDateFieldsTo(ap[index].(map[string]interface{}), dateFields)
+		applications = append(applications, upd)
+	}
+	contentMap["applications"] = applications
+
+	var endpoints []interface{}
+
+	ends, success := bulkMessage["endpoints"].([]m.Endpoint)
+	if !success {
+		panic("type assertion error: + " + err.Error())
+	}
+
+	for index, endpoint := range ends {
+		dateFields = PopulateDateFieldsFrom(&endpoint)
+		ap, success := contentMap["endpoints"].([]interface{})
+		if !success {
+			panic("type assertion error: + " + err.Error())
+		}
+
+		upd := UpdateDateFieldsTo(ap[index].(map[string]interface{}), dateFields)
+		endpoints = append(endpoints, upd)
+	}
+
+	contentMap["endpoints"] = endpoints
+
+	contentJSON, err := json.Marshal(contentMap)
+	if err != nil {
+		panic("marshalling error + " + err.Error())
+	}
+
+	return contentJSON
+}
+
+func TransformDateFieldsInJSONForResource(resourceType string, resourceID string, content []byte) []byte {
+	resource, _ := FetchDataFor(resourceType, resourceID, false)
+
+	contentMap := make(map[string]interface{})
+	err := json.Unmarshal(content, &contentMap)
+	if err != nil {
+		panic("unmarshalling error + " + err.Error())
+	}
+
+	dateFields := PopulateDateFieldsFrom(resource)
+	contentMap = UpdateDateFieldsTo(contentMap, dateFields)
+
+	contentJSON, err := json.Marshal(contentMap)
+	if err != nil {
+		panic("marshalling error + " + err.Error())
+	}
+
+	return contentJSON
+}
+
+func ResourceJSONFor(resourceType string, resourceID string) []byte {
+	content := LoadJSONContentFrom(resourceType, resourceID, "resource_")
+	return TransformDateFieldsInJSONForResource(resourceType, resourceID, content)
+}
+
+func JSONBytesEqual(a, b []byte) (bool, error) {
+	var j, j2 interface{}
+	if err := json.Unmarshal(a, &j); err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal(b, &j2); err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(j2, j), nil
+}
+
+func (streamProducerSender *MockEventStreamSender) RaiseEvent(eventType string, payload []byte, headers []kafka.Header) error {
+	streamProducerSender.RaiseEventCalled = true
+	var err error
+
+	for _, data := range testData {
+		if streamProducerSender.ResourceType == data.ResourceType && streamProducerSender.ResourceID == data.ResourceID {
+			var isResult bool
+			var expectedData []byte
+			if eventType == "Records.update" {
+				expectedData = BulkMessageFor(streamProducerSender.ResourceType, streamProducerSender.ResourceID)
+			} else {
+				expectedData = ResourceJSONFor(streamProducerSender.ResourceType, streamProducerSender.ResourceID)
+			}
+
+			isResult, err = JSONBytesEqual(payload, expectedData)
+			if isResult != true {
+				errMsg := "error in raising event of type %s with resource type %s.\n" +
+					"JSON payloads are not same:\n\n" +
+					"Expected: %s \n" +
+					"Obtained: %s \n"
+
+				streamProducerSender.TestSuite.Errorf(errMsg, eventType, streamProducerSender.ResourceType, expectedData, payload)
+				return fmt.Errorf(errMsg, eventType, streamProducerSender.ResourceType, expectedData, payload)
+			}
+		}
+	}
+
+	if err != nil {
+		streamProducerSender.TestSuite.Errorf("error with parsing JSON: %s", err.Error())
+	}
+
+	return err
+}
+
+func (streamProducerSender *MockEventStreamSender) GetRaiseEventCalled() bool {
+	return (*streamProducerSender).RaiseEventCalled
+}
+
+type ExpectedData struct {
+	BulkMessage  []byte
+	ResourceJSON []byte
+}
+
+type TestData struct {
+	StatusMessage
+	m.AvailabilityStatus
+	ExpectedData
+
+	MessageHeaders []kafkaGo.Header
+
+	RaiseEventCalled bool
+}
+
+func TestConsumeStatusMessage(t *testing.T) {
+	testutils.ConnectToTestDB()
+	testutils.DropSchema()
+	testutils.MigrateSchema()
+	testutils.CreateFixtures()
+
+	log := logrus.Logger{
+		Out:          os.Stdout,
+		Level:        logrus.DebugLevel,
+		Formatter:    MockFormatter{},
+		Hooks:        make(logrus.LevelHooks),
+		ReportCaller: false,
+	}
+
+	logging.Log = &log
+
+	header := kafkaGo.Header{Key: "event_type", Value: []byte("availability_status")}
+	header2 := kafkaGo.Header{Key: "x-rh-identity", Value: []byte("Test identity")}
+	header3 := kafkaGo.Header{Key: "x-rh-sources-account-number", Value: []byte("12345")}
+	headers := []kafkaGo.Header{header, header2, header3}
+	statusMessage := StatusMessage{ResourceType: "Source", ResourceID: "1", Status: m.Available}
+	sourceTestData := TestData{StatusMessage: statusMessage, MessageHeaders: headers, RaiseEventCalled: true}
+
+	statusMessageApplication := StatusMessage{ResourceType: "Application", ResourceID: "1", Status: m.Available}
+	applicationTestData := TestData{StatusMessage: statusMessageApplication, MessageHeaders: headers, RaiseEventCalled: true}
+
+	statusMessageEndpoint := StatusMessage{ResourceType: "Endpoint", ResourceID: "1", Status: m.Available}
+	endpointTestData := TestData{StatusMessage: statusMessageEndpoint, MessageHeaders: headers, RaiseEventCalled: true}
+
+	statusMessageEndpoint = StatusMessage{ResourceType: "Endpoint", ResourceID: "99", Status: m.Available}
+	endpointTestDataNotFound := TestData{StatusMessage: statusMessageEndpoint, MessageHeaders: headers, RaiseEventCalled: false}
+
+	testData = make([]TestData, 4)
+	testData[0] = sourceTestData
+	testData[1] = applicationTestData
+	testData[2] = endpointTestData
+	testData[3] = endpointTestDataNotFound
+
+	for _, testEntry := range testData {
+		sender := MockEventStreamSender{TestSuite: t, StatusMessage: testEntry.StatusMessage}
+		esp := &events.EventStreamProducer{Sender: &sender}
+		avs := AvailabilityStatusListener{EventStreamProducer: esp}
+		message, _ := json.Marshal(testEntry)
+		avs.ConsumeStatusMessage(kafka.Message{Value: message, Headers: testEntry.MessageHeaders})
+
+		raiseEventCalled := esp.Sender.(*MockEventStreamSender).RaiseEventCalled
+		if raiseEventCalled != testEntry.RaiseEventCalled {
+			wasOrWasNot := " "
+			if raiseEventCalled == false {
+				wasOrWasNot = " not "
+			}
+
+			wasOrWasNotExpected := " "
+			if testEntry.RaiseEventCalled == false {
+				wasOrWasNotExpected = " not "
+			}
+
+			sender.TestSuite.Errorf("RaiseEvent was%scalled while it was%sexpected", wasOrWasNot, wasOrWasNotExpected)
+		}
+	}
+
+	testutils.DropSchema()
+}

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -3,6 +3,7 @@ package statuslistener
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -41,7 +42,7 @@ type MockEventStreamSender struct {
 
 func LoadJSONContentFrom(resourceType string, resourceID string, prefix string) []byte {
 	fileName := "./test_data/" + prefix + resourceType + "_" + resourceID + ".json"
-	fileContent, err := os.ReadFile(fileName)
+	fileContent, err := ioutil.ReadFile(fileName)
 
 	if err != nil {
 		panic(fmt.Errorf("unable to read file %s because of %s", fileName, err.Error()))
@@ -288,10 +289,6 @@ func (streamProducerSender *MockEventStreamSender) RaiseEvent(eventType string, 
 	}
 
 	return err
-}
-
-func (streamProducerSender *MockEventStreamSender) GetRaiseEventCalled() bool {
-	return (*streamProducerSender).RaiseEventCalled
 }
 
 type ExpectedData struct {

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -65,19 +65,19 @@ type DateFields struct {
 
 func UpdateDateFieldsTo(fieldsMap map[string]interface{}, dateFields DateFields) map[string]interface{} {
 	if !dateFields.CreatedAt.IsZero() {
-		fieldsMap["created_at"] = util.FormatTimeToString(dateFields.CreatedAt, "2006-01-02 15:04:05 MST")
+		fieldsMap["created_at"] = util.FormatTimeToString(dateFields.CreatedAt, util.RecordDateTimeFormat)
 	}
 
 	if !dateFields.LastAvailableAt.IsZero() {
-		fieldsMap["last_available_at"] = util.FormatTimeToString(dateFields.LastAvailableAt, "2006-01-02 15:04:05 MST")
+		fieldsMap["last_available_at"] = util.FormatTimeToString(dateFields.LastAvailableAt, util.RecordDateTimeFormat)
 	}
 
 	if !dateFields.LastCheckedAt.IsZero() {
-		fieldsMap["last_checked_at"] = util.FormatTimeToString(dateFields.LastCheckedAt, "2006-01-02 15:04:05 MST")
+		fieldsMap["last_checked_at"] = util.FormatTimeToString(dateFields.LastCheckedAt, util.RecordDateTimeFormat)
 	}
 
 	if !dateFields.UpdatedAt.IsZero() {
-		fieldsMap["updated_at"] = util.FormatTimeToString(dateFields.UpdatedAt, "2006-01-02 15:04:05 MST")
+		fieldsMap["updated_at"] = util.FormatTimeToString(dateFields.UpdatedAt, util.RecordDateTimeFormat)
 	}
 
 	return fieldsMap

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -66,7 +66,7 @@
       "availability_status_error": null,
       "certificate_authority": null,
       "created_at": "2021-12-06 20:03:14 CET",
-      "default": true,
+      "default": false,
       "host": "tower.example.com",
       "id": 2,
       "last_available_at": null,

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -1,0 +1,113 @@
+{
+  "application_authentications": [
+  ],
+  "applications": [
+    {
+      "application_type_id": 1,
+      "availability_status": null,
+      "availability_status_error": null,
+      "created_at": "2021-12-06 20:03:14 CET",
+      "extra": {
+        "extra": false
+      },
+      "id": 2,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "paused_at": null,
+      "source_id": 1,
+      "superkey_data": null,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 20:03:14 CET"
+    },
+    {
+      "application_type_id": 1,
+      "availability_status": "available",
+      "availability_status_error": null,
+      "created_at": "2021-12-06 20:03:14 CET",
+      "extra": {
+        "extra": true
+      },
+      "id": 1,
+      "last_available_at": "2021-12-06 21:03:14 CET",
+      "last_checked_at": "2021-12-06 21:03:14 CET",
+      "paused_at": null,
+      "source_id": 1,
+      "superkey_data": null,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 20:03:14 CET"
+    }
+  ],
+  "authentications": [
+  ],
+  "endpoints": [
+    {
+      "availability_status": null,
+      "availability_status_error": null,
+      "certificate_authority": null,
+      "created_at": "2021-12-06 20:03:14 CET",
+      "default": true,
+      "host": "openshift.example.com",
+      "id": 1,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "path": "/",
+      "paused_at": null,
+      "port": 80,
+      "receptor_node": null,
+      "role": null,
+      "scheme": "http",
+      "source_id": 1,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 20:03:14 CET",
+      "verify_ssl": null
+    },
+    {
+      "availability_status": null,
+      "availability_status_error": null,
+      "certificate_authority": null,
+      "created_at": "2021-12-06 20:03:14 CET",
+      "default": true,
+      "host": "tower.example.com",
+      "id": 2,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "path": "/",
+      "paused_at": null,
+      "port": 80,
+      "receptor_node": null,
+      "role": null,
+      "scheme": "https",
+      "source_id": 1,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 20:03:14 CET",
+      "verify_ssl": null
+    }
+  ],
+  "source": {
+    "app_creation_workflow": "manual_configuration",
+    "availability_status": "available",
+    "created_at": "2021-12-06 20:03:14 CET",
+    "id": 1,
+    "imported": null,
+    "last_available_at": "2021-12-06 21:03:14 CET",
+    "last_checked_at": "2021-12-06 21:03:14 CET",
+    "name": "Source1",
+    "paused_at": null,
+    "source_ref": null,
+    "source_type_id": 1,
+    "tenant": "12345",
+    "uid": "5eebe172-7baa-4280-823f-19e597d091e9",
+    "updated_at": "2021-12-06 20:03:14 CET",
+    "version": null
+  },
+  "updated": {
+    "Application": {
+      "1": [
+        "availability_status",
+        "availability_status_error",
+        "last_available_at",
+        "last_checked_at"
+      ]
+    }
+  }
+}

--- a/statuslistener/test_data/bulk_message_Endpoint_1.json
+++ b/statuslistener/test_data/bulk_message_Endpoint_1.json
@@ -1,0 +1,113 @@
+{
+  "application_authentications": [
+  ],
+  "applications": [
+    {
+      "application_type_id": 1,
+      "availability_status": null,
+      "availability_status_error": null,
+      "created_at": "2021-12-06 19:58:14 CET",
+      "extra": {
+        "extra": false
+      },
+      "id": 2,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "paused_at": null,
+      "source_id": 1,
+      "superkey_data": null,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 19:58:14 CET"
+    },
+    {
+      "application_type_id": 1,
+      "availability_status": "available",
+      "availability_status_error": null,
+      "created_at": "2021-12-06 19:58:14 CET",
+      "extra": {
+        "extra": true
+      },
+      "id": 1,
+      "last_available_at": "2021-12-06 20:58:50 CET",
+      "last_checked_at": "2021-12-06 20:58:50 CET",
+      "paused_at": null,
+      "source_id": 1,
+      "superkey_data": null,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 19:58:50 CET"
+    }
+  ],
+  "authentications": [
+  ],
+  "endpoints": [
+    {
+      "availability_status": null,
+      "availability_status_error": null,
+      "certificate_authority": null,
+      "created_at": "2021-12-06 19:58:14 CET",
+      "default": true,
+      "host": "tower.example.com",
+      "id": 2,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "path": "/",
+      "paused_at": null,
+      "port": 80,
+      "receptor_node": null,
+      "role": null,
+      "scheme": "https",
+      "source_id": 1,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 19:58:14 CET",
+      "verify_ssl": null
+    },
+    {
+      "availability_status": "available",
+      "availability_status_error": "",
+      "certificate_authority": null,
+      "created_at": "2021-12-06 19:58:14 CET",
+      "default": true,
+      "host": "openshift.example.com",
+      "id": 1,
+      "last_available_at": "2021-12-06 20:59:08 CET",
+      "last_checked_at": "2021-12-06 20:59:08 CET",
+      "path": "/",
+      "paused_at": null,
+      "port": 80,
+      "receptor_node": null,
+      "role": null,
+      "scheme": "http",
+      "source_id": 1,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 19:59:08 CET",
+      "verify_ssl": null
+    }
+  ],
+  "source": {
+    "app_creation_workflow": "manual_configuration",
+    "availability_status": "available",
+    "created_at": "2021-12-06 19:58:14 CET",
+    "id": 1,
+    "imported": null,
+    "last_available_at": "2021-12-06 20:58:14 CET",
+    "last_checked_at": "2021-12-06 20:58:14 CET",
+    "name": "Source1",
+    "paused_at": null,
+    "source_ref": null,
+    "source_type_id": 1,
+    "tenant": "12345",
+    "uid": "5eebe172-7baa-4280-823f-19e597d091e9",
+    "updated_at": "2021-12-06 19:58:14 CET",
+    "version": null
+  },
+  "updated": {
+    "Endpoint": {
+      "1": [
+        "availability_status",
+        "availability_status_error",
+        "last_available_at",
+        "last_checked_at"
+      ]
+    }
+  }
+}

--- a/statuslistener/test_data/bulk_message_Endpoint_1.json
+++ b/statuslistener/test_data/bulk_message_Endpoint_1.json
@@ -45,7 +45,7 @@
       "availability_status_error": null,
       "certificate_authority": null,
       "created_at": "2021-12-06 19:58:14 CET",
-      "default": true,
+      "default": false,
       "host": "tower.example.com",
       "id": 2,
       "last_available_at": null,

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -66,7 +66,7 @@
       "availability_status_error": null,
       "certificate_authority": null,
       "created_at": "2021-12-06 20:00:14 CET",
-      "default": true,
+      "default": false,
       "host": "tower.example.com",
       "id": 2,
       "last_available_at": null,

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -1,0 +1,112 @@
+{
+  "application_authentications": [
+  ],
+  "applications": [
+    {
+      "application_type_id": 1,
+      "availability_status": null,
+      "availability_status_error": null,
+      "created_at": "2021-12-06 20:00:14 CET",
+      "extra": {
+        "extra": true
+      },
+      "id": 1,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "paused_at": null,
+      "source_id": 1,
+      "superkey_data": null,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 20:00:14 CET"
+    },
+    {
+      "application_type_id": 1,
+      "availability_status": null,
+      "availability_status_error": null,
+      "created_at": "2021-12-06 20:00:14 CET",
+      "extra": {
+        "extra": false
+      },
+      "id": 2,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "paused_at": null,
+      "source_id": 1,
+      "superkey_data": null,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 20:00:14 CET"
+    }
+  ],
+  "authentications": [
+  ],
+  "endpoints": [
+    {
+      "availability_status": null,
+      "availability_status_error": null,
+      "certificate_authority": null,
+      "created_at": "2021-12-06 20:00:14 CET",
+      "default": true,
+      "host": "openshift.example.com",
+      "id": 1,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "path": "/",
+      "paused_at": null,
+      "port": 80,
+      "receptor_node": null,
+      "role": null,
+      "scheme": "http",
+      "source_id": 1,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 20:00:14 CET",
+      "verify_ssl": null
+    },
+    {
+      "availability_status": null,
+      "availability_status_error": null,
+      "certificate_authority": null,
+      "created_at": "2021-12-06 20:00:14 CET",
+      "default": true,
+      "host": "tower.example.com",
+      "id": 2,
+      "last_available_at": null,
+      "last_checked_at": null,
+      "path": "/",
+      "paused_at": null,
+      "port": 80,
+      "receptor_node": null,
+      "role": null,
+      "scheme": "https",
+      "source_id": 1,
+      "tenant": "12345",
+      "updated_at": "2021-12-06 20:00:14 CET",
+      "verify_ssl": null
+    }
+  ],
+  "source": {
+    "app_creation_workflow": "manual_configuration",
+    "availability_status": "available",
+    "created_at": "2021-12-06 20:00:14 CET",
+    "id": 1,
+    "imported": null,
+    "last_available_at": "2021-12-06 21:00:14 CET",
+    "last_checked_at": "2021-12-06 21:00:14 CET",
+    "name": "Source1",
+    "paused_at": null,
+    "source_ref": null,
+    "source_type_id": 1,
+    "tenant": "12345",
+    "uid": "5eebe172-7baa-4280-823f-19e597d091e9",
+    "updated_at": "2021-12-06 20:00:14 CET",
+    "version": null
+  },
+  "updated": {
+    "Source": {
+      "1": [
+        "availability_status",
+        "last_available_at",
+        "last_checked_at"
+      ]
+    }
+  }
+}

--- a/statuslistener/test_data/resource_Application_1.json
+++ b/statuslistener/test_data/resource_Application_1.json
@@ -1,0 +1,17 @@
+{
+  "application_type_id": 1,
+  "availability_status": "available",
+  "availability_status_error": null,
+  "created_at": "2021-12-06 18:06:05 CET",
+  "extra": {
+    "extra": true
+  },
+  "id": 1,
+  "last_available_at": "2021-12-06 19:06:09 CET",
+  "last_checked_at": "2021-12-06 19:06:09 CET",
+  "paused_at": null,
+  "source_id": 1,
+  "superkey_data": null,
+  "tenant": "12345",
+  "updated_at": "2021-12-06 18:06:09 CET"
+}

--- a/statuslistener/test_data/resource_Endpoint_1.json
+++ b/statuslistener/test_data/resource_Endpoint_1.json
@@ -1,0 +1,21 @@
+{
+  "availability_status": "available",
+  "availability_status_error": "",
+  "certificate_authority": null,
+  "created_at": "2021-12-06 18:04:54 CET",
+  "default": true,
+  "host": "openshift.example.com",
+  "id": 1,
+  "last_available_at": "2021-12-06 19:04:58 CET",
+  "last_checked_at": "2021-12-06 19:04:58 CET",
+  "path": "/",
+  "paused_at": null,
+  "port": 80,
+  "receptor_node": null,
+  "role": null,
+  "scheme": "http",
+  "source_id": 1,
+  "tenant": "12345",
+  "updated_at": "2021-12-06 18:04:58 CET",
+  "verify_ssl": null
+}

--- a/statuslistener/test_data/resource_Source_1.json
+++ b/statuslistener/test_data/resource_Source_1.json
@@ -1,0 +1,17 @@
+{
+  "app_creation_workflow": "manual_configuration",
+  "availability_status": "available",
+  "created_at": "2021-11-29 14:55:13 CET",
+  "id": 1,
+  "imported": null,
+  "last_available_at": "2021-11-29 17:31:08 CET",
+  "last_checked_at": "2021-11-29 17:31:08 CET",
+  "name": "Source1",
+  "paused_at": null,
+  "source_ref": null,
+  "source_type_id": 1,
+  "tenant": "12345",
+  "uid": "5eebe172-7baa-4280-823f-19e597d091e9",
+  "updated_at": "2021-11-29 16:31:08 CET",
+  "version": null
+}

--- a/statuslistener/types.go
+++ b/statuslistener/types.go
@@ -1,0 +1,8 @@
+package statuslistener
+
+type StatusMessage struct {
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id"`
+	Status       string `json:"status"`
+	Error        string `json:"error"`
+}

--- a/util/parser.go
+++ b/util/parser.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"strconv"
+	"time"
 )
 
 // InterfaceToInt64 takes an interface and returns an int64 for any float64, int64 or string received -whether they
@@ -45,4 +46,27 @@ func InterfaceToInt64(i interface{}) (int64, error) {
 	default:
 		return 0, fmt.Errorf("invalid format provided")
 	}
+}
+
+func StringValueOrNil(inputValue interface{}) *string {
+	switch value := inputValue.(type) {
+	case string:
+		if value == "" {
+			return nil
+		}
+
+		return &value
+	case *string:
+		return value
+	default:
+		return nil
+	}
+}
+
+func FormatTimeToString(inputTime time.Time, format string) string {
+	if inputTime.IsZero() {
+		return ""
+	}
+
+	return inputTime.Format(format)
 }

--- a/util/parser.go
+++ b/util/parser.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+var RecordDateTimeFormat = "2006-01-02 15:04:05 MST"
+
 // InterfaceToInt64 takes an interface and returns an int64 for any float64, int64 or string received -whether they
 // are pointers or not-.
 func InterfaceToInt64(i interface{}) (int64, error) {

--- a/util/parser.go
+++ b/util/parser.go
@@ -72,3 +72,7 @@ func FormatTimeToString(inputTime time.Time, format string) string {
 
 	return inputTime.Format(format)
 }
+
+func DateTimeToRecordFormat(inputTime time.Time) *string {
+	return StringValueOrNil(FormatTimeToString(inputTime, RecordDateTimeFormat))
+}


### PR DESCRIPTION
- [x] [this](https://github.com/RedHatInsights/sources-api-go/pull/51)  needs to be merged first.
---

Converts ruby (Availability Status Listener https://github.com/RedHatInsights/sources-api/blob/master/lib/availability_status_listener.rb) to GO

[Checks](https://github.com/RedHatInsights/sources-api/blob/master/lib/availability_status_listener.rb#L43-L48) skipped for `x-rh-identity`, `x-rh-sources-account-number` in headers of Kafka message

Missing:
- [x] Tests

Following:
- add `raiseForUpdate` to missing places https://issues.redhat.com/browse/RHCLOUD-17055
- possibility to disable Availability Status Listener in ruby repo by ENV
- go routines for `RaiseEventForUpdate` https://issues.redhat.com/browse/RHCLOUD-17056
- Authentication and ApplicationAuthentication are not included https://issues.redhat.com/browse/RHCLOUD-17059
