### PR TITLE
Fix /app_meta_data endpoint to resemble the original application

### DIFF
--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -81,9 +81,6 @@ type MetaDataDao interface {
 	List(limit, offset int, filters []util.Filter) ([]m.MetaData, int64, error)
 	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.MetaData, int64, error)
 	GetById(id *int64) (*m.MetaData, error)
-	Create(src *m.MetaData) error
-	Update(src *m.MetaData) error
-	Delete(id *int64) error
 }
 
 type SourceTypeDao interface {

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -1,8 +1,6 @@
 package dao
 
 import (
-	"fmt"
-
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
@@ -35,7 +33,7 @@ func (a *MetaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit
 
 func (a *MetaDataDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
 	metaData := make([]m.MetaData, 0, limit)
-	query := DB.Debug().Model(&m.MetaData{})
+	query := DB.Debug().Model(&m.MetaData{}).Where("type = 'AppMetaData'")
 
 	query, err := applyFilters(query, filters)
 	if err != nil {
@@ -57,23 +55,4 @@ func (a *MetaDataDaoImpl) GetById(id *int64) (*m.MetaData, error) {
 	}
 
 	return metaData, nil
-}
-
-func (a *MetaDataDaoImpl) Create(metaData *m.MetaData) error {
-	result := DB.Create(metaData)
-	return result.Error
-}
-
-func (a *MetaDataDaoImpl) Update(metaData *m.MetaData) error {
-	result := DB.Updates(metaData)
-	return result.Error
-}
-
-func (a *MetaDataDaoImpl) Delete(id *int64) error {
-	metaData := &m.MetaData{ID: *id}
-	if result := DB.Delete(metaData); result.RowsAffected == 0 {
-		return fmt.Errorf("failed to delete application id %v", *id)
-	}
-
-	return nil
 }

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -33,7 +33,7 @@ func getMetaDataDaoWithTenant(c echo.Context) (dao.MetaDataDao, error) {
 }
 
 func MetaDataList(c echo.Context) error {
-	applicationDB, err := getMetaDataDao(c)
+	metaDataDB, err := getMetaDataDao(c)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func MetaDataList(c echo.Context) error {
 		count     int64
 	)
 
-	metaDatas, count, err = applicationDB.List(limit, offset, filters)
+	metaDatas, count, err = metaDataDB.List(limit, offset, filters)
 
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
@@ -68,7 +68,7 @@ func MetaDataList(c echo.Context) error {
 }
 
 func ApplicationTypeListMetaData(c echo.Context) error {
-	applicationDB, err := getMetaDataDao(c)
+	metaDataDB, err := getMetaDataDao(c)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 		count     int64
 	)
 
-	metaDatas, count, err = applicationDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
+	metaDatas, count, err = metaDataDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
 
 	if err != nil {
 		if errors.Is(err, util.ErrNotFoundEmpty) {

--- a/model/meta_data.go
+++ b/model/meta_data.go
@@ -28,15 +28,14 @@ func (app *MetaData) RelationInfo() map[string]RelationSetting {
 
 func (app *MetaData) ToResponse() *MetaDataResponse {
 	id := strconv.FormatInt(app.ID, 10)
+	appTypeId := strconv.FormatInt(app.ApplicationTypeID, 10)
 
 	return &MetaDataResponse{
-		ID:            id,
-		CreatedAt:     app.CreatedAt,
-		UpdatedAt:     app.UpdatedAt,
-		Step:          app.Step,
-		Name:          app.Name,
-		Payload:       app.Payload,
-		Substitutions: app.Substitutions,
-		Type:          app.Type,
+		ID:                id,
+		CreatedAt:         app.CreatedAt,
+		UpdatedAt:         app.UpdatedAt,
+		Name:              app.Name,
+		Payload:           app.Payload,
+		ApplicationTypeId: appTypeId,
 	}
 }

--- a/model/meta_data_http.go
+++ b/model/meta_data_http.go
@@ -7,16 +7,11 @@ import (
 )
 
 type MetaDataResponse struct {
-	AvailabilityStatus
-	Pause
-
 	ID        string    `json:"id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
-	Step          int64          `json:"step"`
-	Name          string         `json:"name"`
-	Payload       datatypes.JSON `json:"payload"`
-	Substitutions datatypes.JSON `json:"substitutions"`
-	Type          string         `json:"type"`
+	Name              string         `json:"name"`
+	Payload           datatypes.JSON `json:"payload"`
+	ApplicationTypeId string         `json:"application_type_id"`
 }


### PR DESCRIPTION
Just some things I found while working on the seeding.

1. Don't need create/update/delete methods on the DAO since we're seeding it and its static information
2. Locked down the list view to be only the `AppMetaData` type
3. Removed availabilitystatus/pause fields since those don't exist on the model
