### PR TITLE
Update UBI to RHEL 8.5 in order to bring in Go 1.16

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - uses: Jerome1337/gofmt-action@v1.0.4
 
   govet:
@@ -17,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - run: |
           go vet ./...
 
@@ -25,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -38,5 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - run: |
           go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.4 as build
-
-RUN mkdir /build
+FROM registry.access.redhat.com/ubi8/ubi:8.5-214 as build
 WORKDIR /build
 
 RUN dnf -y --disableplugin=subscription-manager install go
@@ -11,6 +9,6 @@ RUN go mod download
 COPY . .
 RUN go build -o sources-api-go .
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5-218
 COPY --from=build /build/sources-api-go /sources-api-go
 ENTRYPOINT ["/sources-api-go"]

--- a/marketplace/token_test.go
+++ b/marketplace/token_test.go
@@ -2,7 +2,7 @@ package marketplace
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -16,7 +16,7 @@ func TestBearerTokenUnmarshalling(t *testing.T) {
 
 	jsonText := fmt.Sprintf(`{"access_token": "%s", "expiration": %d}`, accessTokenValue, expirationTimestamp)
 
-	readCloser := ioutil.NopCloser(strings.NewReader(jsonText))
+	readCloser := io.NopCloser(strings.NewReader(jsonText))
 	fakeMarketplaceResponse := http.Response{Body: readCloser}
 
 	token, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
@@ -37,7 +37,7 @@ func TestBearerTokenUnmarshalling(t *testing.T) {
 func TestInvalidJsonPassed(t *testing.T) {
 	jsonText := `{"access_token":"abcde", "expiration"}`
 
-	readCloser := ioutil.NopCloser(strings.NewReader(jsonText))
+	readCloser := io.NopCloser(strings.NewReader(jsonText))
 	fakeMarketplaceResponse := http.Response{Body: readCloser}
 
 	_, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
@@ -53,7 +53,7 @@ func TestInvalidJsonPassed(t *testing.T) {
 func TestInvalidStructurePassed(t *testing.T) {
 	jsonText := `{"hello": "world"}`
 
-	readCloser := ioutil.NopCloser(strings.NewReader(jsonText))
+	readCloser := io.NopCloser(strings.NewReader(jsonText))
 	fakeMarketplaceResponse := http.Response{Body: readCloser}
 
 	_, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -19,6 +19,13 @@ IQE_FILTER_EXPRESSION=""
 # source $CICD_ROOT/deploy_ephemeral_env.sh
 # source $CICD_ROOT/smoke_test.sh
 
+# test building in the container
+make container
+if [[ $? != 0 ]]; then
+    exit 1
+fi
+
+
 DB_CONTAINER="sources-api-db-$(uuidgen)"
 echo "Spinning up container: ${DB_CONTAINER}"
 
@@ -33,14 +40,16 @@ docker run -d \
 PORT=$(docker inspect $DB_CONTAINER | grep HostPort | sort | uniq | grep -o [0-9]*)
 echo "DB Listening on Port: ${PORT}"
 
-export DATABASE_HOST=localhost 
-export DATABASE_PORT=$PORT 
-export DATABASE_USER=root 
-export DATABASE_PASSWORD=toor 
+export DATABASE_HOST=localhost
+export DATABASE_PORT=$PORT
+export DATABASE_USER=root
+export DATABASE_PASSWORD=toor
 export DATABASE_NAME=sources_api_test_go
 
 echo "Running tests...here we go"
 
+export GOROOT="/opt/go/1.16.10"
+export PATH="${GOROOT}/bin:${PATH}"
 go test ./... --integration
 
 OUT_CODE=$?

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -3,7 +3,6 @@ package statuslistener
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -41,7 +40,7 @@ type MockEventStreamSender struct {
 
 func LoadJSONContentFrom(resourceType string, resourceID string, prefix string) []byte {
 	fileName := "./test_data/" + prefix + resourceType + "_" + resourceID + ".json"
-	fileContent, err := ioutil.ReadFile(fileName)
+	fileContent, err := os.ReadFile(fileName)
 
 	if err != nil {
 		panic(fmt.Errorf("unable to read file %s because of %s", fileName, err.Error()))


### PR DESCRIPTION
A few things got moved from `ioutil` to just the `io` and `os` packages. We should use these going forward. 

I also added a container build to the pr_check.sh script - that way even if the action build works the container one might fail due to differing go versions. 