### PR TITLE
Test subpackages   in integration testing

### DIFF
--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"fmt"
+
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 )

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -2,7 +2,6 @@ package dao
 
 import (
 	"fmt"
-
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 )
@@ -85,10 +84,10 @@ func (a *EndpointDaoImpl) Tenant() *int64 {
 
 func (a *EndpointDaoImpl) CanEndpointBeSetAsDefaultForSource(sourceId int64) bool {
 	endpoint := &m.Endpoint{}
+
 	// add double quotes to the "default" column to avoid any clashes with postgres' "default" keyword
 	result := DB.Where(`"default" = true AND source_id = ?`, sourceId).First(&endpoint)
-
-	return result.Error == nil
+	return result.Error != nil
 }
 
 func (a *EndpointDaoImpl) IsRoleUniqueForSource(role string, sourceId int64) bool {

--- a/internal/testutils/database.go
+++ b/internal/testutils/database.go
@@ -29,8 +29,6 @@ func ConnectToTestDB() {
 
 	// Set the dao.DB in case any tests want to use it
 	dao.DB = db
-	// Migrate the schema for the first time
-	MigrateSchema()
 }
 
 // CreateFixtures creates the following fixtures for the database —listed in order—:

--- a/internal/testutils/database.go
+++ b/internal/testutils/database.go
@@ -98,6 +98,8 @@ func DropSchema() {
 // MigrateSchema migrates all the models.
 func MigrateSchema() {
 	err := dao.DB.AutoMigrate(
+		&m.Tenant{},
+		
 		&m.SourceType{},
 		&m.ApplicationType{},
 

--- a/internal/testutils/fixtures.go
+++ b/internal/testutils/fixtures.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"gorm.io/datatypes"
+	"time"
 )
 
 var TestTenantData = []m.Tenant{
@@ -27,9 +28,23 @@ var TestApplicationData = []m.Application{
 	{ID: 2, Extra: datatypes.JSON("{\"extra\": false}"), ApplicationTypeID: 1, SourceID: 1, TenantID: 1},
 }
 
+var (
+	CreatedAt, _        = time.Parse("2006-01-02T15:04:05.999Z", "2021-11-26 18:47:19 CET")
+	UpdatedAt           = CreatedAt
+	port                = 80
+	defaultValueSource1 = true
+	defaultValueSource2 = false
+	scheme1             = "http"
+	host1               = "openshift.example.com"
+	path1               = "/"
+	scheme2             = "https"
+	host2               = "tower.example.com"
+	path2               = "/"
+)
+
 var TestEndpointData = []m.Endpoint{
-	{ID: 1, SourceID: 1, TenantID: 1},
-	{ID: 2, SourceID: 1, TenantID: 1},
+	{ID: 1, SourceID: 1, TenantID: 1, Port: &port, Default: &defaultValueSource1, Scheme: &scheme1, Host: &host1, Path: &path1, CreatedAt: CreatedAt, UpdatedAt: UpdatedAt},
+	{ID: 2, SourceID: 1, TenantID: 1, Port: &port, Default: &defaultValueSource2, Scheme: &scheme2, Host: &host2, Path: &path2, CreatedAt: CreatedAt, UpdatedAt: UpdatedAt},
 }
 
 var TestMetaDataData = []m.MetaData{

--- a/internal/testutils/fixtures.go
+++ b/internal/testutils/fixtures.go
@@ -1,9 +1,10 @@
 package testutils
 
 import (
+	"time"
+
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"gorm.io/datatypes"
-	"time"
 )
 
 var TestTenantData = []m.Tenant{

--- a/kafka/main_test.go
+++ b/kafka/main_test.go
@@ -1,0 +1,16 @@
+package kafka
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestMain(t *testing.M) {
+	// we need this to parse arguments otherwise there are not recognized which lead to error
+	flag.Bool("createdb", false, "create the test database")
+	flag.Bool("integration", false, "run unit or integration tests")
+	flag.Parse()
+
+	os.Exit(t.Run())
+}

--- a/main_test.go
+++ b/main_test.go
@@ -29,8 +29,8 @@ func TestMain(t *testing.M) {
 	if flags.CreateDb {
 		testutils.CreateTestDB()
 	} else if flags.Integration {
-		testutils.ConnectToTestDB()
-		testutils.MigrateSchema()
+		testutils.ConnectAndMigrateDB("public")
+
 		getSourceDao = getSourceDaoWithTenant
 		getApplicationDao = getApplicationDaoWithTenant
 		getEndpointDao = getEndpointDaoWithTenant
@@ -60,7 +60,7 @@ func TestMain(t *testing.M) {
 	code := t.Run()
 
 	if flags.Integration {
-		testutils.DropSchema()
+		testutils.DropSchema("public")
 	}
 
 	os.Exit(code)

--- a/main_test.go
+++ b/main_test.go
@@ -30,6 +30,7 @@ func TestMain(t *testing.M) {
 		testutils.CreateTestDB()
 	} else if flags.Integration {
 		testutils.ConnectToTestDB()
+		testutils.MigrateSchema()
 		getSourceDao = getSourceDaoWithTenant
 		getApplicationDao = getApplicationDaoWithTenant
 		getEndpointDao = getEndpointDaoWithTenant

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"flag"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -15,6 +16,10 @@ var e *echo.Echo
 var conf = config.Get()
 
 func TestMain(t *testing.M) {
+	flag.Bool("createdb", false, "create the test database")
+	flag.Bool("integration", false, "run unit or integration tests")
+	flag.Parse()
+
 	l.InitLogger(conf)
 	e = echo.New()
 	code := t.Run()

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -40,7 +40,7 @@ export DATABASE_PASSWORD=toor
 export DATABASE_NAME=sources_api_test_go
 
 echo "Running tests...here we go"
-go test -integration
+go test ./... --integration
 OUT_CODE=$?
 
 echo "Killing DB Container..."

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -23,8 +23,7 @@ func TestMain(t *testing.M) {
 		testutils.CreateTestDB()
 	} else if flags.Integration {
 		runningIntegration = true
-		testutils.ConnectToTestDB()
-		testutils.MigrateSchema()
+		testutils.ConnectAndMigrateDB("service")
 
 		endpointDao = &dao.EndpointDaoImpl{TenantID: &testutils.TestTenantData[0].Id}
 		sourceDao = &dao.SourceDaoImpl{TenantID: &testutils.TestTenantData[0].Id}
@@ -37,7 +36,7 @@ func TestMain(t *testing.M) {
 	code := t.Run()
 
 	if flags.Integration {
-		testutils.DropSchema()
+		testutils.DropSchema("service")
 	}
 
 	os.Exit(code)

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -24,6 +24,7 @@ func TestMain(t *testing.M) {
 	} else if flags.Integration {
 		runningIntegration = true
 		testutils.ConnectToTestDB()
+		testutils.MigrateSchema()
 
 		endpointDao = &dao.EndpointDaoImpl{TenantID: &testutils.TestTenantData[0].Id}
 		sourceDao = &dao.SourceDaoImpl{TenantID: &testutils.TestTenantData[0].Id}

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestMain(t *testing.M) {
+	// we need this to parse arguments otherwise there are not recognized which lead to error
+	flag.Bool("createdb", false, "create the test database")
+	flag.Bool("integration", false, "run unit or integration tests")
+	flag.Parse()
+
+	os.Exit(t.Run())
+}


### PR DESCRIPTION

- we were not testing submodules in integration testing by command `go test ./... --integration`
- it reveals couple places which requires changes:
   - Failing test `TestDefaultEndpointAlreadyExists`: 
     - Fix `Endpoints#CanEndpointBeSetAsDefaultForSource` checks for existence of records by **count** query
     - Extend test data for endpoints (`TestEndpointData`) so we can simulate that default endpoints with certain SourceId already exists (check is present in `Endpoints#CanEndpointBeSetAsDefaultForSource`)
- Tests were failing for submodules but arguments were not processed
   - error message: `flag provided but not defined: -integration` 
   - `testutils.ParseFlags()` was not used because of circle dependency error
   - some submodules required also `os.Exit(t.Run())`
- `go test ./... --integration` added to `pr_check.sh` 
- fixed sporadic failure most likely caused that tests for [different packages run in parallel](https://github.com/golang/go/blob/4df662fb373480b5055e645120558bb536fae42c/src/cmd/go/internal/test/test.go#L255)
  -  solution is that for each package is created own schema and thanks to that tests from various packages cannot affect each other 

### Sporadic failure Reproducer
- run db from container as we have [here](https://github.com/RedHatInsights/sources-api-go/blob/main/pr_check.sh#L33-L49) 
- run test multiple times:
```
go test ./... --integration -v
```
- it should fails sporadically and even each failing run fails thanks to different test
