### PR TITLE
Move out struct status message to "types" package

### DIFF
--- a/internal/types/status_message.go
+++ b/internal/types/status_message.go
@@ -1,4 +1,4 @@
-package statuslistener
+package types
 
 type StatusMessage struct {
 	ResourceType string `json:"resource_type"`

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -7,6 +7,7 @@ import (
 	c "github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/events"
+	"github.com/RedHatInsights/sources-api-go/internal/types"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
@@ -53,7 +54,7 @@ func (avs *AvailabilityStatusListener) subscribeToAvailabilityStatus() {
 }
 
 func (avs *AvailabilityStatusListener) ConsumeStatusMessage(message kafka.Message) {
-	var statusMessage StatusMessage
+	var statusMessage types.StatusMessage
 	err := message.ParseTo(&statusMessage)
 	if err != nil {
 		logging.Log.Errorf("Error in parsing status message %v", err)
@@ -84,7 +85,7 @@ func (avs *AvailabilityStatusListener) headersFrom(message kafka.Message) []kafk
 	return headers
 }
 
-func (avs *AvailabilityStatusListener) processEvent(statusMessage StatusMessage, headers []kafka.Header) {
+func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMessage, headers []kafka.Header) {
 	resourceID, err := util.InterfaceToInt64(statusMessage.ResourceID)
 	if err != nil {
 		logging.Log.Errorf("Error parsing resource_id: %s", err.Error())
@@ -123,7 +124,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage StatusMessage,
 	}
 }
 
-func (avs *AvailabilityStatusListener) attributesForUpdate(statusMessage StatusMessage) map[string]interface{} {
+func (avs *AvailabilityStatusListener) attributesForUpdate(statusMessage types.StatusMessage) map[string]interface{} {
 	updateAttributes := make(map[string]interface{})
 
 	updateAttributes["last_checked_at"] = time.Now().Format("2006-01-02T15:04:05.999Z")

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/events"
+	"github.com/RedHatInsights/sources-api-go/internal/types"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
@@ -33,7 +34,7 @@ func (m MockFormatter) Format(_ *logrus.Entry) ([]byte, error) {
 type MockEventStreamSender struct {
 	events.EventStreamSender
 	TestSuite *testing.T
-	StatusMessage
+	types.StatusMessage
 
 	RaiseEventCalled bool
 }
@@ -295,7 +296,7 @@ type ExpectedData struct {
 }
 
 type TestData struct {
-	StatusMessage
+	types.StatusMessage
 	m.AvailabilityStatus
 	ExpectedData
 
@@ -320,19 +321,20 @@ func TestConsumeStatusMessage(t *testing.T) {
 	logging.Log = &log
 
 	header := kafkaGo.Header{Key: "event_type", Value: []byte("availability_status")}
-	header2 := kafkaGo.Header{Key: "x-rh-identity", Value: []byte("Test identity")}
+	// {"identity":{"account_number":"12345","user": {"is_org_admin":true}}, "internal": {"org_id": "000001"}}
+	header2 := kafkaGo.Header{Key: "x-rh-identity", Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
 	header3 := kafkaGo.Header{Key: "x-rh-sources-account-number", Value: []byte("12345")}
 	headers := []kafkaGo.Header{header, header2, header3}
-	statusMessage := StatusMessage{ResourceType: "Source", ResourceID: "1", Status: m.Available}
+	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", Status: m.Available}
 	sourceTestData := TestData{StatusMessage: statusMessage, MessageHeaders: headers, RaiseEventCalled: true}
 
-	statusMessageApplication := StatusMessage{ResourceType: "Application", ResourceID: "1", Status: m.Available}
+	statusMessageApplication := types.StatusMessage{ResourceType: "Application", ResourceID: "1", Status: m.Available}
 	applicationTestData := TestData{StatusMessage: statusMessageApplication, MessageHeaders: headers, RaiseEventCalled: true}
 
-	statusMessageEndpoint := StatusMessage{ResourceType: "Endpoint", ResourceID: "1", Status: m.Available}
+	statusMessageEndpoint := types.StatusMessage{ResourceType: "Endpoint", ResourceID: "1", Status: m.Available}
 	endpointTestData := TestData{StatusMessage: statusMessageEndpoint, MessageHeaders: headers, RaiseEventCalled: true}
 
-	statusMessageEndpoint = StatusMessage{ResourceType: "Endpoint", ResourceID: "99", Status: m.Available}
+	statusMessageEndpoint = types.StatusMessage{ResourceType: "Endpoint", ResourceID: "99", Status: m.Available}
 	endpointTestDataNotFound := TestData{StatusMessage: statusMessageEndpoint, MessageHeaders: headers, RaiseEventCalled: false}
 
 	testData = make([]TestData, 4)


### PR DESCRIPTION
WIP:
- [x] https://github.com/RedHatInsights/sources-api-go/pull/78

This change allows to avoid cyclic dependency  issues.

### Links
Pull out from https://github.com/RedHatInsights/sources-api-go/pull/76
- Pull out from https://github.com/RedHatInsights/sources-api-go/pull/76
- PR begins from commit [Move struct StatusMessage to 'types' package](https://github.com/RedHatInsights/sources-api-go/pull/79/commits/564f6d2f176a320323f6e224b4f89f5efb1a91ce)




