### PR TITLE
[RHCLOUD-17536] Add /sources/:id/check_availability Endpoint

### DIFF
--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -14,6 +14,7 @@ type SourceDao interface {
 	Delete(id *int64) error
 	Tenant() *int64
 	NameExistsInCurrentTenant(name string) bool
+	GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error)
 }
 
 type ApplicationDao interface {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -91,7 +91,13 @@ func (src *MockSourceDao) NameExistsInCurrentTenant(name string) bool {
 }
 
 func (src *MockSourceDao) GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error) {
-	return nil, nil
+	for _, i := range src.Sources {
+		if i.ID == *id {
+			return &i, nil
+		}
+	}
+
+	return nil, fmt.Errorf("source not found")
 }
 
 func (a *MockApplicationTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -90,6 +90,10 @@ func (src *MockSourceDao) NameExistsInCurrentTenant(name string) bool {
 	return false
 }
 
+func (src *MockSourceDao) GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error) {
+	return nil, nil
+}
+
 func (a *MockApplicationTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
 	count := int64(len(a.ApplicationTypes))
 	return a.ApplicationTypes, count, nil

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -68,6 +68,19 @@ func (s *SourceDaoImpl) GetById(id *int64) (*m.Source, error) {
 	return src, result.Error
 }
 
+// Function that searches for a source and preloads any specified relations
+func (s *SourceDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error) {
+	src := &m.Source{ID: *id}
+	q := DB.Where("tenant_id = ?", s.TenantID)
+
+	for _, preload := range preloads {
+		q = q.Preload(preload)
+	}
+
+	result := q.Find(&src)
+	return src, result.Error
+}
+
 func (s *SourceDaoImpl) Create(src *m.Source) error {
 	src.TenantID = *s.TenantID // the TenantID gets injected in the middleware
 	result := DB.Create(src)

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -77,7 +77,7 @@ func (s *SourceDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.So
 		q = q.Preload(preload)
 	}
 
-	result := q.Find(&src)
+	result := q.First(&src)
 	return src, result.Error
 }
 

--- a/model/application_type.go
+++ b/model/application_type.go
@@ -1,7 +1,10 @@
 package model
 
 import (
+	"net/url"
+	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"gorm.io/datatypes"
@@ -38,4 +41,21 @@ func (a *ApplicationType) ToResponse() *ApplicationTypeResponse {
 		SupportedSourceTypes:         a.SupportedSourceTypes,
 		SupportedAuthenticationTypes: a.SupportedAuthenticationTypes,
 	}
+}
+
+// returns the application's availability check URL, e.g. where to send the
+// request for the client to re-check the application's availability status.
+func (at *ApplicationType) AvailabilityCheckURL() *url.URL {
+	// Transforms the path-style name to a prefix set in the ENV
+	// e.g. /insights/platform/cloud-meter -> CLOUD_METER
+	parts := strings.Split(at.Name, "/")
+	env_prefix := strings.ToUpper(parts[len(parts)-1])
+	env_prefix = strings.ReplaceAll(env_prefix, "-", "_")
+
+	url, err := url.Parse(os.Getenv(env_prefix + "_AVAILABILITY_CHECK_URL"))
+	if err != nil {
+		return nil
+	}
+
+	return url
 }

--- a/model/application_type.go
+++ b/model/application_type.go
@@ -52,7 +52,13 @@ func (at *ApplicationType) AvailabilityCheckURL() *url.URL {
 	env_prefix := strings.ToUpper(parts[len(parts)-1])
 	env_prefix = strings.ReplaceAll(env_prefix, "-", "_")
 
-	url, err := url.Parse(os.Getenv(env_prefix + "_AVAILABILITY_CHECK_URL"))
+	// if the url isn't set don't even try to parse it just return.
+	uri, ok := os.LookupEnv(env_prefix + "_AVAILABILITY_CHECK_URL")
+	if !ok {
+		return nil
+	}
+
+	url, err := url.Parse(uri)
 	if err != nil {
 		return nil
 	}

--- a/model/application_type_test.go
+++ b/model/application_type_test.go
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGoodUrl(t *testing.T) {
+	expected := "http://a.good/uri"
+	os.Setenv("TEST_NAME_AVAILABILITY_CHECK_URL", expected)
+
+	a := ApplicationType{Name: "/this/is/my/test-name"}
+	uri := a.AvailabilityCheckURL()
+
+	if uri.String() != expected {
+		t.Errorf("got the wrong availability check url, got %v expected %v", uri.String(), expected)
+	}
+}
+
+func TestNotExistingUrl(t *testing.T) {
+	a := ApplicationType{Name: "/this/one/does/not/exist"}
+	uri := a.AvailabilityCheckURL()
+
+	if uri != nil {
+		t.Errorf("uri pulled from ENV even though it does not exist")
+	}
+}

--- a/model/main_test.go
+++ b/model/main_test.go
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"os"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+)
+
+func TestMain(t *testing.M) {
+	_ = parser.ParseFlags()
+	os.Exit(t.Run())
+}

--- a/routes.go
+++ b/routes.go
@@ -46,6 +46,7 @@ func setupRoutes(e *echo.Echo) {
 	v3.POST("/sources", SourceCreate, permissionMiddleware...)
 	v3.PATCH("/sources/:id", SourceEdit, permissionMiddleware...)
 	v3.DELETE("/sources/:id", SourceDelete, permissionMiddleware...)
+	v3.POST("/sources/:source_id/check_availability", CheckSourceAvailability, middleware.Tenancy)
 	v3.GET("/sources/:source_id/application_types", SourceListApplicationTypes, tenancyWithListMiddleware...)
 	v3.GET("/sources/:source_id/applications", SourceListApplications, tenancyWithListMiddleware...)
 	v3.GET("/sources/:source_id/endpoints", SourceListEndpoint, tenancyWithListMiddleware...)

--- a/routes.go
+++ b/routes.go
@@ -46,7 +46,7 @@ func setupRoutes(e *echo.Echo) {
 	v3.POST("/sources", SourceCreate, permissionMiddleware...)
 	v3.PATCH("/sources/:id", SourceEdit, permissionMiddleware...)
 	v3.DELETE("/sources/:id", SourceDelete, permissionMiddleware...)
-	v3.POST("/sources/:source_id/check_availability", CheckSourceAvailability, middleware.Tenancy)
+	v3.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy)
 	v3.GET("/sources/:source_id/application_types", SourceListApplicationTypes, tenancyWithListMiddleware...)
 	v3.GET("/sources/:source_id/applications", SourceListApplications, tenancyWithListMiddleware...)
 	v3.GET("/sources/:source_id/endpoints", SourceListEndpoint, tenancyWithListMiddleware...)

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	l "github.com/RedHatInsights/sources-api-go/logger"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// storing the satellite topic here since it doesn't change after initial
+// startup.
+var satelliteTopic = config.Get().KafkaTopic("platform.topological-inventory.operations-satellite")
+
+// requests both types of availability checks for a source
+func RequestAvailabilityCheck(source *m.Source) {
+	l.Log.Infof("Requesting Availability Check for Source [%v]", source.ID)
+
+	if len(source.Applications) != 0 {
+		applicationAvailabilityCheck(source)
+	}
+
+	if len(source.Endpoints) != 0 {
+		endpointAvailabilityCheck(source)
+	}
+
+	l.Log.Infof("Finished Publishing Availability Messages for Source %v", source.ID)
+}
+
+// sends off an availability check http request for each of the source's
+// applications
+func applicationAvailabilityCheck(source *m.Source) {
+	for _, app := range source.Applications {
+		l.Log.Infof("Requesting Availability Check for Application %v", app.ID)
+
+		uri := app.ApplicationType.AvailabilityCheckURL()
+		if uri == nil {
+			l.Log.Warnf("Failed to fetch availability check url for [%v] - continuing", app.ApplicationType.Name)
+			continue
+		}
+
+		requestAvailabilityCheck(source, &app, uri)
+	}
+}
+
+func requestAvailabilityCheck(source *m.Source, app *m.Application, uri *url.URL) {
+	httpClient := http.Client{Timeout: 10 * time.Second}
+
+	body := map[string]string{"source_id": strconv.FormatInt(app.SourceID, 10)}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		l.Log.Warnf("Failed to marshal source body for [%v] - continuing", app.SourceID)
+		return
+	}
+
+	req, err := http.NewRequest(http.MethodPost, uri.String(), bytes.NewBuffer(raw))
+	if err != nil {
+		l.Log.Warnf("Failed to make request for application [%v], uri [%v]", app.ID, uri.String())
+		return
+	}
+
+	req.Header.Add("x-rh-sources-account-number", source.Tenant.ExternalTenant)
+	req.Header.Add("x-rh-identity", util.XRhIdentityWithAccountNumber(source.Tenant.ExternalTenant))
+	req.Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		l.Log.Warnf("Error requesting availability status for application [%v], error: %v", app.ID, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// anything greater than 299 is bad, right??? right????
+	if resp.StatusCode%100 > 2 {
+		l.Log.Warnf("Bad response from client: %v", resp.StatusCode)
+	}
+}
+
+// codified version of what we were sending over kafka. The satellite operations
+// worker picks this message up and makes the proper requests to the
+// platform-receptor-controller.
+type satelliteAvailabilityMessage struct {
+	SourceID       string  `json:"source_id"`
+	SourceUID      *string `json:"source_uid"`
+	SourceRef      *string `json:"source_ref"`
+	ExternalTenant string  `json:"external_tenant"`
+}
+
+// sends off an availability check kafka message for each of the source's
+// endpoints but only if the source is of type satellite - we do not support any
+// other operations currently (legacy behavior)
+func endpointAvailabilityCheck(source *m.Source) {
+	if source.SourceType.Name != "satellite" {
+		l.Log.Infof("Skipping Endpoint availability check for non-satellite source type")
+		return
+	}
+
+	// instantiate a producer for this source
+	mgr := &kafka.Manager{Config: kafka.Config{
+		KafkaBrokers:   config.Get().KafkaBrokers,
+		ProducerConfig: kafka.ProducerConfig{Topic: satelliteTopic},
+	}}
+
+	l.Log.Infof("Publishing message for Source [%v] topic [%v] ", source.ID, mgr.ProducerConfig.Topic)
+	for _, endpoint := range source.Endpoints {
+		publishSatelliteMessage(mgr, source, &endpoint)
+	}
+}
+
+func publishSatelliteMessage(mgr *kafka.Manager, source *m.Source, endpoint *m.Endpoint) {
+	l.Log.Infof("Requesting Availability Check for Endpoint %v", endpoint.ID)
+
+	msg := &kafka.Message{}
+	err := msg.AddValueAsJSON(&satelliteAvailabilityMessage{
+		SourceID:       strconv.FormatInt(source.ID, 10),
+		SourceUID:      source.Uid,
+		SourceRef:      source.SourceRef,
+		ExternalTenant: source.Tenant.ExternalTenant,
+	})
+	if err != nil {
+		l.Log.Warnf("Failed to add struct value as json to kafka message")
+		return
+	}
+
+	msg.AddHeaders([]kafka.Header{
+		{Key: "x-rh-identity", Value: []byte(util.XRhIdentityWithAccountNumber(endpoint.Tenant.ExternalTenant))},
+	})
+
+	err = mgr.Produce(msg)
+	if err != nil {
+		l.Log.Warnf("Failed to produce kafka message for Source %v, error: %v", source.ID, err)
+	}
+}

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -58,11 +58,11 @@ func (acr availabilityCheckRequester) ApplicationAvailabilityCheck(source *m.Sou
 			continue
 		}
 
-		requestAvailabilityCheck(source, &app, uri)
+		httpAvailabilityRequest(source, &app, uri)
 	}
 }
 
