### PR TITLE
refactor: use 405 status code for invalid http verbs in requests

### DIFF
--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -60,7 +60,8 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			if identity.Identity.System != nil {
 				// system-auth only allows GET and POST requests.
 				if c.Request().Method != http.MethodGet && c.Request().Method != http.MethodPost {
-					return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Unauthorized Action: system authentication only allows GET/POST", "401"))
+					c.Response().Header().Set("Allow", "GET, POST")
+					return c.JSON(http.StatusMethodNotAllowed, util.ErrorDoc("Method not allowed", "405"))
 				}
 
 				// basically we're checking whether cn or cluster_id is set in

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -174,8 +174,8 @@ func TestSystemPatch(t *testing.T) {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 401 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 401)
+	if rec.Code != 405 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 405)
 	}
 }
 
@@ -199,8 +199,8 @@ func TestSystemDelete(t *testing.T) {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 401 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 401)
+	if rec.Code != 405 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 405)
 	}
 }
 


### PR DESCRIPTION
It replaces the "401 Unauthorized" responses with a more accurate "405 Method not allowed" response.