### PR TITLE
fix: marketplace host not being taken from env variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,7 +99,7 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("LogHandler", os.Getenv("LOG_HANDLER"))
 	options.SetDefault("LogLevelForMiddlewareLogs", "DEBUG")
 	options.SetDefault("LogLevelForSqlLogs", "DEBUG")
-	options.SetDefault("MarketplaceHost", "MARKETPLACE_HOST")
+	options.SetDefault("MarketplaceHost", os.Getenv("MARKETPLACE_HOST"))
 	options.SetDefault("SlowSQLThreshold", 2) //seconds
 	options.SetDefault("BypassRbac", os.Getenv("BYPASS_RBAC") == "true")
 


### PR DESCRIPTION
I forgot to use the "os.Getenv" function, which resulted in the configuration variable having an static string.