### PR TITLE
Use interface for Vault instance

### DIFF
--- a/dao/db.go
+++ b/dao/db.go
@@ -16,7 +16,7 @@ var (
 	DB *gorm.DB
 
 	vaultClient *vault.Client
-	Vault       *vault.Logical
+	Vault       VaultClient
 
 	conf = config.Get()
 )
@@ -55,6 +55,7 @@ func Init() {
 	if err != nil {
 		panic(fmt.Sprintf("Failed to Create Vault Client: %v", err))
 	}
+
 	Vault = vaultClient.Logical()
 }
 

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -3,6 +3,7 @@ package dao
 import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/hashicorp/vault/api"
 )
 
 type SourceDao interface {
@@ -89,4 +90,11 @@ type SourceTypeDao interface {
 	Create(src *m.SourceType) error
 	Update(src *m.SourceType) error
 	Delete(id *int64) error
+}
+
+type VaultClient interface {
+	Read(path string) (*api.Secret, error)
+	List(path string) (*api.Secret, error)
+	Write(path string, data map[string]interface{}) (*api.Secret, error)
+	Delete(path string) (*api.Secret, error)
 }

--- a/internal/testutils/mocks/mock_vault.go
+++ b/internal/testutils/mocks/mock_vault.go
@@ -1,0 +1,41 @@
+package mocks
+
+import (
+	"fmt"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/hashicorp/vault/api"
+)
+
+type MockVault struct {
+}
+
+func (m *MockVault) Read(path string) (*api.Secret, error) {
+	if path != fmt.Sprintf("secret/data/%d/%v", fixtures.TestTenantData[0].Id, "") {
+		return nil, nil
+	}
+
+	secret := &api.Secret{}
+	secret.Data = make(map[string]interface{})
+	secret.Data["data"] = map[string]interface{}{}
+	secret.Data["metadata"] = map[string]interface{}{}
+
+	return secret, nil
+}
+
+func (m *MockVault) List(_ string) (*api.Secret, error) {
+	secret := &api.Secret{}
+
+	secret.Data = make(map[string]interface{})
+	secret.Data["keys"] = []interface{}{""}
+
+	return secret, nil
+}
+
+func (m *MockVault) Write(path string, data map[string]interface{}) (*api.Secret, error) {
+	panic("implement me Write")
+}
+
+func (m *MockVault) Delete(path string) (*api.Secret, error) {
+	panic("implement me Delete")
+}


### PR DESCRIPTION
This change also add mock struct which satisfy interface `LogicalClient` as well as `vault.Logical` - it can be used for testing for Vault-related code.


### Links
Pull out from https://github.com/RedHatInsights/sources-api-go/pull/76
