### PR TITLE
Add Static Cache for Application/Source Type Id's

### DIFF
--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -1,0 +1,15 @@
+package dao
+
+import (
+	"os"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+)
+
+func TestMain(t *testing.M) {
+	// we need this to parse arguments otherwise there are not recognized which lead to error
+	_ = parser.ParseFlags()
+
+	os.Exit(t.Run())
+}

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -8,7 +8,7 @@ import (
 type SourceTypeDaoImpl struct {
 }
 
-func (a *SourceTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
+func (st *SourceTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
 	// allocating a slice of source types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	sourceTypes := make([]m.SourceType, 0, limit)
@@ -29,21 +29,21 @@ func (a *SourceTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.
 	return sourceTypes, count, result.Error
 }
 
-func (a *SourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
+func (st *SourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
 	sourceType := &m.SourceType{Id: *id}
 	result := DB.Debug().First(sourceType)
 
 	return sourceType, result.Error
 }
 
-func (a *SourceTypeDaoImpl) Create(_ *m.SourceType) error {
+func (st *SourceTypeDaoImpl) Create(_ *m.SourceType) error {
 	panic("not needed (yet) due to seeding.")
 }
 
-func (a *SourceTypeDaoImpl) Update(_ *m.SourceType) error {
+func (st *SourceTypeDaoImpl) Update(_ *m.SourceType) error {
 	panic("not needed (yet) due to seeding.")
 }
 
-func (a *SourceTypeDaoImpl) Delete(_ *int64) error {
+func (st *SourceTypeDaoImpl) Delete(_ *int64) error {
 	panic("not needed (yet) due to seeding.")
 }

--- a/dao/type_cache.go
+++ b/dao/type_cache.go
@@ -1,0 +1,95 @@
+package dao
+
+import (
+	"strings"
+
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
+
+// Package level Type cache - to be accessed from anywhere
+var Static typeCache
+
+/*
+	typeCache is a small struct that just contains the map between
+	application/source types and their keys in the database.
+
+	The cache is populated at startup so one can fetch foreign keys when
+	building objects easily.
+*/
+type typeCache struct {
+	sourceTypes      map[string]int64
+	applicationTypes map[string]int64
+}
+
+// returns the source type id for a given name, 0 if not found.
+func (tc *typeCache) GetSourceTypeId(name string) int64 {
+	return tc.sourceTypes[name]
+}
+
+/*
+    Returns the application type id for a given name, 0 if not found.
+
+	Can search via name or display name for application types, there is also a
+	shortcut for the last place in the "path" of the name e.g. `/this/is/a/type`
+	is also available as `type`
+*/
+func (tc *typeCache) GetApplicationTypeId(name string) int64 {
+	return tc.applicationTypes[name]
+}
+
+/*
+	Fetches every Source+Application Type record from the database and builds
+	out the cache. Returns an error if it fails (e.g. the app shouldn't be
+	running then)
+*/
+func PopulateStaticTypeCache() error {
+	tc := typeCache{}
+	tc.sourceTypes = make(map[string]int64)
+	tc.applicationTypes = make(map[string]int64)
+
+	err := populateSourceTypes(tc)
+	if err != nil {
+		return err
+	}
+	err = populateApplicationTypes(tc)
+	if err != nil {
+		return err
+	}
+
+	Static = tc
+	return nil
+}
+
+func populateSourceTypes(cache typeCache) error {
+	sourceTypes := make([]m.SourceType, 0)
+	result := DB.Model(&m.SourceType{}).Scan(&sourceTypes)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	for _, st := range sourceTypes {
+		cache.sourceTypes[st.Name] = st.Id
+	}
+
+	return nil
+}
+
+func populateApplicationTypes(cache typeCache) error {
+	appTypes := make([]m.ApplicationType, 0)
+	result := DB.Model(&m.ApplicationType{}).Scan(&appTypes)
+	if result.Error != nil {
+		return result.Error
+	}
+
+	for _, at := range appTypes {
+		// The entire path name
+		cache.applicationTypes[at.Name] = at.Id
+
+		// the last part of the path name (usually used in bulk_create)
+		parts := strings.Split(at.Name, "/")
+		shortName := parts[len(parts)-1]
+		cache.applicationTypes[shortName] = at.Id
+	}
+
+	return nil
+}

--- a/dao/type_cache_test.go
+++ b/dao/type_cache_test.go
@@ -1,0 +1,18 @@
+package dao
+
+import "testing"
+
+func TestStaticCache(t *testing.T) {
+	Static = typeCache{
+		sourceTypes:      map[string]int64{"amazon": 17},
+		applicationTypes: map[string]int64{"cloud-meter": 1},
+	}
+
+	if Static.GetApplicationTypeId("cloud-meter") != 1 {
+		t.Errorf("Incorrect ApplicationType ID returned")
+	}
+
+	if Static.GetSourceTypeId("amazon") != 17 {
+		t.Errorf("Incorrect SourceType ID returned")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -58,5 +58,11 @@ func runServer() {
 	// setting up the "http.Client" for the marketplace token provider
 	marketplace.GetHttpClient = marketplace.GetHttpClientStdlib
 
+	// Set up the TypeCache
+	err := dao.PopulateStaticTypeCache()
+	if err != nil {
+		e.Logger.Fatal(err)
+	}
+
 	e.Logger.Fatal(e.Start(":8000"))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -21,12 +21,14 @@ var (
 	mockSourceTypeDao      dao.SourceTypeDao
 	mockApplicationDao     dao.ApplicationDao
 	mockMetaDataDao        dao.MetaDataDao
+
+	flags parser.Flags
 )
 
 func TestMain(t *testing.M) {
 	l.InitLogger(conf)
 
-	flags := parser.ParseFlags()
+	flags = parser.ParseFlags()
 
 	if flags.CreateDb {
 		database.CreateTestDB()
@@ -41,6 +43,10 @@ func TestMain(t *testing.M) {
 		getMetaDataDao = getMetaDataDaoWithTenant
 
 		database.CreateFixtures()
+		err := dao.PopulateStaticTypeCache()
+		if err != nil {
+			panic("failed to populate static type cache")
+		}
 	} else {
 		mockSourceDao = &dao.MockSourceDao{Sources: fixtures.TestSourceData}
 		mockApplicationDao = &dao.MockApplicationDao{Applications: fixtures.TestApplicationData}

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -48,6 +48,13 @@ func SourceList(c echo.Context) error {
 		count   int64
 	)
 
+	// When listing sources via cert-auth we want to lock them down to only the
+	// satellite source type.
+	if c.Get("cert-auth") != nil {
+		satlliteId := strconv.Itoa(int(dao.Static.GetSourceTypeId("satellite")))
+		filters = append(filters, util.Filter{Name: "source_type_id", Value: []string{satlliteId}})
+	}
+
 	sources, count, err = sourcesDB.List(limit, offset, filters)
 
 	if err != nil {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -51,8 +51,8 @@ func SourceList(c echo.Context) error {
 	// When listing sources via cert-auth we want to lock them down to only the
 	// satellite source type.
 	if c.Get("cert-auth") != nil {
-		satlliteId := strconv.Itoa(int(dao.Static.GetSourceTypeId("satellite")))
-		filters = append(filters, util.Filter{Name: "source_type_id", Value: []string{satlliteId}})
+		satelliteId := strconv.Itoa(int(dao.Static.GetSourceTypeId("satellite")))
+		filters = append(filters, util.Filter{Name: "source_type_id", Value: []string{satelliteId}})
 	}
 
 	sources, count, err = sourcesDB.List(limit, offset, filters)

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -176,6 +176,54 @@ func TestSourceList(t *testing.T) {
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
+func TestSourceListSatellite(t *testing.T) {
+	if !flags.Integration {
+		t.Skip("Only runs during integration tests")
+	}
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": int64(1),
+			// this gets set during the parse middleware
+			"cert-auth": true,
+		})
+
+	err := SourceList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 200 {
+		t.Error("Did not return 200")
+	}
+
+	var out util.Collection
+	err = json.Unmarshal(rec.Body.Bytes(), &out)
+	if err != nil {
+		t.Error("Failed unmarshaling output")
+	}
+
+	if out.Meta.Limit != 100 {
+		t.Error("limit not set correctly")
+	}
+
+	if out.Meta.Offset != 0 {
+		t.Error("offset not set correctly")
+	}
+
+	if len(out.Data) != 0 {
+		t.Error("Objects were not filtered out of request")
+	}
+
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
+}
+
 func TestSourceGet(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,


### PR DESCRIPTION
This PR adds the static cache we discussed in Slack today. This is what it looks like in memory:
![image](https://user-images.githubusercontent.com/5856504/148831181-6d5cc180-011d-420b-8ca9-419851f3f10b.png)

---

I have comments in the struct but will add more here. Basically it caches the `SourceType` name -> id mapping as well as the `ApplicationType` name -> id mapping. For ApplicationType though I did not only the path-style name but also the "short" name since we use that in some places in the app.

---

I also have another commit as an example of it being used: limiting satellite listing sources to _only_ the satellite source_type_id.

\# TODO:
- [x] Tests for SourceList with cert-auth being used
- [x] Maybe tests for the typeCache?