### PR TITLE
Fix some type asserts and skip running the linter on test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+issues:
+  exclude-rules:
+    # skip forcing a type assert on test files. can add more skips for test files as necessary
+    # per https://golangci-lint.run/usage/false-positives/
+    - path: '(.+)_test\.go'
+      linters:
+        - forcetypeassert

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -252,7 +252,12 @@ func (a *AuthenticationDaoImpl) Create(auth *m.Authentication) error {
 	if err != nil {
 		return err
 	}
-	auth.Version = out.Data["version"].(json.Number).String()
+
+	number, ok := out.Data["version"].(json.Number)
+	if !ok {
+		return nil
+	}
+	auth.Version = number.String()
 
 	return nil
 }
@@ -269,7 +274,11 @@ func (a *AuthenticationDaoImpl) Update(auth *m.Authentication) error {
 	if err != nil {
 		return err
 	}
-	auth.Version = out.Data["version"].(json.Number).String()
+	number, ok := out.Data["version"].(json.Number)
+	if !ok {
+		return nil
+	}
+	auth.Version = number.String()
 
 	return nil
 }
@@ -390,7 +399,11 @@ func authFromVault(secret *api.Secret) *m.Authentication {
 	// than a panic happening at runtime.
 	auth := &m.Authentication{}
 	auth.CreatedAt = createdAt
-	auth.Version = metadata["version"].(json.Number).String()
+	number, ok := metadata["version"].(json.Number)
+	if !ok {
+		return nil
+	}
+	auth.Version = number.String()
 
 	if extra != nil {
 		auth.Extra = extra


### PR DESCRIPTION
golangci-lint has been failing for a minute now - took some time to fix the type asserts I had introduced pre-linter and then got copied.

Also added the config file for golangci-lint to not hold the test files as accountable as the actual source files. 