-func requestAvailabilityCheck(source *m.Source, app *m.Application, uri *url.URL) {
+func httpAvailabilityRequest(source *m.Source, app *m.Application, uri *url.URL) {
 	body := map[string]string{"source_id": strconv.FormatInt(app.SourceID, 10)}
 	raw, err := json.Marshal(body)
 	if err != nil {
@@ -145,6 +145,7 @@ func publishSatelliteMessage(mgr *kafka.Manager, source *m.Source, endpoint *m.E
 
 	msg.AddHeaders([]kafka.Header{
 		{Key: "x-rh-identity", Value: []byte(util.XRhIdentityWithAccountNumber(endpoint.Tenant.ExternalTenant))},
+		{Key: "x-rh-sources-account-number", Value: []byte(endpoint.Tenant.ExternalTenant)},
 	})
 
 	err = mgr.Produce(msg)

--- a/service/availability_check_test.go
+++ b/service/availability_check_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"testing"
+
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
+
+type dummyChecker struct {
+	ApplicationCounter int
+	EndpointCounter    int
+}
+
+func (c *dummyChecker) ApplicationAvailabilityCheck(source *m.Source) {
+	for i := 0; i < len(source.Applications); i++ {
+		c.ApplicationCounter++
+	}
+}
+
+func (c *dummyChecker) EndpointAvailabilityCheck(source *m.Source) {
+	for i := 0; i < len(source.Endpoints); i++ {
+		c.EndpointCounter++
+	}
+}
+
+func TestApplicationAvailability(t *testing.T) {
+	d := &dummyChecker{}
+	ac = d
+
+	RequestAvailabilityCheck(&m.Source{
+		// 2 applications on this source.
+		Applications: []m.Application{{}, {}},
+	})
+
+	if d.ApplicationCounter != 2 {
+		t.Errorf("availability check not called for both applications, got %v expected %v", d.ApplicationCounter, 2)
+	}
+}
+
+func TestEndpointAvailability(t *testing.T) {
+	d := &dummyChecker{}
+	ac = d
+
+	RequestAvailabilityCheck(&m.Source{
+		// 3 endpoints on this source.
+		Endpoints: []m.Endpoint{{}, {}, {}},
+	})
+
+	if d.EndpointCounter != 3 {
+		t.Errorf("availability check not called for all endpoints, got %v expected %v", d.EndpointCounter, 3)
+	}
+}
+
+func TestBothAvailability(t *testing.T) {
+	d := &dummyChecker{}
+	ac = d
+
+	RequestAvailabilityCheck(&m.Source{
+		// 2 applications on this source.
+		Applications: []m.Application{{}, {}, {}},
+		// 3 endpoints on this source.
+		Endpoints: []m.Endpoint{{}, {}, {}, {}},
+	})
+
+	if d.ApplicationCounter != 3 {
+		t.Errorf("availability check not called for both applications, got %v expected %v", d.ApplicationCounter, 3)
+	}
+
+	if d.EndpointCounter != 4 {
+		t.Errorf("availability check not called for all endpoints, got %v expected %v", d.EndpointCounter, 4)
+	}
+}

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -4,10 +4,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+	"github.com/RedHatInsights/sources-api-go/logger"
 )
 
 var (
@@ -19,6 +21,8 @@ var (
 )
 
 func TestMain(t *testing.M) {
+	logger.InitLogger(config.Get())
+
 	flags := parser.ParseFlags()
 
 	if flags.CreateDb {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -278,7 +278,7 @@ func SourceListAuthentications(c echo.Context) error {
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), 100, 0))
 }
 
-func CheckSourceAvailability(c echo.Context) error {
+func SourceCheckAvailability(c echo.Context) error {
 	sourceDao, err := getSourceDao(c)
 	if err != nil {
 		return err

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -308,3 +308,49 @@ func TestSourceCreate(t *testing.T) {
 		t.Errorf("Did not return 200. Body: %s", rec.Body.String())
 	}
 }
+
+func TestAvailabilityStatusCheck(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/check_availability",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues("1")
+
+	err := SourceCheckAvailability(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 202 {
+		t.Errorf("Wrong code, got %v, expected %v", rec.Code, 202)
+	}
+}
+
+func TestAvailabilityStatusCheckNotFound(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/183209745/check_availability",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues("183209745")
+
+	err := SourceCheckAvailability(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 404 {
+		t.Errorf("Wrong code, got %v, expected %v", rec.Code, 404)
+	}
+}

--- a/util/identity_header.go
+++ b/util/identity_header.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"encoding/base64"
+	"encoding/json"
+)
+
+type minimalIdentityHeader struct {
+	Identity id `json:"identity"`
+}
+
+type id struct {
+	Account string `json:"account_number"`
+}
+
+func newMinimalIdentity(account string) *minimalIdentityHeader {
+	return &minimalIdentityHeader{Identity: id{Account: account}}
+}
+
+// returns a base64 encoded header to use as x-rh-identity when one is not
+// provided
+func XRhIdentityWithAccountNumber(account string) string {
+	bytes, err := json.Marshal(newMinimalIdentity(account))
+	if err != nil {
+		return ""
+	}
+
+	return base64.StdEncoding.EncodeToString(bytes)
+}

--- a/util/identity_header_test.go
+++ b/util/identity_header_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+func TestCreateIdentityHeader(t *testing.T) {
+	out := XRhIdentityWithAccountNumber("1234")
+
+	bytes, err := base64.StdEncoding.DecodeString(out)
+	if err != nil {
+		t.Errorf("failed to decode generated x-rh-identity")
+	}
+
+	var identity identity.XRHID
+	err = json.Unmarshal(bytes, &identity)
+	if err != nil {
+		t.Errorf("failed to unmarshal generated x-rh-identity")
+	}
+
+	if identity.Identity.AccountNumber != "1234" {
+		t.Errorf("did not marshal correctly, got %v wanted %v", identity.Identity.AccountNumber, "1234")
+	}
+}


### PR DESCRIPTION
[RHCLOUD-17536](https://issues.redhat.com/browse/RHCLOUD-17536)

Adds the endpoint to request an availability status for a source.

It basically follows this flow:
1. Lookup source (and basically all of its subresources)
2. Loop through applications, sending http requests to the configured endpoint (set in deploy/clowdapp.yml)
3. Loop through endpoints, checking to see if the source is a satellite source, then proceeding to produce kafka messages for the source.

--- 

Another notable thing is the `SourceDao.GetByIdWithPreload` which basically allows you to pass a variable amount of args and let gorm.io preload the relations. Works great!

\# TODO:
- [x] tests, shouldn't be too bad.