### PR TITLE
Add PSK Check for write endpoints

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
+)
+
+var PSKS = conf.Psks
+
+func permissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		switch {
+		case c.Get("psk") != nil:
+			psk, ok := c.Get("psk").(string)
+			if !ok {
+				return fmt.Errorf("error casting psk to string: %v", psk)
+			}
+
+			if !pskMatches(psk) {
+				return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Unauthorized Action: Incorrect PSK", "401"))
+			}
+		case c.Get("x-rh-identity") != nil:
+			// TODO: Hit RBAC
+		default:
+			return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Authentication required by either [x-rh-identity] or [x-rh-sources-psk]", "401"))
+		}
+
+		return next(c)
+	}
+}
+
+func pskMatches(psk string) bool {
+	return util.SliceContainsString(PSKS, psk)
+}

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/labstack/echo/v4"
+)
+
+var checkPSKOrElse204 = permissionCheck(echo.HandlerFunc(func(c echo.Context) error {
+	return c.NoContent(http.StatusNoContent)
+}))
+
+func TestPSKMatches(t *testing.T) {
+	PSKS = []string{"1234"}
+	if pskMatches("1234") != true {
+		t.Errorf("psk didn't match when it should have")
+	}
+
+	if pskMatches("12345") == true {
+		t.Errorf("psk matched when it should not have")
+	}
+}
+
+func TestGoodPSK(t *testing.T) {
+	PSKS = []string{"1234"}
+	c, rec := testutils.CreateTestContext(
+		"POST",
+		"/",
+		nil,
+		map[string]interface{}{"psk": "1234"},
+	)
+
+	err := checkPSKOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one")
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 200)
+	}
+}
+
+func TestBadPSK(t *testing.T) {
+	PSKS = []string{"abcdef"}
+	c, rec := testutils.CreateTestContext(
+		"POST",
+		"/",
+		nil,
+		map[string]interface{}{"psk": "1234"},
+	)
+
+	err := checkPSKOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one")
+	}
+
+	if rec.Code != 401 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 401)
+	}
+}
+
+func TestNoPSK(t *testing.T) {
+	PSKS = []string{"abcdef"}
+	c, rec := testutils.CreateTestContext(
+		"POST",
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	err := checkPSKOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one")
+	}
+
+	if rec.Code != 401 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 401)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/spf13/viper"
@@ -35,6 +36,7 @@ type SourcesApiConfig struct {
 	CachePort                 int
 	CachePassword             string
 	SlowSQLThreshold          int
+	Psks                      []string
 }
 
 // Get - returns the config parsed from runtime vars
@@ -109,6 +111,8 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("Hostname", hostname)
 	options.SetDefault("AppName", "source-api-go")
 
+	options.SetDefault("psks", strings.Split(os.Getenv("SOURCES_PSKS"), ","))
+
 	options.AutomaticEnv()
 	parsedConfig = &SourcesApiConfig{
 		AppName:                   options.GetString("AppName"),
@@ -132,6 +136,7 @@ func Get() *SourcesApiConfig {
 		CacheHost:                 options.GetString("CacheHost"),
 		CachePort:                 options.GetInt("CachePort"),
 		CachePassword:             options.GetString("CachePassword"),
+		Psks:                      options.GetStringSlice("psks"),
 	}
 
 	return parsedConfig

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -32,6 +32,12 @@ objects:
               optional: true
         - name: RBAC_URL
           value: ${RBAC_SCHEME}://${RBAC_HOST}:${RBAC_PORT}
+        - name: SOURCES_PSKS
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-secrets
+              key: psks
+              optional: true
         readinessProbe:
           tcpSocket:
             port: 8000

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	appconf "github.com/RedHatInsights/sources-api-go/config"
@@ -57,7 +58,7 @@ func forwardLogsToStderr(logHandler string) bool {
 func LogrusLogLevelFrom(configLogLevel string) logrus.Level {
 	var logLevel logrus.Level
 
-	switch configLogLevel {
+	switch strings.ToUpper(configLogLevel) {
 	case "DEBUG":
 		logLevel = logrus.DebugLevel
 	case "ERROR":
@@ -152,7 +153,7 @@ func (f *CustomLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 func logLevelToEchoLogLevel(configLogLevel string) echoLog.Lvl {
 	var logLevel echoLog.Lvl
 
-	switch configLogLevel {
+	switch strings.ToUpper(configLogLevel) {
 	case "DEBUG":
 		logLevel = echoLog.DEBUG
 	case "ERROR":


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-17253

Adding some middleware for checking against `SOURCES_PSKS` for `POST/PATCH/DELETE` calls.

Will probably make a follow-up that builds on this but for the rbac side of thigns, it'll follow the same flow except instead of comparing to a list stored in the environment it will hit the rbac service.