### PR TITLE
[RHCLOUD-16717] Use single instance of cloudwatch hook in logger

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -21,8 +21,18 @@ import (
 
 var Log *logrus.Logger
 
+var cloudWatchHook *lc.Hook
+
+func singleCloudWatchLogrusHook(config *appconf.SourcesApiConfig) *lc.Hook {
+	if cloudWatchHook == nil {
+		cloudWatchHook = cloudWatchLogrusHook(config)
+	}
+
+	return cloudWatchHook
+}
+
 func AddHooksTo(logger *logrus.Logger, config *appconf.SourcesApiConfig) {
-	hook := cloudWatchLogrusHook(config)
+	hook := singleCloudWatchLogrusHook(config)
 	if hook == nil {
 		Log.Warn("Key or Secret are missing for logging to Cloud Watch.")
 	} else {


### PR DESCRIPTION
Connection to cloudwatch has been created twice which
could produce error about invalid sequenceToken when
logs are sent(by PutLogEvents) with same sequenceToken:

"If you call PutLogEvents twice within a narrow time
period using the same value for sequenceToken, both
calls might be successful or one might be rejected."

See more: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html

It fixes error:

```
Failed to fire hook: InvalidSequenceTokenException: The given sequenceToken is invalid. The next expected sequenceToken is: 49611013085122989219357090845167240971201614806094184850
{
  RespMetadata: {
    StatusCode: 400,
    RequestID: "17d77acd-41af-40c4-900d-6c6cd4fb78c9"
  },
  ExpectedSequenceToken: "49611013085122989219357090845167240971201614806094184850",
  Message_: "The given sequenceToken is invalid. The next expected sequenceToken is: 49611013085122989219357090845167240971201614806094184850"
}
```

When server is run multiple time
there is still possibility to obtain
this error.

This error doesn't cause that logs are not sent -
it causes that error is displayed- [**fix to suppress error is here**](https://github.com/RedHatInsights/platform-go-middlewares/pull/26)

# Links
https://issues.redhat.com/browse/RHCLOUD-16717


Signed-off-by: Libor Pichler <lpichler@redhat.com>
