### PR TITLE
refactor: replace "testutils" with "testutils/parser"

### DIFF
--- a/marketplace/main_test.go
+++ b/marketplace/main_test.go
@@ -4,12 +4,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 )
 
 func TestMain(t *testing.M) {
 	// we need this to parse arguments otherwise there are not recognized which lead to error
-	_ = testutils.ParseFlags()
+	_ = parser.ParseFlags()
 
 	os.Exit(t.Run())
 }


### PR DESCRIPTION
The "testutils" package was refactored to avoid errors with import
cycles[1]. However, before merging that PR, there was another PR[2]
which didn't include these changes, and that was merged. This has
caused to have some code which now references the "testutils" package
that doesn't exist anymore.

[1]: https://github.com/RedHatInsights/sources-api-go/pull/56
[2]: https://github.com/RedHatInsights/sources-api-go/pull/55