### PR TITLE
Add Create/Edit/Delete operations for the Application Model

### DIFF
--- a/application_handlers.go
+++ b/application_handlers.go
@@ -91,7 +91,7 @@ func ApplicationGet(c echo.Context) error {
 }
 
 func ApplicationCreate(c echo.Context) error {
-	applicationDB, err := getApplicationDaoWithTenant(c)
+	applicationDB, err := getApplicationDao(c)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func ApplicationCreate(c echo.Context) error {
 }
 
 func ApplicationEdit(c echo.Context) error {
-	applicationDB, err := getApplicationDaoWithTenant(c)
+	applicationDB, err := getApplicationDao(c)
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func ApplicationEdit(c echo.Context) error {
 }
 
 func ApplicationDelete(c echo.Context) error {
-	applicationDB, err := getApplicationDaoWithTenant(c)
+	applicationDB, err := getApplicationDao(c)
 	if err != nil {
 		return err
 	}

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -62,7 +62,9 @@ func (a *ApplicationDaoImpl) GetById(id *int64) (*m.Application, error) {
 }
 
 func (a *ApplicationDaoImpl) Create(app *m.Application) error {
+	app.TenantID = *a.TenantID
 	result := DB.Create(app)
+
 	return result.Error
 }
 

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -1,8 +1,11 @@
 package dao
 
 import (
+	"fmt"
+
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"gorm.io/datatypes"
 )
 
 type ApplicationTypeDaoImpl struct {
@@ -72,4 +75,29 @@ func (a *ApplicationTypeDaoImpl) Update(_ *m.ApplicationType) error {
 
 func (a *ApplicationTypeDaoImpl) Delete(_ *int64) error {
 	panic("not needed (yet) due to seeding.")
+}
+
+func (at *ApplicationTypeDaoImpl) ApplicationTypeCompatibleWithSource(typeId, sourceId int64) (bool, error) {
+	source := m.Source{ID: sourceId}
+	result := DB.Preload("SourceType").Find(&source)
+	if result.Error != nil {
+		return false, fmt.Errorf("source not found")
+	}
+
+	// searching for the application type that has the source type's name in its
+	// supported source types column.
+	result = DB.Find(
+		&m.ApplicationType{Id: typeId},
+		datatypes.JSONQuery("supported_source_types").HasKey(source.SourceType.Name),
+	)
+
+	if result.Error != nil {
+		return false, fmt.Errorf("failed to fetch application type %v", typeId)
+	}
+
+	if result.RowsAffected == 0 {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -77,27 +77,19 @@ func (a *ApplicationTypeDaoImpl) Delete(_ *int64) error {
 	panic("not needed (yet) due to seeding.")
 }
 
-func (at *ApplicationTypeDaoImpl) ApplicationTypeCompatibleWithSource(typeId, sourceId int64) (bool, error) {
+func (at *ApplicationTypeDaoImpl) ApplicationTypeCompatibleWithSource(typeId, sourceId int64) error {
 	source := m.Source{ID: sourceId}
 	result := DB.Preload("SourceType").Find(&source)
 	if result.Error != nil {
-		return false, fmt.Errorf("source not found")
+		return fmt.Errorf("source not found")
 	}
 
 	// searching for the application type that has the source type's name in its
 	// supported source types column.
-	result = DB.Find(
+	result = DB.First(
 		&m.ApplicationType{Id: typeId},
 		datatypes.JSONQuery("supported_source_types").HasKey(source.SourceType.Name),
 	)
 
-	if result.Error != nil {
-		return false, fmt.Errorf("failed to fetch application type %v", typeId)
-	}
-
-	if result.RowsAffected == 0 {
-		return false, nil
-	}
-
-	return true, nil
+	return result.Error
 }

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -57,7 +57,7 @@ type ApplicationTypeDao interface {
 	Create(src *m.ApplicationType) error
 	Update(src *m.ApplicationType) error
 	Delete(id *int64) error
-	ApplicationTypeCompatibleWithSource(typeId, sourceId int64) (bool, error)
+	ApplicationTypeCompatibleWithSource(typeId, sourceId int64) error
 }
 
 type EndpointDao interface {

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -57,6 +57,7 @@ type ApplicationTypeDao interface {
 	Create(src *m.ApplicationType) error
 	Update(src *m.ApplicationType) error
 	Delete(id *int64) error
+	ApplicationTypeCompatibleWithSource(typeId, sourceId int64) (bool, error)
 }
 
 type EndpointDao interface {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -20,6 +20,8 @@ type MockEndpointDao struct {
 }
 type MockApplicationTypeDao struct {
 	ApplicationTypes []m.ApplicationType
+	Compatible       bool
+	CompatibleError  error
 }
 
 type MockSourceTypeDao struct {
@@ -198,6 +200,10 @@ func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}
 	}
 
 	return appTypes, count, nil
+}
+
+func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSource(_, _ int64) (bool, error) {
+	return a.Compatible, a.CompatibleError
 }
 
 func (a *MockSourceTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"errors"
 	"fmt"
 
 	m "github.com/RedHatInsights/sources-api-go/model"
@@ -21,7 +22,6 @@ type MockEndpointDao struct {
 type MockApplicationTypeDao struct {
 	ApplicationTypes []m.ApplicationType
 	Compatible       bool
-	CompatibleError  error
 }
 
 type MockSourceTypeDao struct {
@@ -202,8 +202,12 @@ func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}
 	return appTypes, count, nil
 }
 
-func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSource(_, _ int64) (bool, error) {
-	return a.Compatible, a.CompatibleError
+func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSource(_, _ int64) error {
+	if a.Compatible {
+		return nil
+	}
+
+	return errors.New("Not compatible!")
 }
 
 func (a *MockSourceTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
@@ -270,15 +274,15 @@ func (a *MockApplicationDao) GetById(id *int64) (*m.Application, error) {
 }
 
 func (a *MockApplicationDao) Create(src *m.Application) error {
-	panic("not implemented") // TODO: Implement
+	return nil
 }
 
 func (a *MockApplicationDao) Update(src *m.Application) error {
-	panic("not implemented") // TODO: Implement
+	return nil
 }
 
 func (a *MockApplicationDao) Delete(id *int64) error {
-	panic("not implemented") // TODO: Implement
+	return nil
 }
 
 func (a *MockApplicationDao) Tenant() *int64 {

--- a/internal/testutils/request/body_utils.go
+++ b/internal/testutils/request/body_utils.go
@@ -1,0 +1,5 @@
+package request
+
+func PointerToString(str string) *string {
+	return &str
+}

--- a/main_test.go
+++ b/main_test.go
@@ -63,7 +63,6 @@ func TestMain(t *testing.M) {
 		getApplicationTypeDao = func(c echo.Context) (dao.ApplicationTypeDao, error) { return mockApplicationTypeDao, nil }
 
 		getMetaDataDao = func(c echo.Context) (dao.MetaDataDao, error) { return mockMetaDataDao, nil }
-
 	}
 
 	code := t.Run()

--- a/model/application.go
+++ b/model/application.go
@@ -70,3 +70,17 @@ func (app *Application) ToResponse() *ApplicationResponse {
 		ApplicationTypeID:       appTypeId,
 	}
 }
+
+func (app *Application) UpdateFromRequest(req *ApplicationEditRequest) {
+	if req.Extra != nil {
+		app.Extra = req.Extra
+	}
+
+	if req.AvailabilityStatus != nil {
+		app.AvailabilityStatus = AvailabilityStatus{AvailabilityStatus: *req.AvailabilityStatus}
+	}
+
+	if req.AvailabilityStatusError != nil {
+		app.AvailabilityStatusError = *req.AvailabilityStatusError
+	}
+}

--- a/model/application_http.go
+++ b/model/application_http.go
@@ -20,3 +20,19 @@ type ApplicationResponse struct {
 	SourceID          string `json:"source_id"`
 	ApplicationTypeID string `json:"application_type_id"`
 }
+
+type ApplicationCreateRequest struct {
+	Extra datatypes.JSON `json:"extra,omitempty"`
+
+	SourceID             int64       `json:"-"`
+	SourceIDRaw          interface{} `json:"source_id"`
+	ApplicationTypeID    int64       `json:"-"`
+	ApplicationTypeIDRaw interface{} `json:"application_type_id"`
+}
+
+type ApplicationEditRequest struct {
+	Extra datatypes.JSON `json:"extra,omitempty"`
+
+	AvailabilityStatus      *string `json:"availability_status"`
+	AvailabilityStatusError *string `json:"availability_status_error"`
+}

--- a/routes.go
+++ b/routes.go
@@ -55,6 +55,9 @@ func setupRoutes(e *echo.Echo) {
 	// Applications
 	v3.GET("/applications", ApplicationList, tenancyWithListMiddleware...)
 	v3.GET("/applications/:id", ApplicationGet, middleware.Tenancy)
+	v3.POST("/applications", ApplicationCreate, permissionMiddleware...)
+	v3.PATCH("/applications/:id", ApplicationEdit, permissionMiddleware...)
+	v3.DELETE("/applications/:id", ApplicationDelete, permissionMiddleware...)
 	v3.GET("/applications/:application_id/authentications", ApplicationListAuthentications, tenancyWithListMiddleware...)
 
 	// Authentications

--- a/service/application_validation.go
+++ b/service/application_validation.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// by default we'll be using an empty instanct of the apptype dao - replacing it
+// in tests.
+var appTypeDao dao.ApplicationTypeDao = &dao.ApplicationTypeDaoImpl{}
+
+/*
+	Go through and validate the application create request.
+
+	Really not much here other than validating the application type is
+	compatible with the specified source type.
+*/
+func ValidateApplicationCreateRequest(appReq *m.ApplicationCreateRequest) error {
+	// need both source id + application type id
+	if appReq.SourceIDRaw == nil || appReq.ApplicationTypeIDRaw == nil {
+		return fmt.Errorf("missing required parameters of source_id or application_type_id")
+	}
+
+	// parse both the ids
+	appTypeID, err := util.InterfaceToInt64(appReq.ApplicationTypeIDRaw)
+	if err != nil {
+		return fmt.Errorf("invalid application type id %v", appReq.ApplicationTypeIDRaw)
+	}
+	appReq.ApplicationTypeID = appTypeID
+
+	source, err := util.InterfaceToInt64(appReq.SourceIDRaw)
+	if err != nil {
+		return fmt.Errorf("invalid source id %v", appReq.SourceIDRaw)
+	}
+	appReq.SourceID = source
+
+	// check that the application type supports the source type we're attaching
+	// it to.
+	compatible, err := appTypeDao.ApplicationTypeCompatibleWithSource(appReq.ApplicationTypeID, appReq.SourceID)
+	if err != nil {
+		return fmt.Errorf("failed to check compatibility between application and source type")
+	}
+
+	if !compatible {
+		return fmt.Errorf("source type is not compatible with this application type")
+	}
+
+	return nil
+}

--- a/service/application_validation.go
+++ b/service/application_validation.go
@@ -8,9 +8,9 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-// by default we'll be using an empty instanct of the apptype dao - replacing it
+// by default we'll be using an empty instance of the apptype dao - replacing it
 // in tests.
-var appTypeDao dao.ApplicationTypeDao = &dao.ApplicationTypeDaoImpl{}
+var AppTypeDao dao.ApplicationTypeDao = &dao.ApplicationTypeDaoImpl{}
 
 /*
 	Go through and validate the application create request.
@@ -20,8 +20,12 @@ var appTypeDao dao.ApplicationTypeDao = &dao.ApplicationTypeDaoImpl{}
 */
 func ValidateApplicationCreateRequest(appReq *m.ApplicationCreateRequest) error {
 	// need both source id + application type id
-	if appReq.SourceIDRaw == nil || appReq.ApplicationTypeIDRaw == nil {
-		return fmt.Errorf("missing required parameters of source_id or application_type_id")
+	if appReq.SourceIDRaw == nil {
+		return fmt.Errorf("missing required parameter source_id")
+	}
+
+	if appReq.ApplicationTypeIDRaw == nil {
+		return fmt.Errorf("missing required parameter application_type_id")
 	}
 
 	// parse both the ids
@@ -39,12 +43,8 @@ func ValidateApplicationCreateRequest(appReq *m.ApplicationCreateRequest) error 
 
 	// check that the application type supports the source type we're attaching
 	// it to.
-	compatible, err := appTypeDao.ApplicationTypeCompatibleWithSource(appReq.ApplicationTypeID, appReq.SourceID)
+	err = AppTypeDao.ApplicationTypeCompatibleWithSource(appReq.ApplicationTypeID, appReq.SourceID)
 	if err != nil {
-		return fmt.Errorf("failed to check compatibility between application and source type")
-	}
-
-	if !compatible {
 		return fmt.Errorf("source type is not compatible with this application type")
 	}
 

--- a/service/application_validation_test.go
+++ b/service/application_validation_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
@@ -10,7 +9,7 @@ import (
 )
 
 func TestValidApplicationRequest(t *testing.T) {
-	appTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		Extra:                []byte(`{"a good":"thing"`),
@@ -37,7 +36,7 @@ func TestValidApplicationRequest(t *testing.T) {
 }
 
 func TestInvalidApplicationTypeForSource(t *testing.T) {
-	appTypeDao = &dao.MockApplicationTypeDao{Compatible: false}
+	AppTypeDao = &dao.MockApplicationTypeDao{Compatible: false}
 
 	req := m.ApplicationCreateRequest{
 		Extra:                []byte(`{"a good":"thing"`),
@@ -55,27 +54,8 @@ func TestInvalidApplicationTypeForSource(t *testing.T) {
 	}
 }
 
-func TestErrorCheckingApplicationType(t *testing.T) {
-	appTypeDao = &dao.MockApplicationTypeDao{Compatible: false, CompatibleError: errors.New("boom!")}
-
-	req := m.ApplicationCreateRequest{
-		Extra:                []byte(`{"a good":"thing"`),
-		SourceIDRaw:          "1",
-		ApplicationTypeIDRaw: "1",
-	}
-
-	err := ValidateApplicationCreateRequest(&req)
-	if err == nil {
-		t.Errorf("Got no error when there should not have been one")
-	}
-
-	if !strings.Contains(err.Error(), "failed to check") {
-		t.Errorf("malformed error message: %v", err)
-	}
-}
-
 func TestMissingApplicationTypeId(t *testing.T) {
-	appTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		Extra:       []byte(`{"a good":"thing"`),
@@ -89,7 +69,7 @@ func TestMissingApplicationTypeId(t *testing.T) {
 }
 
 func TestMissingSourceId(t *testing.T) {
-	appTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		Extra:                []byte(`{"a good":"thing"`),

--- a/service/application_validation_test.go
+++ b/service/application_validation_test.go
@@ -1,0 +1,103 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
+
+func TestValidApplicationRequest(t *testing.T) {
+	appTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+
+	req := m.ApplicationCreateRequest{
+		Extra:                []byte(`{"a good":"thing"`),
+		SourceIDRaw:          "1",
+		ApplicationTypeIDRaw: "1",
+	}
+
+	err := ValidateApplicationCreateRequest(&req)
+	if err != nil {
+		t.Errorf("Got an error when there should not have been one: %v", err)
+	}
+
+	if req.ApplicationTypeID != 1 {
+		t.Errorf("Failed to parse app type id, got %v, wanted 1", req.ApplicationTypeID)
+	}
+
+	if req.ApplicationTypeID != 1 {
+		t.Errorf("Failed to parse app type id, got %v, wanted 1", req.ApplicationTypeID)
+	}
+
+	if req.SourceID != 1 {
+		t.Errorf("Failed to parse source id, got %v, wanted 1", req.SourceID)
+	}
+}
+
+func TestInvalidApplicationTypeForSource(t *testing.T) {
+	appTypeDao = &dao.MockApplicationTypeDao{Compatible: false}
+
+	req := m.ApplicationCreateRequest{
+		Extra:                []byte(`{"a good":"thing"`),
+		SourceIDRaw:          "1",
+		ApplicationTypeIDRaw: "1",
+	}
+
+	err := ValidateApplicationCreateRequest(&req)
+	if err == nil {
+		t.Errorf("Got no error when there should not have been one")
+	}
+
+	if !strings.Contains(err.Error(), "is not compatible") {
+		t.Errorf("malformed error message: %v", err)
+	}
+}
+
+func TestErrorCheckingApplicationType(t *testing.T) {
+	appTypeDao = &dao.MockApplicationTypeDao{Compatible: false, CompatibleError: errors.New("boom!")}
+
+	req := m.ApplicationCreateRequest{
+		Extra:                []byte(`{"a good":"thing"`),
+		SourceIDRaw:          "1",
+		ApplicationTypeIDRaw: "1",
+	}
+
+	err := ValidateApplicationCreateRequest(&req)
+	if err == nil {
+		t.Errorf("Got no error when there should not have been one")
+	}
+
+	if !strings.Contains(err.Error(), "failed to check") {
+		t.Errorf("malformed error message: %v", err)
+	}
+}
+
+func TestMissingApplicationTypeId(t *testing.T) {
+	appTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+
+	req := m.ApplicationCreateRequest{
+		Extra:       []byte(`{"a good":"thing"`),
+		SourceIDRaw: "1",
+	}
+
+	err := ValidateApplicationCreateRequest(&req)
+	if err == nil {
+		t.Errorf("No error when there should have been one")
+	}
+}
+
+func TestMissingSourceId(t *testing.T) {
+	appTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+
+	req := m.ApplicationCreateRequest{
+		Extra:                []byte(`{"a good":"thing"`),
+		ApplicationTypeIDRaw: "1",
+	}
+
+	err := ValidateApplicationCreateRequest(&req)
+	if err == nil {
+		t.Errorf("No error when there should have been one")
+	}
+}

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -71,96 +71,6 @@ func SourceList(c echo.Context) error {
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
-func SourceTypeListSource(c echo.Context) error {
-	sourcesDB, err := getSourceDao(c)
-	if err != nil {
-		return err
-	}
-
-	filters, err := getFilters(c)
-	if err != nil {
-		return err
-	}
-
-	limit, offset, err := getLimitAndOffset(c)
-	if err != nil {
-		return err
-	}
-
-	var (
-		sources []m.Source
-		count   int64
-	)
-
-	id, err := strconv.ParseInt(c.Param("source_type_id"), 10, 64)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
-	}
-
-	sources, count, err = sourcesDB.SubCollectionList(m.SourceType{Id: id}, limit, offset, filters)
-
-	if err != nil {
-		if errors.Is(err, util.ErrNotFoundEmpty) {
-			return err
-		}
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
-	}
-
-	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
-
-	out := make([]interface{}, len(sources))
-	for i, s := range sources {
-		out[i] = *s.ToResponse()
-	}
-
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
-}
-
-func ApplicationTypeListSource(c echo.Context) error {
-	sourcesDB, err := getSourceDao(c)
-	if err != nil {
-		return err
-	}
-
-	filters, err := getFilters(c)
-	if err != nil {
-		return err
-	}
-
-	limit, offset, err := getLimitAndOffset(c)
-	if err != nil {
-		return err
-	}
-
-	var (
-		sources []m.Source
-		count   int64
-	)
-
-	id, err := strconv.ParseInt(c.Param("application_type_id"), 10, 64)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
-	}
-
-	sources, count, err = sourcesDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
-
-	if err != nil {
-		if errors.Is(err, util.ErrNotFoundEmpty) {
-			return err
-		}
-		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
-	}
-
-	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
-
-	out := make([]interface{}, len(sources))
-	for i, s := range sources {
-		out[i] = *s.ToResponse()
-	}
-
-	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
-}
-
 func SourceGet(c echo.Context) error {
 	sourcesDB, err := getSourceDao(c)
 	if err != nil {
@@ -296,6 +206,96 @@ func SourceListAuthentications(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), 100, 0))
+}
+
+func SourceTypeListSource(c echo.Context) error {
+	sourcesDB, err := getSourceDao(c)
+	if err != nil {
+		return err
+	}
+
+	filters, err := getFilters(c)
+	if err != nil {
+		return err
+	}
+
+	limit, offset, err := getLimitAndOffset(c)
+	if err != nil {
+		return err
+	}
+
+	var (
+		sources []m.Source
+		count   int64
+	)
+
+	id, err := strconv.ParseInt(c.Param("source_type_id"), 10, 64)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
+	}
+
+	sources, count, err = sourcesDB.SubCollectionList(m.SourceType{Id: id}, limit, offset, filters)
+
+	if err != nil {
+		if errors.Is(err, util.ErrNotFoundEmpty) {
+			return err
+		}
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
+	}
+
+	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
+
+	out := make([]interface{}, len(sources))
+	for i, s := range sources {
+		out[i] = *s.ToResponse()
+	}
+
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
+}
+
+func ApplicationTypeListSource(c echo.Context) error {
+	sourcesDB, err := getSourceDao(c)
+	if err != nil {
+		return err
+	}
+
+	filters, err := getFilters(c)
+	if err != nil {
+		return err
+	}
+
+	limit, offset, err := getLimitAndOffset(c)
+	if err != nil {
+		return err
+	}
+
+	var (
+		sources []m.Source
+		count   int64
+	)
+
+	id, err := strconv.ParseInt(c.Param("application_type_id"), 10, 64)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
+	}
+
+	sources, count, err = sourcesDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
+
+	if err != nil {
+		if errors.Is(err, util.ErrNotFoundEmpty) {
+			return err
+		}
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
+	}
+
+	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
+
+	out := make([]interface{}, len(sources))
+	for i, s := range sources {
+		out[i] = *s.ToResponse()
+	}
+
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
 }
 
 func SourceCheckAvailability(c echo.Context) error {


### PR DESCRIPTION
Noticed these weren't done when I went to start on the bulk create stuff so I implemented them quick.

I moved around a few of the handlers just to make them ordered a bit easier to understand too (e.g. CRUD first, then subcollections, etc)

\# TODO:
- [x] validation service file that does validations on the application model
- [x] validation tests
- [x] handler tests. 