### PR TITLE
move tenancy + permission check authorization to `middleware/` package

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
@@ -19,7 +18,7 @@ func TestSourceApplicationSubcollectionList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)
@@ -77,7 +76,7 @@ func TestApplicationList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
@@ -19,7 +18,7 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)
@@ -76,7 +75,7 @@ func TestApplicationTypeList(t *testing.T) {
 		map[string]interface{}{
 			"limit":   100,
 			"offset":  0,
-			"filters": []middleware.Filter{},
+			"filters": []util.Filter{},
 		},
 	)
 

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -3,15 +3,15 @@ package dao
 import (
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type ApplicationAuthenticationDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationAuthentication, int64, error) {
+func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
 	applications := make([]m.ApplicationAuthentication, 0, limit)
 	query := DB.Debug().Model(&m.ApplicationAuthentication{}).
 		Offset(offset).

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -4,15 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type ApplicationDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
+func (a *ApplicationDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
 	applications := make([]m.Application, 0, limit)
 	sourceType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
@@ -33,7 +33,7 @@ func (a *ApplicationDaoImpl) SubCollectionList(primaryCollection interface{}, li
 	return applications, count, result.Error
 }
 
-func (a *ApplicationDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
+func (a *ApplicationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
 	applications := make([]m.Application, 0, limit)
 	query := DB.Debug().Model(&m.Application{}).
 		Offset(offset).

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -1,15 +1,15 @@
 package dao
 
 import (
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type ApplicationTypeDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {
+func (a *ApplicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
 	// allocating a slice of application types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	applicationTypes := make([]m.ApplicationType, 0, limit)
@@ -30,7 +30,7 @@ func (a *ApplicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}
 	return applicationTypes, count, result.Error
 }
 
-func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {
+func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
 	// allocating a slice of application types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	apptypes := make([]m.ApplicationType, 0, limit)

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/uuid"
 	"github.com/hashicorp/vault/api"
 )
@@ -26,7 +26,7 @@ type AuthenticationDaoImpl struct {
 	TODO: Maybe parallelize fetching multiple records with goroutines +
 	waitgroup
 */
-func (a *AuthenticationDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error) {
+func (a *AuthenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
 	keys, err := a.listKeys()
 	if err != nil {
 		return nil, 0, err

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -4,15 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type EndpointDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *EndpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {
+func (a *EndpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
 
 	sourceType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
@@ -34,7 +34,7 @@ func (a *EndpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit
 	return endpoints, count, result.Error
 }
 
-func (a *EndpointDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {
+func (a *EndpointDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
 	query := DB.Debug().Model(&m.Endpoint{}).
 		Offset(offset).

--- a/dao/filtering.go
+++ b/dao/filtering.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
+	"github.com/RedHatInsights/sources-api-go/util"
 	"gorm.io/gorm"
 )
 
-func applyFilters(query *gorm.DB, filters []middleware.Filter) (*gorm.DB, error) {
+func applyFilters(query *gorm.DB, filters []util.Filter) (*gorm.DB, error) {
 	if query.Statement.Table == "" {
 		err := query.Statement.Parse(query.Statement.Model)
 		if err != nil {

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -1,13 +1,13 @@
 package dao
 
 import (
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type SourceDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error)
+	List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error)
 	GetById(id *int64) (*m.Source, error)
 	Create(src *m.Source) error
 	Update(src *m.Source) error
@@ -17,8 +17,8 @@ type SourceDao interface {
 }
 
 type ApplicationDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.Application, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Application, int64, error)
+	List(limit, offset int, filters []util.Filter) ([]m.Application, int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Application, int64, error)
 	GetById(id *int64) (*m.Application, error)
 	Create(src *m.Application) error
 	Update(src *m.Application) error
@@ -27,7 +27,7 @@ type ApplicationDao interface {
 }
 
 type AuthenticationDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.Authentication, int64, error)
+	List(limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
 	GetById(id string) (*m.Authentication, error)
 	Create(src *m.Authentication) error
 	Update(src *m.Authentication) error
@@ -36,7 +36,7 @@ type AuthenticationDao interface {
 }
 
 type ApplicationAuthenticationDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationAuthentication, int64, error)
+	List(limit, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error)
 	GetById(id *int64) (*m.ApplicationAuthentication, error)
 	Create(src *m.ApplicationAuthentication) error
 	Update(src *m.ApplicationAuthentication) error
@@ -45,8 +45,8 @@ type ApplicationAuthenticationDao interface {
 }
 
 type ApplicationTypeDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error)
+	List(limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error)
 	GetById(id *int64) (*m.ApplicationType, error)
 	Create(src *m.ApplicationType) error
 	Update(src *m.ApplicationType) error
@@ -54,8 +54,8 @@ type ApplicationTypeDao interface {
 }
 
 type EndpointDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error)
+	List(limit, offset int, filters []util.Filter) ([]m.Endpoint, int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Endpoint, int64, error)
 	GetById(id *int64) (*m.Endpoint, error)
 	Create(src *m.Endpoint) error
 	Update(src *m.Endpoint) error
@@ -71,8 +71,8 @@ type EndpointDao interface {
 }
 
 type MetaDataDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error)
-	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error)
+	List(limit, offset int, filters []util.Filter) ([]m.MetaData, int64, error)
+	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.MetaData, int64, error)
 	GetById(id *int64) (*m.MetaData, error)
 	Create(src *m.MetaData) error
 	Update(src *m.MetaData) error
@@ -80,7 +80,7 @@ type MetaDataDao interface {
 }
 
 type SourceTypeDao interface {
-	List(limit, offset int, filters []middleware.Filter) ([]m.SourceType, int64, error)
+	List(limit, offset int, filters []util.Filter) ([]m.SourceType, int64, error)
 	GetById(id *int64) (*m.SourceType, error)
 	Create(src *m.SourceType) error
 	Update(src *m.SourceType) error

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -3,15 +3,15 @@ package dao
 import (
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type MetaDataDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
+func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
 	metadatas := make([]m.MetaData, 0, limit)
 	collection, err := m.NewRelationObject(primaryCollection, -1, DB.Debug())
 	if err != nil {
@@ -33,7 +33,7 @@ func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit
 	return metadatas, count, result.Error
 }
 
-func (a *MetaDataDaoImpl) List(limit int, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
+func (a *MetaDataDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
 	metaData := make([]m.MetaData, 0, limit)
 	query := DB.Debug().Model(&m.MetaData{})
 

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -3,8 +3,8 @@ package dao
 import (
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type MockSourceDao struct {
@@ -30,7 +30,7 @@ type MockMetaDataDao struct {
 	MetaDatas []m.MetaData
 }
 
-func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
+func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	count := int64(1)
 
 	var sources []m.Source
@@ -52,7 +52,7 @@ func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit
 	return sources, count, nil
 }
 
-func (src *MockSourceDao) List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
+func (src *MockSourceDao) List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	count := int64(len(src.Sources))
 	return src.Sources, count, nil
 }
@@ -90,7 +90,7 @@ func (src *MockSourceDao) NameExistsInCurrentTenant(name string) bool {
 	return false
 }
 
-func (a *MockApplicationTypeDao) List(limit int, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {
+func (a *MockApplicationTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
 	count := int64(len(a.ApplicationTypes))
 	return a.ApplicationTypes, count, nil
 }
@@ -105,12 +105,12 @@ func (a *MockApplicationTypeDao) GetById(id *int64) (*m.ApplicationType, error) 
 	return nil, fmt.Errorf("application Type not found")
 }
 
-func (a *MockMetaDataDao) List(limit int, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
+func (a *MockMetaDataDao) List(limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
 	count := int64(len(a.MetaDatas))
 	return a.MetaDatas, count, nil
 }
 
-func (a *MockMetaDataDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.MetaData, int64, error) {
+func (a *MockMetaDataDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
 	count := int64(len(a.MetaDatas))
 	return a.MetaDatas, count, nil
 }
@@ -148,13 +148,13 @@ func (a *MockApplicationTypeDao) Update(src *m.ApplicationType) error {
 func (a *MockApplicationTypeDao) Delete(id *int64) error {
 	panic("not implemented") // TODO: Implement
 }
-func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.ApplicationType, int64, error) {
+func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
 	count := int64(1) // ApplicationType ID=1
 
 	return []m.ApplicationType{a.ApplicationTypes[0]}, count, nil
 }
 
-func (a *MockSourceTypeDao) List(limit int, offset int, filters []middleware.Filter) ([]m.SourceType, int64, error) {
+func (a *MockSourceTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
 	count := int64(len(a.SourceTypes))
 	return a.SourceTypes, count, nil
 }
@@ -181,12 +181,12 @@ func (a *MockSourceTypeDao) Delete(id *int64) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *MockApplicationDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
+func (a *MockApplicationDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Application, int64, error) {
 	count := int64(len(a.Applications))
 	return a.Applications, count, nil
 }
 
-func (a *MockApplicationDao) List(limit int, offset int, filters []middleware.Filter) ([]m.Application, int64, error) {
+func (a *MockApplicationDao) List(limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
 	count := int64(len(a.Applications))
 	return a.Applications, count, nil
 }
@@ -218,12 +218,12 @@ func (a *MockApplicationDao) Tenant() *int64 {
 	return &tenant
 }
 
-func (a *MockEndpointDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {
+func (a *MockEndpointDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	count := int64(len(a.Endpoints))
 	return a.Endpoints, count, nil
 }
 
-func (a *MockEndpointDao) List(limit int, offset int, filters []middleware.Filter) ([]m.Endpoint, int64, error) {
+func (a *MockEndpointDao) List(limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	count := int64(len(a.Endpoints))
 	return a.Endpoints, count, nil
 }

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -4,15 +4,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type SourceDaoImpl struct {
 	TenantID *int64
 }
 
-func (s *SourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
+func (s *SourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	// allocating a slice of source types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	sources := make([]m.Source, 0, limit)
@@ -40,7 +40,7 @@ func (s *SourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 	return sources, count, result.Error
 }
 
-func (s *SourceDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.Source, int64, error) {
+func (s *SourceDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	sources := make([]m.Source, 0, limit)
 	query := DB.Debug().Model(&m.Source{}).
 		Offset(offset).

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -1,14 +1,14 @@
 package dao
 
 import (
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type SourceTypeDaoImpl struct {
 }
 
-func (a *SourceTypeDaoImpl) List(limit, offset int, filters []middleware.Filter) ([]m.SourceType, int64, error) {
+func (a *SourceTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
 	// allocating a slice of source types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	sourceTypes := make([]m.SourceType, 0, limit)

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
@@ -21,7 +20,7 @@ func TestSourceEndpointSubcollectionList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)
@@ -79,7 +78,7 @@ func TestEndpointList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)

--- a/helpers.go
+++ b/helpers.go
@@ -3,16 +3,16 @@ package main
 import (
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware"
+	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
 
-func getFilters(c echo.Context) ([]middleware.Filter, error) {
-	var filters []middleware.Filter
+func getFilters(c echo.Context) ([]util.Filter, error) {
+	var filters []util.Filter
 	var ok bool
 
 	filterVal := c.Get("filters")
-	if filters, ok = filterVal.([]middleware.Filter); !ok {
+	if filters, ok = filterVal.([]util.Filter); !ok {
 		return nil, fmt.Errorf("failed to pull filters from request")
 	}
 

--- a/meta_data_handlers_test.go
+++ b/meta_data_handlers_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
@@ -19,7 +18,7 @@ func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)
@@ -77,7 +76,7 @@ func TestMetaDataList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -1,4 +1,4 @@
-package main
+package middleware
 
 import (
 	"context"
@@ -8,17 +8,27 @@ import (
 	"time"
 
 	"github.com/RedHatInsights/rbac-client-go"
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
 
-var PSKS = conf.Psks
+var PSKS = config.Get().Psks
 
-// TODO: move to middleware package after removing circular dependency
-func permissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
+/*
+	Takes the information stored in the context and returns a 401 if we do not
+	have authorization to perform "write" things such as POST/PATCH/DELETE.
+
+	1. Checks for PSK (if present) and if it is there and matches any of the
+	   PSKs we approve, lets it through.
+
+	2. Sends the x-rh-identity header off to rbac to get an ACL list, and
+	   returns whether or not it contains the correct `sources:*:*` permission.
+*/
+func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		switch {
-		case conf.BypassRbac:
+		case config.Get().BypassRbac:
 			c.Logger().Debugf("Skipping authorization check -- disabled in ENV")
 		case c.Get("psk") != nil:
 			psk, ok := c.Get("psk").(string)
@@ -29,6 +39,7 @@ func permissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			if !pskMatches(psk) {
 				return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Unauthorized Action: Incorrect PSK", "401"))
 			}
+
 		case c.Get("x-rh-identity") != nil:
 			rhid, ok := c.Get("x-rh-identity").(string)
 			if !ok {
@@ -43,6 +54,7 @@ func permissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			if !allowed {
 				return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Unauthorized Action: Missing RBAC permissions", "401"))
 			}
+
 		default:
 			return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Authentication required by either [x-rh-identity] or [x-rh-sources-psk]", "401"))
 		}
@@ -57,11 +69,13 @@ func pskMatches(psk string) bool {
 
 var r = rbac.NewClient(os.Getenv("RBAC_URL"), "sources")
 
-func rbacAllowed(rhid string) (bool, error) {
+// fetches an access list from RBAC based on RBAC_URL and returns whether or not
+// the xrhid has the `sources:*:*` permission
+func rbacAllowed(xrhid string) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	acl, err := r.GetAccess(ctx, rhid, "")
+	acl, err := r.GetAccess(ctx, xrhid, "")
 	if err != nil {
 		return false, err
 	}

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -1,4 +1,4 @@
-package main
+package middleware
 
 import (
 	"net/http"
@@ -8,7 +8,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-var checkPSKOrElse204 = permissionCheck(echo.HandlerFunc(func(c echo.Context) error {
+var checkPSKOrElse204 = PermissionCheck(echo.HandlerFunc(func(c echo.Context) error {
 	return c.NoContent(http.StatusNoContent)
 }))
 

--- a/middleware/filtering.go
+++ b/middleware/filtering.go
@@ -1,20 +1,11 @@
 package middleware
 
 import (
-	"regexp"
 	"strings"
 
+	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
-
-var filterRegex = regexp.MustCompile(`^filter\[(\w+)](\[\w*]|$)`)
-
-// TODO: make the dao package not rely on this.
-type Filter struct {
-	Name      string
-	Operation string
-	Value     []string
-}
 
 func SortAndFilter(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
@@ -28,13 +19,13 @@ func SortAndFilter(next echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
-func parseFilter(c echo.Context) []Filter {
-	f := make([]Filter, 0)
+func parseFilter(c echo.Context) []util.Filter {
+	f := make([]util.Filter, 0)
 	for key, values := range c.QueryParams() {
 		if strings.HasPrefix(key, "filter") {
-			matches := filterRegex.FindAllStringSubmatch(key, -1)
+			matches := util.FilterRegex.FindAllStringSubmatch(key, -1)
 
-			filter := Filter{Name: matches[0][1], Value: values}
+			filter := util.Filter{Name: matches[0][1], Value: values}
 			if len(matches[0]) == 3 {
 				filter.Operation = matches[0][2]
 			}
@@ -46,10 +37,10 @@ func parseFilter(c echo.Context) []Filter {
 	return f
 }
 
-func parseSorting(c echo.Context) *Filter {
+func parseSorting(c echo.Context) *util.Filter {
 	for k, v := range c.QueryParams() {
 		if k == "sort_by" {
-			return &Filter{Operation: "sort_by", Value: v}
+			return &util.Filter{Operation: "sort_by", Value: v}
 		}
 	}
 

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -1,0 +1,76 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+/*
+	Parses all authorization related things into request context, notably:
+
+	1. 'psk' -> x-rh-sources-psk
+
+	2. 'identity' -> parsed version of identity header as a XRHID struct
+
+	3. 'x-rh-identity' -> raw version (b64 encoded) of the identity header
+
+
+	Returns a 401 if we cannot authorize the request from the required headers.
+	For example if we have a psk but no account-number, or if we have neither
+	headers when required.
+*/
+func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		c.Set("psk", c.Request().Header.Get("x-rh-sources-psk"))
+		c.Set("x-rh-identity", c.Request().Header.Get("x-rh-identity"))
+
+		switch {
+		case c.Request().Header.Get("x-rh-sources-account-number") != "":
+			accountNumber := c.Request().Header.Get("x-rh-sources-account-number")
+			c.Logger().Debugf("Looking up Tenant ID for account number %v", accountNumber)
+			t, err := dao.GetOrCreateTenantID(accountNumber)
+			if err != nil {
+				return c.JSON(http.StatusInternalServerError, util.ErrorDoc("Failed to get or create tenant for request", "500"))
+			}
+			c.Set("tenantID", *t)
+
+		case c.Request().Header.Get("x-rh-identity") != "":
+			idRaw, err := base64.StdEncoding.DecodeString(c.Request().Header.Get("x-rh-identity"))
+			if err != nil {
+				return c.JSON(http.StatusUnauthorized, util.ErrorDoc(fmt.Sprintf("Error decoding Identity: %v", err), "401"))
+			}
+
+			var jsonData identity.XRHID
+			err = json.Unmarshal(idRaw, &jsonData)
+			if err != nil {
+				return c.JSON(http.StatusUnauthorized, util.ErrorDoc("x-rh-identity header does not contain valid JSON", "401"))
+			}
+
+			// store the parsed header for later usage.
+			c.Set("identity", jsonData)
+
+			if jsonData.Identity.AccountNumber == "" {
+				return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Account number not present in x-rh-identity", "401"))
+			}
+
+			c.Logger().Debugf("Looking up Tenant ID for account number %v", jsonData.Identity.AccountNumber)
+			t, err := dao.GetOrCreateTenantID(jsonData.Identity.AccountNumber)
+			if err != nil {
+				return c.JSON(http.StatusInternalServerError, util.ErrorDoc(fmt.Sprintf("Failed to get or create tenant for request: %s", err.Error()), "500"))
+			}
+			c.Set("tenantID", *t)
+
+		default:
+			return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Authentication required by either [x-rh-identity] or [x-rh-sources-psk]", "401"))
+		}
+
+		return next(c)
+	}
+}

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -28,8 +28,13 @@ import (
 */
 func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		c.Set("psk", c.Request().Header.Get("x-rh-sources-psk"))
-		c.Set("x-rh-identity", c.Request().Header.Get("x-rh-identity"))
+		// set psk + raw xrhid (if present) always - we'll need them later.
+		if c.Request().Header.Get("x-rh-sources-psk") != "" {
+			c.Set("psk", c.Request().Header.Get("x-rh-sources-psk"))
+		}
+		if c.Request().Header.Get("x-rh-identity") != "" {
+			c.Set("x-rh-identity", c.Request().Header.Get("x-rh-identity"))
+		}
 
 		switch {
 		case c.Request().Header.Get("x-rh-sources-account-number") != "":

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
@@ -20,7 +19,7 @@ func TestSourceTypeSourceSubcollectionList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)
@@ -75,7 +74,7 @@ func TestApplicationSourceSubcollectionList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		},
 	)
@@ -132,7 +131,7 @@ func TestSourceList(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []middleware.Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": int64(1),
 		})
 

--- a/source_type_handlers_test.go
+++ b/source_type_handlers_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/middleware"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
@@ -18,7 +17,7 @@ func TestSourceTypeList(t *testing.T) {
 		map[string]interface{}{
 			"limit":   100,
 			"offset":  0,
-			"filters": []middleware.Filter{},
+			"filters": []util.Filter{},
 		},
 	)
 

--- a/util/filtering.go
+++ b/util/filtering.go
@@ -1,0 +1,11 @@
+package util
+
+import "regexp"
+
+var FilterRegex = regexp.MustCompile(`^filter\[(\w+)](\[\w*]|$)`)
+
+type Filter struct {
+	Name      string
+	Operation string
+	Value     []string
+}


### PR DESCRIPTION
Been wanting to do this for a bit - but the problem became that I stuck the `Filter` struct in the middleware package. By moving it to `util/` that allowed me to finally put all our middleware in the right pacakge including the tenancy check as well as authorization check. 

Most of the changes are just package renames - best to just check out the changes under `middleware/`

I'll be following this up with changes to allow the system header through - if it contains a `cluster_id` or a `cn` field.

**EDIT**:  I also added the current sources-api behavior to the authorization check - e.g. if there is a system header present we just let the request through. 