### PR TITLE
fix: use the authentication type as the identifier for marketplace auths

### DIFF
--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -479,7 +479,7 @@ func (a *AuthenticationDaoImpl) ToEventJSON(resource util.Resource) ([]byte, err
 // only if the provided authentication is of the type "marketplace".
 func setMarketplaceTokenAuthExtraField(auth *m.Authentication) error {
 	// If the authentication isn't a "marketplace" auth, then skip getting the token
-	if auth.Name != "marketplace" {
+	if auth.AuthType != "marketplace-token" {
 		return nil
 	}
 

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -24,6 +24,11 @@ func setUpBearerToken() *marketplace.BearerToken {
 	}
 }
 
+// setUpValidMarketplaceAuth sets up a valid authentication which is of the "marketplace" type.
+func setUpValidMarketplaceAuth() *m.Authentication {
+	return &m.Authentication{AuthType: "marketplace-token", Password: "apiKey"}
+}
+
 // -----------------------------
 // --- [Mocks & fakes setup] ---
 // -----------------------------
@@ -105,9 +110,10 @@ func (marketplaceTokenProviderFailure) RequestToken() (*marketplace.BearerToken,
 // TestNotMarketplaceAuthNotProcessed tests that in the case of having a non-marketplace authentication, no token is
 // fetched whatsoever.
 func TestNotMarketplaceAuthNotProcessed(t *testing.T) {
-	auth := m.Authentication{Name: "whatever"}
+	auth := setUpValidMarketplaceAuth()
+	auth.AuthType = "whatever"
 
-	err := setMarketplaceTokenAuthExtraField(&auth)
+	err := setMarketplaceTokenAuthExtraField(auth)
 	if err != nil {
 		t.Errorf("want no errors, got %s", err)
 	}
@@ -131,7 +137,7 @@ func TestAuthFromVaultMarketplaceCacheHit(t *testing.T) {
 	tenantId := int64(5)
 	marketplaceTokenCacher = GetMarketplaceTokenCacher(&tenantId)
 
-	auth := &m.Authentication{Name: "marketplace"}
+	auth := setUpValidMarketplaceAuth()
 
 	// Call the function under test
 	err := setMarketplaceTokenAuthExtraField(auth)
@@ -179,7 +185,8 @@ func TestAuthFromVaultMarketplaceProviderEmptyPassword(t *testing.T) {
 	tenantId := int64(5)
 	marketplaceTokenCacher = GetMarketplaceTokenCacher(&tenantId)
 
-	auth := &m.Authentication{Name: "marketplace", Password: ""}
+	auth := setUpValidMarketplaceAuth()
+	auth.Password = "" // set up the empty password to simulate a missing API key
 
 	// Call the function under test
 	err := setMarketplaceTokenAuthExtraField(auth)
@@ -209,7 +216,7 @@ func TestAuthFromVaultMarketplaceProviderSuccess(t *testing.T) {
 	tenantId := int64(5)
 	marketplaceTokenCacher = GetMarketplaceTokenCacher(&tenantId)
 
-	auth := &m.Authentication{Name: "marketplace", Password: "12345"}
+	auth := setUpValidMarketplaceAuth()
 
 	// We need the logging mechanism initialized, as otherwise we will hit a dereference error when trying to use the
 	// logger.
@@ -247,7 +254,7 @@ func TestAuthFromVaultMarketplaceProviderSuccessCacheFailure(t *testing.T) {
 	tenantId := int64(5)
 	marketplaceTokenCacher = GetMarketplaceTokenCacher(&tenantId)
 
-	auth := &m.Authentication{Name: "marketplace", Password: "12345"}
+	auth := setUpValidMarketplaceAuth()
 
 	// Call the function under test
 	err := setMarketplaceTokenAuthExtraField(auth)
@@ -280,7 +287,7 @@ func TestAuthFromVaultMarketplaceProviderFailure(t *testing.T) {
 	tenantId := int64(5)
 	marketplaceTokenCacher = GetMarketplaceTokenCacher(&tenantId)
 
-	auth := &m.Authentication{Name: "marketplace", Password: "12345"}
+	auth := setUpValidMarketplaceAuth()
 
 	err := setMarketplaceTokenAuthExtraField(auth)
 	if err == nil {


### PR DESCRIPTION
The frontend creates the marketplace authentications with the "authentication type" field set to "marketplace-token". Therefore, using the "authentication.Name" field to identify marketplace authentications doesn't make sense.

## Links

* Related PR: [[sources-api/pull/475]](https://github.com/RedHatInsights/sources-api/pull/475)
* Jira issue: [[RHCLOUD-17795]](https://issues.redhat.com/browse/RHCLOUD-17795)