### PR TITLE
Remove duplicated "TestMain" function from the "dao" package

### DIFF
--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -4,23 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/marketplace"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/redis"
 	"github.com/sirupsen/logrus"
 )
-
-func TestMain(t *testing.M) {
-	// we need this to parse arguments otherwise there are not recognized which lead to error
-	_ = parser.ParseFlags()
-
-	os.Exit(t.Run())
-}
 
 // setUpBearerToken sets up a fake bearer token to be used in the tests.
 func setUpBearerToken() *marketplace.BearerToken {


### PR DESCRIPTION
The "authentication_dao_test" file had a "TestMain" already, which is causing the "duplicated test main function" issue when running the tests.