### PR TITLE
[RHCLOUD-17247] Fetch tokens from marketplace and store them in an struct

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,7 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("LogHandler", os.Getenv("LOG_HANDLER"))
 	options.SetDefault("LogLevelForMiddlewareLogs", "DEBUG")
 	options.SetDefault("LogLevelForSqlLogs", "DEBUG")
+	options.SetDefault("MarketplaceHost", "MARKETPLACE_HOST")
 	options.SetDefault("SlowSQLThreshold", 2) //seconds
 	options.SetDefault("BypassRbac", os.Getenv("BYPASS_RBAC") == "true")
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type SourcesApiConfig struct {
 	LogGroup                  string
 	LogHandler                string
 	LogLevelForSqlLogs        string
+	MarketplaceHost           string
 	AwsRegion                 string
 	AwsAccessKeyID            string
 	AwsSecretAccessKey        string
@@ -128,6 +129,7 @@ func Get() *SourcesApiConfig {
 		LogLevelForMiddlewareLogs: options.GetString("LogLevelForMiddlewareLogs"),
 		LogHandler:                options.GetString("LogHandler"),
 		LogGroup:                  options.GetString("LogGroup"),
+		MarketplaceHost:           options.GetString("MarketplaceHost"),
 		AwsRegion:                 options.GetString("AwsRegion"),
 		AwsAccessKeyID:            options.GetString("AwsAccessKeyID"),
 		AwsSecretAccessKey:        options.GetString("AwsSecretAccessKey"),

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -162,3 +162,8 @@ parameters:
   name: RBAC_PATH
   required: true
   value: /api/rbac/v1/
+- description: Host to user for the marketplace URL.
+  displayName: Marketplace host URL
+  name: MARKETPLACE_HOST
+  required: true
+  value: 'https://sandbox.marketplace.redhat.com'

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/marketplace"
 	"github.com/RedHatInsights/sources-api-go/redis"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -39,6 +40,9 @@ func main() {
 	getSourceTypeDao = getSourceTypeDaoWithoutTenant
 	getEndpointDao = getEndpointDaoWithTenant
 	getMetaDataDao = getMetaDataDaoWithTenant
+
+	// setting up the "http.Client" for the marketplace token provider
+	marketplace.GetHttpClient = marketplace.GetHttpClientStdlib
 
 	e.Logger.Fatal(e.Start(":8000"))
 }

--- a/marketplace/main_test.go
+++ b/marketplace/main_test.go
@@ -1,0 +1,15 @@
+package marketplace
+
+import (
+	"os"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+)
+
+func TestMain(t *testing.M) {
+	// we need this to parse arguments otherwise there are not recognized which lead to error
+	_ = testutils.ParseFlags()
+
+	os.Exit(t.Run())
+}

--- a/marketplace/markeptlace_token_provider_test.go
+++ b/marketplace/markeptlace_token_provider_test.go
@@ -29,7 +29,9 @@ func (h httpClientInvalidStatusCodeResponse) Do(req *http.Request) (*http.Respon
 
 // TestNotReachingMarketplace tests that an error is returned when an error occurs within the HTTP Client.
 func TestNotReachingMarketplace(t *testing.T) {
-	_, err := GetToken(&httpClientErrorRequest{}, "a")
+	GetHttpClient = func() HttpClient { return httpClientErrorRequest{} }
+
+	_, err := GetToken("a")
 
 	if err == nil {
 		t.Errorf("want error, got none")
@@ -44,7 +46,9 @@ func TestNotReachingMarketplace(t *testing.T) {
 // TestInvalidStatusCodeReturnsError checks that an error is returned when a non 200 status code is returned on the
 // response from the marketplace.
 func TestInvalidStatusCodeReturnsError(t *testing.T) {
-	_, err := GetToken(&httpClientInvalidStatusCodeResponse{}, "a")
+	GetHttpClient = func() HttpClient { return httpClientInvalidStatusCodeResponse{} }
+
+	_, err := GetToken("a")
 
 	if err == nil {
 		t.Errorf("want error, got none")

--- a/marketplace/markeptlace_token_provider_test.go
+++ b/marketplace/markeptlace_token_provider_test.go
@@ -27,11 +27,15 @@ func (h httpClientInvalidStatusCodeResponse) Do(req *http.Request) (*http.Respon
 	return &response, nil
 }
 
+// Fake variables for the tests
+var fakeApiKey = "fakeApiKey"
+var marketplaceTokenProvider = &MarketplaceTokenProvider{ApiKey: &fakeApiKey}
+
 // TestNotReachingMarketplace tests that an error is returned when an error occurs within the HTTP Client.
 func TestNotReachingMarketplace(t *testing.T) {
 	GetHttpClient = func() HttpClient { return httpClientErrorRequest{} }
 
-	_, err := GetToken("a")
+	_, err := marketplaceTokenProvider.RequestToken()
 
 	if err == nil {
 		t.Errorf("want error, got none")
@@ -48,7 +52,7 @@ func TestNotReachingMarketplace(t *testing.T) {
 func TestInvalidStatusCodeReturnsError(t *testing.T) {
 	GetHttpClient = func() HttpClient { return httpClientInvalidStatusCodeResponse{} }
 
-	_, err := GetToken("a")
+	_, err := marketplaceTokenProvider.RequestToken()
 
 	if err == nil {
 		t.Errorf("want error, got none")

--- a/marketplace/markeptlace_token_provider_test.go
+++ b/marketplace/markeptlace_token_provider_test.go
@@ -1,0 +1,57 @@
+package marketplace
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// httpClientErrorRequest is a mock of the http.Client object which always returns an error when the ".Do" function
+// gets called.
+type httpClientErrorRequest struct{}
+
+// httpClientInvalidStatusCodeResponse is a mock of the http.Client which always returns a response with a 400 status
+// code.
+type httpClientInvalidStatusCodeResponse struct{}
+
+// Do returns an error simulating a non-reachability issue to the provided host.
+func (h httpClientErrorRequest) Do(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("simulating not being able to reach the marketplace")
+
+}
+
+// Do returns an empty response with an 400 code.
+func (h httpClientInvalidStatusCodeResponse) Do(req *http.Request) (*http.Response, error) {
+	response := http.Response{StatusCode: 400}
+
+	return &response, nil
+}
+
+// TestNotReachingMarketplace tests that an error is returned when an error occurs within the HTTP Client.
+func TestNotReachingMarketplace(t *testing.T) {
+	_, err := GetToken(&httpClientErrorRequest{}, "a", "a")
+
+	if err == nil {
+		t.Errorf("want error, got none")
+	}
+
+	want := "could not perform the request to the marketplace: simulating not being able to reach the marketplace"
+	if err.Error() != want {
+		t.Errorf("want %s, got %s", want, err)
+	}
+}
+
+// TestInvalidStatusCodeReturnsError checks that an error is returned when a non 200 status code is returned on the
+// response from the marketplace.
+func TestInvalidStatusCodeReturnsError(t *testing.T) {
+	_, err := GetToken(&httpClientInvalidStatusCodeResponse{}, "a", "a")
+
+	if err == nil {
+		t.Errorf("want error, got none")
+	}
+
+	want := "unexpected status code received from the marketplace: 400"
+	if err.Error() != want {
+		t.Errorf("want %s, got %s", want, err)
+	}
+}

--- a/marketplace/markeptlace_token_provider_test.go
+++ b/marketplace/markeptlace_token_provider_test.go
@@ -29,7 +29,7 @@ func (h httpClientInvalidStatusCodeResponse) Do(req *http.Request) (*http.Respon
 
 // TestNotReachingMarketplace tests that an error is returned when an error occurs within the HTTP Client.
 func TestNotReachingMarketplace(t *testing.T) {
-	_, err := GetToken(&httpClientErrorRequest{}, "a", "a")
+	_, err := GetToken(&httpClientErrorRequest{}, "a")
 
 	if err == nil {
 		t.Errorf("want error, got none")
@@ -44,7 +44,7 @@ func TestNotReachingMarketplace(t *testing.T) {
 // TestInvalidStatusCodeReturnsError checks that an error is returned when a non 200 status code is returned on the
 // response from the marketplace.
 func TestInvalidStatusCodeReturnsError(t *testing.T) {
-	_, err := GetToken(&httpClientInvalidStatusCodeResponse{}, "a", "a")
+	_, err := GetToken(&httpClientInvalidStatusCodeResponse{}, "a")
 
 	if err == nil {
 		t.Errorf("want error, got none")

--- a/marketplace/marketplace_token_provider.go
+++ b/marketplace/marketplace_token_provider.go
@@ -14,7 +14,7 @@ type httpClient interface {
 }
 
 // GetToken sends a request to the marketplace to request a bearer token.
-func GetToken(httpClient httpClient, marketplaceHost string, apiKey string) (BearerToken, error) {
+func GetToken(httpClient httpClient, marketplaceHost string, apiKey string) (*BearerToken, error) {
 	// Reference docs for the request: https://marketplace.redhat.com/en-us/documentation/api-authentication
 	data := url.Values{}
 	data.Set("apikey", apiKey)
@@ -27,7 +27,7 @@ func GetToken(httpClient httpClient, marketplaceHost string, apiKey string) (Bea
 	)
 
 	if err != nil {
-		return BearerToken{}, fmt.Errorf("could not create the request object: %s", err)
+		return nil, fmt.Errorf("could not create the request object: %s", err)
 	}
 
 	// Set the proper headers to accept JSON, and let the server know we're sending urlencoded data.
@@ -36,11 +36,11 @@ func GetToken(httpClient httpClient, marketplaceHost string, apiKey string) (Bea
 
 	response, err := httpClient.Do(request)
 	if err != nil {
-		return BearerToken{}, fmt.Errorf("could not perform the request to the marketplace: %s", err)
+		return nil, fmt.Errorf("could not perform the request to the marketplace: %s", err)
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return BearerToken{}, fmt.Errorf("unexpected status code received from the marketplace: %d", response.StatusCode)
+		return nil, fmt.Errorf("unexpected status code received from the marketplace: %d", response.StatusCode)
 	}
 
 	return DecodeMarketplaceTokenFromResponse(response)

--- a/marketplace/marketplace_token_provider.go
+++ b/marketplace/marketplace_token_provider.go
@@ -1,0 +1,42 @@
+package marketplace
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// GetToken sends a request to the marketplace to request a bearer token.
+func GetToken(marketplaceHost string, apiKey string) (BearerToken, error) {
+	// Reference docs for the request: https://marketplace.redhat.com/en-us/documentation/api-authentication
+	data := url.Values{}
+	data.Set("apikey", apiKey)
+	data.Set("grant_type", "urn:ibm:params:oauth:grant-type:apikey")
+
+	client := http.Client{}
+	request, err := http.NewRequest(
+		"POST",
+		marketplaceHost+"/api-security/om-auth/cloud/token",
+		strings.NewReader(data.Encode()),
+	)
+
+	if err != nil {
+		return BearerToken{}, fmt.Errorf("could not create the request object: %s", err)
+	}
+
+	// Set the proper headers to accept JSON, and let the server know we're sending urlencoded data.
+	request.Header.Add("Accept", "application/json")
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return BearerToken{}, fmt.Errorf("could not perform the request to the marketplace: %s", err)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return BearerToken{}, fmt.Errorf("unexpected status code received from the marketplace: %d", response.StatusCode)
+	}
+
+	return DecodeMarketplaceTokenFromResponse(response)
+}

--- a/marketplace/marketplace_token_provider.go
+++ b/marketplace/marketplace_token_provider.go
@@ -7,8 +7,14 @@ import (
 	"strings"
 )
 
+// httpClient abstracts away the client to be used in the GetToken function, and allows mocking it easily for the
+// tests.
+type httpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // GetToken sends a request to the marketplace to request a bearer token.
-func GetToken(marketplaceHost string, apiKey string) (BearerToken, error) {
+func GetToken(httpClient httpClient, marketplaceHost string, apiKey string) (BearerToken, error) {
 	// Reference docs for the request: https://marketplace.redhat.com/en-us/documentation/api-authentication
 	data := url.Values{}
 	data.Set("apikey", apiKey)
@@ -28,8 +34,7 @@ func GetToken(marketplaceHost string, apiKey string) (BearerToken, error) {
 	request.Header.Add("Accept", "application/json")
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	client := http.Client{}
-	response, err := client.Do(request)
+	response, err := httpClient.Do(request)
 	if err != nil {
 		return BearerToken{}, fmt.Errorf("could not perform the request to the marketplace: %s", err)
 	}

--- a/marketplace/marketplace_token_provider.go
+++ b/marketplace/marketplace_token_provider.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/RedHatInsights/sources-api-go/config"
 )
 
 // httpClient abstracts away the client to be used in the GetToken function, and allows mocking it easily for the
@@ -14,7 +16,7 @@ type httpClient interface {
 }
 
 // GetToken sends a request to the marketplace to request a bearer token.
-func GetToken(httpClient httpClient, marketplaceHost string, apiKey string) (*BearerToken, error) {
+func GetToken(httpClient httpClient, apiKey string) (*BearerToken, error) {
 	// Reference docs for the request: https://marketplace.redhat.com/en-us/documentation/api-authentication
 	data := url.Values{}
 	data.Set("apikey", apiKey)
@@ -22,7 +24,7 @@ func GetToken(httpClient httpClient, marketplaceHost string, apiKey string) (*Be
 
 	request, err := http.NewRequest(
 		"POST",
-		marketplaceHost+"/api-security/om-auth/cloud/token",
+		config.Get().MarketplaceHost+"/api-security/om-auth/cloud/token",
 		strings.NewReader(data.Encode()),
 	)
 

--- a/marketplace/marketplace_token_provider.go
+++ b/marketplace/marketplace_token_provider.go
@@ -24,11 +24,22 @@ func GetHttpClientStdlib() HttpClient {
 	return &http.Client{Timeout: 10}
 }
 
-// GetToken sends a request to the marketplace to request a bearer token.
-func GetToken(apiKey string) (*BearerToken, error) {
+type TokenProvider interface {
+	// RequestToken returns a bearer token using the given API Key.
+	RequestToken() (*BearerToken, error)
+}
+
+// MarketplaceTokenProvider is a type that satisfies the "TokenProvider" interface. The aim is to abstract away the
+// injection of this dependency on other code, which will make testing easier.
+type MarketplaceTokenProvider struct {
+	ApiKey *string
+}
+
+// RequestToken sends a request to the marketplace to request a bearer token.
+func (mtp *MarketplaceTokenProvider) RequestToken() (*BearerToken, error) {
 	// Reference docs for the request: https://marketplace.redhat.com/en-us/documentation/api-authentication
 	data := url.Values{}
-	data.Set("apikey", apiKey)
+	data.Set("apikey", *mtp.ApiKey)
 	data.Set("grant_type", "urn:ibm:params:oauth:grant-type:apikey")
 
 	request, err := http.NewRequest(

--- a/marketplace/marketplace_token_provider.go
+++ b/marketplace/marketplace_token_provider.go
@@ -14,7 +14,6 @@ func GetToken(marketplaceHost string, apiKey string) (BearerToken, error) {
 	data.Set("apikey", apiKey)
 	data.Set("grant_type", "urn:ibm:params:oauth:grant-type:apikey")
 
-	client := http.Client{}
 	request, err := http.NewRequest(
 		"POST",
 		marketplaceHost+"/api-security/om-auth/cloud/token",
@@ -29,6 +28,7 @@ func GetToken(marketplaceHost string, apiKey string) (BearerToken, error) {
 	request.Header.Add("Accept", "application/json")
 	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
+	client := http.Client{}
 	response, err := client.Do(request)
 	if err != nil {
 		return BearerToken{}, fmt.Errorf("could not perform the request to the marketplace: %s", err)

--- a/marketplace/token.go
+++ b/marketplace/token.go
@@ -1,0 +1,26 @@
+package marketplace
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// BearerToken represents the bearer token sent by the marketplace, and includes the Unix timestamp of the time when
+// it expires.
+type BearerToken struct {
+	Expiration int    `json:"expiration"`
+	Token      string `json:"access_token"`
+}
+
+// DecodeMarketplaceTokenFromResponse decodes the bearer token and the expiration timestamp from the received
+// response.
+func DecodeMarketplaceTokenFromResponse(response *http.Response) (BearerToken, error) {
+	token := BearerToken{}
+
+	err := json.NewDecoder(response.Body).Decode(&token)
+	if err != nil {
+		return BearerToken{}, err
+	}
+
+	return token, nil
+}

--- a/marketplace/token.go
+++ b/marketplace/token.go
@@ -15,17 +15,17 @@ type BearerToken struct {
 
 // DecodeMarketplaceTokenFromResponse decodes the bearer token and the expiration timestamp from the received
 // response.
-func DecodeMarketplaceTokenFromResponse(response *http.Response) (BearerToken, error) {
+func DecodeMarketplaceTokenFromResponse(response *http.Response) (*BearerToken, error) {
 	token := BearerToken{}
 
 	err := json.NewDecoder(response.Body).Decode(&token)
 	if err != nil {
-		return BearerToken{}, err
+		return nil, err
 	}
 
 	if token.Expiration == 0 || token.Token == "" {
 		return BearerToken{}, fmt.Errorf("unexpected JSON structure received from the marketplace")
 	}
 
-	return token, nil
+	return &token, nil
 }

--- a/marketplace/token.go
+++ b/marketplace/token.go
@@ -9,8 +9,8 @@ import (
 // BearerToken represents the bearer token sent by the marketplace, and includes the Unix timestamp of the time when
 // it expires.
 type BearerToken struct {
-	Expiration int    `json:"expiration"`
-	Token      string `json:"access_token"`
+	Expiration *int    `json:"expiration"`
+	Token      *string `json:"access_token"`
 }
 
 // DecodeMarketplaceTokenFromResponse decodes the bearer token and the expiration timestamp from the received
@@ -23,8 +23,8 @@ func DecodeMarketplaceTokenFromResponse(response *http.Response) (*BearerToken, 
 		return nil, err
 	}
 
-	if token.Expiration == 0 || token.Token == "" {
-		return BearerToken{}, fmt.Errorf("unexpected JSON structure received from the marketplace")
+	if token.Expiration == nil || token.Token == nil {
+		return nil, fmt.Errorf("unexpected JSON structure received from the marketplace")
 	}
 
 	return &token, nil

--- a/marketplace/token.go
+++ b/marketplace/token.go
@@ -3,7 +3,6 @@ package marketplace
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -26,7 +25,7 @@ func DecodeMarketplaceTokenFromResponse(response *http.Response) (*BearerToken, 
 
 	err = response.Body.Close()
 	if err != nil {
-		log.Fatalf("could not close the marketplace JWT token response's body: %s", err)
+		return nil, fmt.Errorf("could not close the marketplace JWT token response's body: %s", err)
 	}
 
 	if token.Expiration == nil || token.Token == nil {

--- a/marketplace/token.go
+++ b/marketplace/token.go
@@ -2,6 +2,7 @@ package marketplace
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -20,6 +21,10 @@ func DecodeMarketplaceTokenFromResponse(response *http.Response) (BearerToken, e
 	err := json.NewDecoder(response.Body).Decode(&token)
 	if err != nil {
 		return BearerToken{}, err
+	}
+
+	if token.Expiration == 0 || token.Token == "" {
+		return BearerToken{}, fmt.Errorf("unexpected JSON structure received from the marketplace")
 	}
 
 	return token, nil

--- a/marketplace/token.go
+++ b/marketplace/token.go
@@ -3,6 +3,7 @@ package marketplace
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 )
 
@@ -21,6 +22,11 @@ func DecodeMarketplaceTokenFromResponse(response *http.Response) (*BearerToken, 
 	err := json.NewDecoder(response.Body).Decode(&token)
 	if err != nil {
 		return nil, err
+	}
+
+	err = response.Body.Close()
+	if err != nil {
+		log.Fatalf("could not close the marketplace JWT token response's body: %s", err)
 	}
 
 	if token.Expiration == nil || token.Token == nil {

--- a/marketplace/token_test.go
+++ b/marketplace/token_test.go
@@ -32,3 +32,35 @@ func TestBearerTokenUnmarshalling(t *testing.T) {
 		t.Errorf("want %d, got %d", expirationTimestamp, token.Expiration)
 	}
 }
+
+// TestInvalidJsonPassed tests that when an invalid JSON is given, the decoding function returns an error.
+func TestInvalidJsonPassed(t *testing.T) {
+	jsonText := `{"access_token":"abcde", "expiration"}`
+
+	readCloser := ioutil.NopCloser(strings.NewReader(jsonText))
+	fakeMarketplaceResponse := http.Response{Body: readCloser}
+
+	_, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
+
+	if err == nil {
+		t.Errorf("want error, got none")
+	}
+}
+
+// TestInvalidStructurePassed tests that an error is thrown when an unexpected JSON structure is sent by the
+// marketplace. For an "unexpected structure" we mean a structure that doesn't contain the access token or
+// the expiration timestamp of it.
+func TestInvalidStructurePassed(t *testing.T) {
+	jsonText := `{"hello": "world"}`
+
+	readCloser := ioutil.NopCloser(strings.NewReader(jsonText))
+	fakeMarketplaceResponse := http.Response{Body: readCloser}
+
+	token, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
+
+	if err == nil {
+		t.Errorf("want error, got none")
+	}
+
+	fmt.Println(token)
+}

--- a/marketplace/token_test.go
+++ b/marketplace/token_test.go
@@ -1,0 +1,34 @@
+package marketplace
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestBearerTokenUnmarshalling tests that upon receiving a properly structured response from the marketplace,
+// the unmarshalling process succeeds.
+func TestBearerTokenUnmarshalling(t *testing.T) {
+	accessTokenValue := "test"
+	expirationTimestamp := 1609455600 // 2021-01-01T00:00:00
+
+	jsonText := fmt.Sprintf(`{"access_token": "%s", "expiration": %d}`, accessTokenValue, expirationTimestamp)
+
+	readCloser := ioutil.NopCloser(strings.NewReader(jsonText))
+	fakeMarketplaceResponse := http.Response{Body: readCloser}
+
+	token, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
+	if err != nil {
+		t.Errorf("want no errors, got %s", err)
+	}
+
+	if accessTokenValue != token.Token {
+		t.Errorf("want %s, got %s", accessTokenValue, token.Token)
+	}
+
+	if expirationTimestamp != token.Expiration {
+		t.Errorf("want %d, got %d", expirationTimestamp, token.Expiration)
+	}
+}

--- a/marketplace/token_test.go
+++ b/marketplace/token_test.go
@@ -56,11 +56,9 @@ func TestInvalidStructurePassed(t *testing.T) {
 	readCloser := ioutil.NopCloser(strings.NewReader(jsonText))
 	fakeMarketplaceResponse := http.Response{Body: readCloser}
 
-	token, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
+	_, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
 
 	if err == nil {
 		t.Errorf("want error, got none")
 	}
-
-	fmt.Println(token)
 }

--- a/marketplace/token_test.go
+++ b/marketplace/token_test.go
@@ -24,11 +24,11 @@ func TestBearerTokenUnmarshalling(t *testing.T) {
 		t.Errorf("want no errors, got %s", err)
 	}
 
-	if accessTokenValue != token.Token {
-		t.Errorf("want %s, got %s", accessTokenValue, token.Token)
+	if accessTokenValue != *token.Token {
+		t.Errorf("want %s, got %s", accessTokenValue, *token.Token)
 	}
 
-	if expirationTimestamp != token.Expiration {
+	if expirationTimestamp != *token.Expiration {
 		t.Errorf("want %d, got %d", expirationTimestamp, token.Expiration)
 	}
 }


### PR DESCRIPTION
Implements a function that calls the marketplace endpoints to get a new token, and extracts the `access_token` and the `expiration` timestamp from the response, to return them in a `BearerToken` struct that we can use latter.

[[RHCLOUD-17247]](https://issues.redhat.com/browse/RHCLOUD-17247)