### PR TITLE
refactor: run Miniredis in a non-default port

### DIFF
--- a/redis/main_test.go
+++ b/redis/main_test.go
@@ -1,15 +1,31 @@
 package redis
 
 import (
+	"log"
 	"os"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+	miniredisV2 "github.com/alicebob/miniredis/v2"
 )
+
+var miniredis *miniredisV2.Miniredis
 
 func TestMain(t *testing.M) {
 	// we need this to parse arguments otherwise there are not recognized which lead to error
 	_ = parser.ParseFlags()
 
-	os.Exit(t.Run())
+	// Start Miniredis
+	miniredis = miniredisV2.NewMiniRedis()
+	err := miniredis.StartAddr("localhost:45884")
+	if err != nil {
+		log.Fatalf("Could not initialize Minidredis: %s", err)
+	}
+
+	result := t.Run()
+
+	// Close Miniredis
+	miniredis.Close()
+
+	os.Exit(result)
 }

--- a/redis/marketplace_token_test.go
+++ b/redis/marketplace_token_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 var tokenCacher = &MarketplaceTokenCacher{TenantID: 5}
+var redisAddr = "localhost:45884"
 
 // setUpFakeToken sets up a test token ready to be used.
 func setUpFakeToken() *marketplace.BearerToken {
@@ -28,7 +29,8 @@ func setUpFakeToken() *marketplace.BearerToken {
 
 // TestGetTokenBadTenant tests that when given a bad or nonexistent tenant, an expected error is returned.
 func TestGetTokenBadTenant(t *testing.T) {
-	mr, err := miniredis.Run()
+	mr := miniredis.NewMiniRedis()
+	err := mr.StartAddr(redisAddr)
 	if err != nil {
 		t.Errorf("cannot run the Miniredis mock server: %s", err)
 	}
@@ -50,7 +52,8 @@ func TestGetTokenBadTenant(t *testing.T) {
 
 // TestGetToken sets up a predefined token on the Redis cache, and tries to fetch it using the "GetToken" function.
 func TestGetToken(t *testing.T) {
-	mr, err := miniredis.Run()
+	mr := miniredis.NewMiniRedis()
+	err := mr.StartAddr(redisAddr)
 	if err != nil {
 		t.Errorf("cannot run the Miniredis mock server: %s", err)
 	}
@@ -111,7 +114,8 @@ func TestSetTokenUnreachableRedis(t *testing.T) {
 
 // TestSetTokenSuccess tests that the token is successfully set on Redis.
 func TestSetTokenSuccess(t *testing.T) {
-	mr, err := miniredis.Run()
+	mr := miniredis.NewMiniRedis()
+	err := mr.StartAddr(redisAddr)
 	if err != nil {
 		t.Errorf("cannot run the Miniredis mock server: %s", err)
 	}
@@ -158,7 +162,8 @@ func TestSetTokenSuccess(t *testing.T) {
 
 // TestSetTokenExpired tests that an error is returned when an expired token is trying to be cached.
 func TestSetTokenExpired(t *testing.T) {
-	mr, err := miniredis.Run()
+	mr := miniredis.NewMiniRedis()
+	err := mr.StartAddr(redisAddr)
 	if err != nil {
 		t.Errorf("cannot run the Miniredis mock server: %s", err)
 	}

--- a/redis/marketplace_token_test.go
+++ b/redis/marketplace_token_test.go
@@ -8,13 +8,11 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/marketplace"
-	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis"
 	"github.com/sirupsen/logrus"
 )
 
 var tokenCacher = &MarketplaceTokenCacher{TenantID: 5}
-var redisAddr = "localhost:45884"
 
 // setUpFakeToken sets up a test token ready to be used.
 func setUpFakeToken() *marketplace.BearerToken {
@@ -29,22 +27,14 @@ func setUpFakeToken() *marketplace.BearerToken {
 
 // TestGetTokenBadTenant tests that when given a bad or nonexistent tenant, an expected error is returned.
 func TestGetTokenBadTenant(t *testing.T) {
-	mr := miniredis.NewMiniRedis()
-	err := mr.StartAddr(redisAddr)
-	if err != nil {
-		t.Errorf("cannot run the Miniredis mock server: %s", err)
-	}
-
-	defer mr.Close()
-
 	Client = redis.NewClient(
 		&redis.Options{
-			Addr: mr.Addr(),
+			Addr: miniredis.Addr(),
 		},
 	)
 
 	tokenCacher.TenantID = 12345
-	_, err = tokenCacher.FetchToken()
+	_, err := tokenCacher.FetchToken()
 	if err == nil {
 		t.Error("want error, got none")
 	}
@@ -52,20 +42,12 @@ func TestGetTokenBadTenant(t *testing.T) {
 
 // TestGetToken sets up a predefined token on the Redis cache, and tries to fetch it using the "GetToken" function.
 func TestGetToken(t *testing.T) {
-	mr := miniredis.NewMiniRedis()
-	err := mr.StartAddr(redisAddr)
-	if err != nil {
-		t.Errorf("cannot run the Miniredis mock server: %s", err)
-	}
-
 	// We need a logger as the cache and uncache functions log what's being done.
 	logger.Log = logrus.New()
 
-	defer mr.Close()
-
 	Client = redis.NewClient(
 		&redis.Options{
-			Addr: mr.Addr(),
+			Addr: miniredis.Addr(),
 		},
 	)
 
@@ -79,7 +61,7 @@ func TestGetToken(t *testing.T) {
 	// Use a fake tenant id to set the token on Redis
 	tokenCacher.TenantID = 5
 
-	err = mr.Set(fmt.Sprintf("marketplace_token_%d", tokenCacher.TenantID), string(marshalledToken))
+	err = miniredis.Set(fmt.Sprintf("marketplace_token_%d", tokenCacher.TenantID), string(marshalledToken))
 	if err != nil {
 		t.Errorf("no error expected, got %s", err)
 	}
@@ -114,20 +96,12 @@ func TestSetTokenUnreachableRedis(t *testing.T) {
 
 // TestSetTokenSuccess tests that the token is successfully set on Redis.
 func TestSetTokenSuccess(t *testing.T) {
-	mr := miniredis.NewMiniRedis()
-	err := mr.StartAddr(redisAddr)
-	if err != nil {
-		t.Errorf("cannot run the Miniredis mock server: %s", err)
-	}
-
-	defer mr.Close()
-
 	// We need a logger as the cache and uncache functions log what's being done.
 	logger.Log = logrus.New()
 
 	Client = redis.NewClient(
 		&redis.Options{
-			Addr: mr.Addr(),
+			Addr: miniredis.Addr(),
 		},
 	)
 
@@ -136,13 +110,13 @@ func TestSetTokenSuccess(t *testing.T) {
 	tokenCacher.TenantID = 5
 
 	// Call the actual function
-	err = tokenCacher.CacheToken(fakeToken)
+	err := tokenCacher.CacheToken(fakeToken)
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
 	}
 
 	// Fetch the token from Redis
-	got, err := mr.Get(fmt.Sprintf("marketplace_token_%d", tokenCacher.TenantID))
+	got, err := miniredis.Get(fmt.Sprintf("marketplace_token_%d", tokenCacher.TenantID))
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
 	}
@@ -162,20 +136,12 @@ func TestSetTokenSuccess(t *testing.T) {
 
 // TestSetTokenExpired tests that an error is returned when an expired token is trying to be cached.
 func TestSetTokenExpired(t *testing.T) {
-	mr := miniredis.NewMiniRedis()
-	err := mr.StartAddr(redisAddr)
-	if err != nil {
-		t.Errorf("cannot run the Miniredis mock server: %s", err)
-	}
-
-	defer mr.Close()
-
 	// We need a logger as the cache and uncache functions log what's being done.
 	logger.Log = logrus.New()
 
 	Client = redis.NewClient(
 		&redis.Options{
-			Addr: mr.Addr(),
+			Addr: miniredis.Addr(),
 		},
 	)
 
@@ -188,7 +154,7 @@ func TestSetTokenExpired(t *testing.T) {
 	tokenCacher.TenantID = 5
 
 	// Call the actual function
-	err = tokenCacher.CacheToken(fakeToken)
+	err := tokenCacher.CacheToken(fakeToken)
 	if err == nil {
 		t.Errorf("want error, got none")
 	}


### PR DESCRIPTION
Apparently Miniredis is causing some issues with people who are running a full Redis instance locally. It seems that turning off the Redis instance makes the tests pass again, so changing the port on which Miniredis runs should do the trick.

Instead of using the "RunT" function of Miniredis and requesting a random port, a hardcoded one is used instead. This is to avoid having the one in a million chance of getting the default Redis port as the random port. Hopefully this will avoid head scratching to the developer who has to experience tests failing once, and then passing without any issue in the next run.