### PR TITLE
Move header parsing to its own middleware 

### DIFF
--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -17,6 +17,7 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 				util.ErrorDoc(fmt.Sprintf("Internal Server Error: %v", err.Error()), "500"),
 			)
 		}
-		return err
+
+		return nil
 	}
 }

--- a/middleware/error_handling_test.go
+++ b/middleware/error_handling_test.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/labstack/echo/v4"
+)
+
+func TestError(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	explosion := HandleErrors(func(echo.Context) error { return fmt.Errorf("boom!") })
+	err := explosion(c)
+
+	if err != nil {
+		t.Error("caught an error when there should not have been one")
+	}
+
+	if rec.Code != 500 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 500)
+	}
+
+	body, _ := ioutil.ReadAll(rec.Body)
+
+	if !strings.Contains(string(body), "Internal Server Error:") {
+		t.Errorf("malformed body: %s", body)
+	}
+}
+
+func TestNoError(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	goodRequest := HandleErrors(func(echo.Context) error { return nil })
+	err := goodRequest(c)
+
+	if err != nil {
+		t.Error("caught an error when there should not have been one")
+	}
+
+	if rec.Code != 200 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 200)
+	}
+
+}

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -3,26 +3,14 @@ package middleware
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/config"
-	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
-	l "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/labstack/echo/v4"
 )
 
 var e *echo.Echo
 var conf = config.Get()
-
-func TestMain(t *testing.M) {
-	_ = parser.ParseFlags()
-
-	l.InitLogger(conf)
-	e = echo.New()
-	code := t.Run()
-	os.Exit(code)
-}
 
 func TestParseFilterWithOperation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?filter[name][eq]=test", nil)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+/*
+   Parse the required headers for processing this request. Currently this
+   involves _three_ major headers:
+
+   1. `x-rh-identity`: contains the account number and various other information
+      about the request. This is set by 3scale.
+
+   2. `x-rh-sources-psk`: a pre-shared-key (psk) which is used internally to
+      authenticate from within the CRC cluster. This is checked against a list
+      of known keys which are set in vault, if it matches any of them the
+      request is authorized.
+
+    3. `x-rh-sources-account-number`: used with a PSK to access a certain
+       account. Only accessible from within the CRC cluster.
+*/
+func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		// the PSK related headers - just storing them as raw strings.
+		if c.Request().Header.Get("x-rh-sources-psk") != "" {
+			c.Set("psk", c.Request().Header.Get("x-rh-sources-psk"))
+		}
+
+		if c.Request().Header.Get("x-rh-sources-account-number") != "" {
+			c.Set("psk-account", c.Request().Header.Get("x-rh-sources-account-number"))
+		}
+
+		// parsing the base64-encoded identity header if present
+		if c.Request().Header.Get("x-rh-identity") != "" {
+			// store it raw first.
+			c.Set("x-rh-identity", c.Request().Header.Get("x-rh-identity"))
+
+			idRaw, err := base64.StdEncoding.DecodeString(c.Request().Header.Get("x-rh-identity"))
+			if err != nil {
+				return fmt.Errorf("error decoding Identity: %v", err)
+			}
+
+			var id identity.XRHID
+			err = json.Unmarshal(idRaw, &id)
+			if err != nil {
+				return fmt.Errorf("x-rh-identity header does not contain valid JSON")
+			}
+
+			// store the parsed header for later usage.
+			c.Set("identity", id)
+
+			// store whether or not this a cert-auth based request
+			if id.Identity.System != nil && id.Identity.System["cn"] != nil {
+				c.Set("cert-auth", true)
+			}
+		}
+
+		return next(c)
+	}
+}

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -1,0 +1,133 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+var parseOrElse204 = ParseHeaders(func(c echo.Context) error {
+	return c.NoContent(http.StatusNoContent)
+})
+
+func TestParseAll(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	c.Request().Header.Set("x-rh-identity", xrhid)
+	c.Request().Header.Set("x-rh-sources-psk", "1234")
+	c.Request().Header.Set("x-rh-sources-account-number", "9876")
+
+	err := parseOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	}
+
+	if c.Get("psk").(string) != "1234" {
+		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
+	}
+
+	if c.Get("psk-account").(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get("psk-account").(string), "9876")
+	}
+
+	id, _ := c.Get("identity").(identity.XRHID)
+
+	if id.Identity.AccountNumber != "12345" {
+		t.Errorf("%v was set as identity account-number instead of %v", id.Identity.AccountNumber, "12345")
+	}
+}
+
+func TestBadIdentityBase64(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	c.Request().Header.Set("x-rh-identity", "not valid base64")
+
+	err := parseOrElse204(c)
+	if err == nil {
+		t.Errorf("there was no error when there should have been one")
+	}
+
+	if !strings.HasPrefix(err.Error(), "error decoding Identity: illegal base64") {
+		t.Errorf("incorrect error message: %v", err)
+	}
+
+	if rec.Code != 200 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 200)
+	}
+}
+
+func TestBadIdentityJson(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	// base64 for: {"not a real field": true}
+	c.Request().Header.Set("x-rh-identity", "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
+
+	err := parseOrElse204(c)
+	if err == nil {
+		t.Errorf("there was no error when there should have been one")
+	}
+
+	if err.Error() != "x-rh-identity header does not contain valid JSON" {
+		t.Errorf("incorrect error message: %v", err)
+	}
+
+	if rec.Code != 200 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 200)
+	}
+}
+
+func TestOnlyPskHeaders(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	c.Request().Header.Set("x-rh-sources-psk", "1234")
+	c.Request().Header.Set("x-rh-sources-account-number", "9876")
+
+	err := parseOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	}
+
+	if c.Get("psk").(string) != "1234" {
+		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
+	}
+
+	if c.Get("psk-account").(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get("psk-account").(string), "9876")
+	}
+
+	if c.Get("identity") != nil {
+		t.Errorf("an identity was present when none was specified")
+	}
+}

