### PR TITLE
Fix linter-fixes fixes: return error on failed cast rather than nothing

### DIFF
--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -255,7 +255,7 @@ func (a *AuthenticationDaoImpl) Create(auth *m.Authentication) error {
 
 	number, ok := out.Data["version"].(json.Number)
 	if !ok {
-		return nil
+		return errors.New("failed to cast vault version number to string")
 	}
 	auth.Version = number.String()
 
@@ -276,7 +276,7 @@ func (a *AuthenticationDaoImpl) Update(auth *m.Authentication) error {
 	}
 	number, ok := out.Data["version"].(json.Number)
 	if !ok {
-		return nil
+		return errors.New("failed to cast vault version number to string")
 	}
 	auth.Version = number.String()
 


### PR DESCRIPTION
I made a mistake in #86, returning nil is fine in the `authFromVault` function - but we need to bubble the error up. Whoops.