--- a/middleware/main_test.go
+++ b/middleware/main_test.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+	"github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+var (
+	xrhid         string
+	emptyIdentity = identity.XRHID{Identity: identity.Identity{AccountNumber: "12345"}}
+)
+
+func TestMain(t *testing.M) {
+	_ = parser.ParseFlags()
+
+	// for header parsing test
+	rawId, _ := json.Marshal(emptyIdentity)
+	xrhid = string(base64.StdEncoding.EncodeToString(rawId))
+
+	logger.InitLogger(conf)
+	e = echo.New()
+	code := t.Run()
+	os.Exit(code)
+}

--- a/routes.go
+++ b/routes.go
@@ -38,7 +38,7 @@ func setupRoutes(e *echo.Echo) {
 		return c.String(http.StatusOK, out)
 	})
 
-	v3 := e.Group("/api/sources/v3.1", middleware.HandleErrors)
+	v3 := e.Group("/api/sources/v3.1", middleware.HandleErrors, middleware.ParseHeaders)
 
 	// Sources
 	v3.GET("/sources", SourceList, tenancyWithListMiddleware...)


### PR DESCRIPTION
- [x] #65 needs to be merged first.

So this PR does a few things:
1. Moves _all_ of the header parsing to its own middleware. This way the headers are only getting parsed in one place. Before it was intermixed between the tenancy middleware and the authorization middleware. This also lets us store more knowledge about the request all in one spot too. I put this middleware right after the error handler - so it runs for all requests on the v3 group.
2. Thins down the tenancy middleware (alternate: put the tenancy middleware on a diet), basically pulling the info from the request and acting on it rather than parsing headers.
3. Fixes an error in the ErrorHandling middleware where i was returning the error rather than nil after handling the 500. 
4. ...and finally, added a bunch of tests around the middleware package. Mostly around the error handler. 

Any questions let me know. It should be a lot easier to review after #65  gets merged. 