### PR TITLE
[RHCLOUD-17055] Add Middleware for raising event-stream events

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -252,7 +252,7 @@ func TestApplicationCreateGood(t *testing.T) {
 
 	id, _ := strconv.ParseInt(app.ID, 10, 64)
 	dao, _ := getApplicationDao(c)
-	_ = dao.Delete(&id)
+	_, _ = dao.Delete(&id)
 }
 
 func TestApplicationCreateMissingSourceId(t *testing.T) {

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -92,6 +92,8 @@ func AuthenticationCreate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
+	// TODO: once ToEvent() is added for authentication un-comment this.
+	// setEventStreamResource(c, auth)
 	return c.JSON(http.StatusCreated, auth.ToResponse())
 }
 
@@ -118,6 +120,8 @@ func AuthenticationUpdate(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
+	// TODO: once ToEvent() is added for authentication un-comment this.
+	// setEventStreamResource(c, auth)
 	return c.JSON(http.StatusOK, auth.ToResponse())
 }
 
@@ -127,10 +131,12 @@ func AuthenticationDelete(c echo.Context) error {
 		return err
 	}
 
-	err = authDao.Delete(c.Param("uid"))
+	_, err = authDao.Delete(c.Param("uid"))
 	if err != nil {
 		return err
 	}
 
+	// TODO: once ToEvent() is added for authentication un-comment this.
+	// setEventStreamResource(c, auth)
 	return c.NoContent(http.StatusNoContent)
 }

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -73,13 +73,18 @@ func (a *ApplicationDaoImpl) Update(app *m.Application) error {
 	return result.Error
 }
 
-func (a *ApplicationDaoImpl) Delete(id *int64) error {
+func (a *ApplicationDaoImpl) Delete(id *int64) (*m.Application, error) {
 	app := &m.Application{ID: *id}
-	if result := DB.Delete(app); result.RowsAffected == 0 {
-		return fmt.Errorf("failed to delete application id %v", *id)
+	result := DB.Where("tenant_id = ?", a.TenantID).First(app)
+	if result.Error != nil {
+		return nil, util.NewErrNotFound("application")
 	}
 
-	return nil
+	if result := DB.Delete(app); result.Error != nil {
+		return nil, fmt.Errorf("failed to delete application id %v", *id)
+	}
+
+	return app, nil
 }
 
 func (a *ApplicationDaoImpl) Tenant() *int64 {

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -283,22 +283,22 @@ func (a *AuthenticationDaoImpl) Update(auth *m.Authentication) error {
 	return nil
 }
 
-func (a *AuthenticationDaoImpl) Delete(uid string) error {
+func (a *AuthenticationDaoImpl) Delete(uid string) (*m.Authentication, error) {
 	keys, err := a.listKeys()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, key := range keys {
 		if strings.HasSuffix(key, uid) {
 			path := fmt.Sprintf("secret/metadata/%d/%s", *a.TenantID, key)
-			_, err := Vault.Delete(path)
+			sec, err := Vault.Delete(path)
 
-			return err
+			return authFromVault(sec), err
 		}
 	}
 
-	return fmt.Errorf("not found")
+	return nil, fmt.Errorf("not found")
 }
 
 func (a *AuthenticationDaoImpl) Tenant() *int64 {

--- a/dao/common.go
+++ b/dao/common.go
@@ -38,21 +38,16 @@ func BulkMessageFromSource(source *m.Source) (map[string]interface{}, error) {
 	bulkMessage := map[string]interface{}{}
 	bulkMessage["source"] = source.ToEvent()
 
-	endpoints := make([]m.EndpointEvent, len(source.Endpoints))
+	endpoints := make([]interface{}, len(source.Endpoints))
 	for i, endpoint := range source.Endpoints {
-		endpoints[i] = *endpoint.ToEvent()
+		endpoints[i] = endpoint.ToEvent()
 	}
 
 	bulkMessage["endpoints"] = endpoints
 
-	applications := make([]m.ApplicationEvent, len(source.Applications))
+	applications := make([]interface{}, len(source.Applications))
 	for i, application := range source.Applications {
-		event, ok := application.ToEvent().(*m.ApplicationEvent)
-		if !ok {
-			return nil, fmt.Errorf("failed to create application event from application")
-		}
-
-		applications[i] = *event
+		applications[i] = application.ToEvent()
 	}
 
 	bulkMessage["applications"] = applications

--- a/dao/common.go
+++ b/dao/common.go
@@ -47,7 +47,12 @@ func BulkMessageFromSource(source *m.Source) (map[string]interface{}, error) {
 
 	applications := make([]m.ApplicationEvent, len(source.Applications))
 	for i, application := range source.Applications {
-		applications[i] = *application.ToEvent()
+		event, ok := application.ToEvent().(*m.ApplicationEvent)
+		if !ok {
+			return nil, fmt.Errorf("failed to create application event from application")
+		}
+
+		applications[i] = *event
 	}
 
 	bulkMessage["applications"] = applications

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -74,13 +74,18 @@ func (a *EndpointDaoImpl) Update(app *m.Endpoint) error {
 	return result.Error
 }
 
-func (a *EndpointDaoImpl) Delete(id *int64) error {
-	app := &m.Endpoint{ID: *id}
-	if result := DB.Delete(app); result.RowsAffected == 0 {
-		return fmt.Errorf("failed to delete endpoint id %v", *id)
+func (a *EndpointDaoImpl) Delete(id *int64) (*m.Endpoint, error) {
+	endpt := &m.Endpoint{ID: *id}
+	result := DB.Where("tenant_id = ?", a.TenantID).First(&endpt)
+	if result.Error != nil {
+		return nil, util.NewErrNotFound("endpoint")
 	}
 
-	return nil
+	if result := DB.Delete(endpt); result.Error != nil {
+		return nil, fmt.Errorf("failed to delete endpoint id %v", *id)
+	}
+
+	return endpt, nil
 }
 
 func (a *EndpointDaoImpl) Tenant() *int64 {

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -24,7 +24,7 @@ type ApplicationDao interface {
 	GetById(id *int64) (*m.Application, error)
 	Create(src *m.Application) error
 	Update(src *m.Application) error
-	Delete(id *int64) error
+	Delete(id *int64) (*m.Application, error)
 	Tenant() *int64
 }
 

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -12,7 +12,7 @@ type SourceDao interface {
 	GetById(id *int64) (*m.Source, error)
 	Create(src *m.Source) error
 	Update(src *m.Source) error
-	Delete(id *int64) error
+	Delete(id *int64) (*m.Source, error)
 	Tenant() *int64
 	NameExistsInCurrentTenant(name string) bool
 	GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error)

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -66,7 +66,7 @@ type EndpointDao interface {
 	GetById(id *int64) (*m.Endpoint, error)
 	Create(src *m.Endpoint) error
 	Update(src *m.Endpoint) error
-	Delete(id *int64) error
+	Delete(id *int64) (*m.Endpoint, error)
 	Tenant() *int64
 	// CanEndpointBeSetAsDefaultForSource checks if the endpoint can be set as default, by checking if the given source
 	// id already has another endpoint marked as default.

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -37,7 +37,7 @@ type AuthenticationDao interface {
 	ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
 	Create(src *m.Authentication) error
 	Update(src *m.Authentication) error
-	Delete(id string) error
+	Delete(id string) (*m.Authentication, error)
 	Tenant() *int64
 }
 

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -281,8 +281,8 @@ func (a *MockApplicationDao) Update(src *m.Application) error {
 	return nil
 }
 
-func (a *MockApplicationDao) Delete(id *int64) error {
-	return nil
+func (a *MockApplicationDao) Delete(id *int64) (*m.Application, error) {
+	return nil, nil
 }
 
 func (a *MockApplicationDao) Tenant() *int64 {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -334,7 +334,7 @@ func (a *MockEndpointDao) Update(src *m.Endpoint) error {
 	panic("not implemented") // TODO: Implement
 }
 
-func (a *MockEndpointDao) Delete(id *int64) error {
+func (a *MockEndpointDao) Delete(id *int64) (*m.Endpoint, error) {
 	panic("not implemented") // TODO: Implement
 }
 

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -81,7 +81,7 @@ func (src *MockSourceDao) Update(s *m.Source) error {
 	panic("implement me")
 }
 
-func (src *MockSourceDao) Delete(id *int64) error {
+func (src *MockSourceDao) Delete(id *int64) (*m.Source, error) {
 	panic("implement me")
 }
 

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -95,13 +95,18 @@ func (s *SourceDaoImpl) Update(src *m.Source) error {
 	return result.Error
 }
 
-func (s *SourceDaoImpl) Delete(id *int64) error {
+func (s *SourceDaoImpl) Delete(id *int64) (*m.Source, error) {
 	src := &m.Source{ID: *id}
-	if result := DB.Delete(src); result.RowsAffected == 0 {
-		return fmt.Errorf("failed to delete source id %v", *id)
+	result := DB.Where("tenant_id = ?", s.TenantID).First(src)
+	if result.Error != nil {
+		return nil, util.NewErrNotFound("source")
 	}
 
-	return nil
+	if result := DB.Delete(src); result.Error != nil {
+		return nil, fmt.Errorf("failed to delete source id %v", *id)
+	}
+
+	return src, nil
 }
 
 func (s *SourceDaoImpl) Tenant() *int64 {

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -170,7 +170,34 @@ func EndpointCreate(c echo.Context) error {
 		return err
 	}
 
+	setEventStreamResource(c, endpoint)
 	return c.JSON(http.StatusCreated, endpoint.ToResponse())
+}
+
+func EndpointDelete(c echo.Context) error {
+	endpointDao, err := getEndpointDao(c)
+	if err != nil {
+		return err
+	}
+
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	c.Logger().Infof("Deleting Endpoint Id %v", id)
+
+	endpt, err := endpointDao.Delete(&id)
+	if err != nil {
+		if errors.Is(err, util.ErrNotFoundEmpty) {
+			return err
+		}
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
+	}
+
+	setEventStreamResource(c, endpt)
+
+	return c.NoContent(http.StatusNoContent)
 }
 
 func EndpointListAuthentications(c echo.Context) error {

--- a/helpers.go
+++ b/helpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
@@ -34,4 +35,8 @@ func getLimitAndOffset(c echo.Context) (int, int, error) {
 	}
 
 	return limit, offset, nil
+}
+
+func setEventStreamResource(c echo.Context, model m.Event) {
+	c.Set("resource", model.ToEvent())
 }

--- a/internal/testutils/request/request.go
+++ b/internal/testutils/request/request.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"io"
+	"net/http"
 	"net/http/httptest"
 
 	"github.com/labstack/echo/v4"
@@ -21,4 +22,10 @@ func CreateTestContext(method string, path string, body io.Reader, context map[s
 	}
 
 	return echoContext, recorder
+}
+
+// EmptyTestContext returns an empty http context - for when we don't need much
+// other than the recorder + context
+func EmptyTestContext() (echo.Context, *httptest.ResponseRecorder) {
+	return CreateTestContext(http.MethodGet, "/", nil, nil)
 }

--- a/middleware/event_stream.go
+++ b/middleware/event_stream.go
@@ -60,7 +60,7 @@ func raiseEvent(eventType string) echo.MiddlewareFunc {
 			// in the handler for this to work.
 			resource := c.Get("resource")
 			if resource == nil {
-				l.Log.Warnf("failed to pull event resource from context - skipping raise event")
+				l.Log.Infof("failed to pull event resource from context - skipping raise event")
 				return nil
 			}
 

--- a/middleware/event_stream.go
+++ b/middleware/event_stream.go
@@ -1,0 +1,131 @@
+package middleware
+
+import (
+	"encoding/json"
+
+	"github.com/RedHatInsights/sources-api-go/internal/events"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	l "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
+)
+
+// middleware functions for each event type - adding this to the middleware
+// stack will raise an event based on the `resource` field set in the context
+// during the handler
+
+var (
+	RaiseSourceCreateEvent  = raiseEvent("Source.create")
+	RaiseSourceUpdateEvent  = raiseEvent("Source.update")
+	RaiseSourceDestroyEvent = raiseEvent("Source.destroy")
+
+	RaiseApplicationCreateEvent  = raiseEvent("Application.create")
+	RaiseApplicationUpdateEvent  = raiseEvent("Application.update")
+	RaiseApplicationDestroyEvent = raiseEvent("Application.destroy")
+
+	RaiseEndpointCreateEvent  = raiseEvent("Endpoint.create")
+	RaiseEndpointUpdateEvent  = raiseEvent("Endpoint.update")
+	RaiseEndpointDestroyEvent = raiseEvent("Endpoint.destroy")
+
+	RaiseAuthenticationCreateEvent  = raiseEvent("Authentication.create")
+	RaiseAuthenticationUpdateEvent  = raiseEvent("Authentication.update")
+	RaiseAuthenticationDestroyEvent = raiseEvent("Authentication.destroy")
+
+	RaiseApplicationAuthenticationCreateEvent  = raiseEvent("ApplicationAuthentication.create")
+	RaiseApplicationAuthenticationUpdateEvent  = raiseEvent("ApplicationAuthentication.update")
+	RaiseApplicationAuthenticationDestroyEvent = raiseEvent("ApplicationAuthentication.destroy")
+)
+
+// producer instance used to send messages - default just an empty instance of
+// the struct.
+var producer = events.EventStreamProducer{Sender: &events.EventStreamSender{}}
+
+/*
+	Function that takes an event-type as a string and then returns a middleware
+	function that raises the specified event if the handler operation succeeds.
+
+	It bails out if there isn't a `resource` field on the context which should
+	be a model.ToEvent() call in the handler.
+*/
+func raiseEvent(eventType string) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// first call the handler function (or the next middlware)
+			err := next(c)
+			if err != nil {
+				return err
+			}
+
+			// pull the "event" resource from the context, which needs to be set
+			// in the handler for this to work.
+			resource := c.Get("resource")
+			if resource == nil {
+				l.Log.Warnf("failed to pull event resource from context - skipping raise event")
+				return nil
+			}
+
+			// specifically skip raising an event if this is set - usually when
+			// a create action happened but we do not want to re-raise the
+			// event.
+			if c.Get("skip_raise") != nil {
+				l.Log.Infof("skipping raise event per skip_raise set on context")
+				return nil
+			}
+
+			l.Log.Infof("Raising Event %v", eventType)
+
+			msg, err := json.Marshal(resource)
+			if err != nil {
+				return err
+			}
+
+			// TODO: make this async? Run this in a goroutine that way the
+			// request isn't effectively blocked by kafka .
+			headers := append(getRequestHeaders(c), kafka.Header{Key: "event_type", Value: []byte(eventType)})
+			err = producer.RaiseEvent(eventType, msg, headers)
+			if err != nil {
+				l.Log.Warnf("failed to raise event to kafka: %v", err)
+				return nil
+			}
+
+			return nil
+		}
+	}
+}
+
+/*
+    Fetch the headers from the requeset that are needed to forward along
+
+	1. x-rh-identity -- a generated one if it wasn't passed along (e.g. psk)
+
+	2. x-rh-sources-psk -- always passed if present, and used for generation.
+*/
+func getRequestHeaders(c echo.Context) []kafka.Header {
+	headers := make([]kafka.Header, 0)
+
+	if c.Get("psk-account") != nil {
+		psk, ok := c.Get("psk-account").(string)
+		if ok {
+			headers = append(headers, kafka.Header{Key: "x-rh-sources-account-number", Value: []byte(psk)})
+		}
+	}
+
+	if c.Get("x-rh-identity") != nil {
+		xrhid, ok := c.Get("x-rh-identity").(string)
+		if ok {
+			headers = append(headers, kafka.Header{Key: "x-rh-identity", Value: []byte(xrhid)})
+		}
+	} else {
+		psk, ok := c.Get("psk-account").(string)
+		if ok {
+			// the only way this would be nil is if psk auth was used - so lets
+			// generate a dummy header for services that still rely on it.
+			headers = append(headers, kafka.Header{
+				Key:   "x-rh-identity",
+				Value: []byte(util.XRhIdentityWithAccountNumber(psk)),
+			})
+		}
+	}
+
+	return headers
+}

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -1,0 +1,164 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/events"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
+)
+
+var raiseMiddleware = raiseEvent("Thingy.create")
+
+type mockSender struct {
+	hit     int
+	headers []kafka.Header
+	body    string
+}
+
+func (m *mockSender) RaiseEvent(_ string, b []byte, headers []kafka.Header) error {
+	m.headers = headers
+	m.body = string(b)
+	m.hit++
+	return nil
+}
+
+func TestRaiseEvent(t *testing.T) {
+	s := mockSender{}
+	producer = events.EventStreamProducer{Sender: &s}
+	c, rec := request.EmptyTestContext()
+
+	f := raiseMiddleware(func(c echo.Context) error {
+		c.Set("resource", map[string]interface{}{"raised": true})
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	err := f(c)
+	if err != nil {
+		t.Errorf("Got an error when none would have been expected: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("Wrong return code, expected %v got %v", 204, rec.Code)
+	}
+
+	if s.hit != 1 {
+		t.Errorf("Wrong number of hits to raise event, got %v expected %v", s.hit, 1)
+	}
+}
+
+func TestRaiseEventWithHeaders(t *testing.T) {
+	s := mockSender{}
+	producer = events.EventStreamProducer{Sender: &s}
+	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
+		"psk-account":   "1234",
+		"x-rh-identity": "asdfasdf",
+	})
+
+	f := raiseMiddleware(func(c echo.Context) error {
+		c.Set("resource", map[string]interface{}{"raised": true})
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	err := f(c)
+	if err != nil {
+		t.Errorf("Got an error when none would have been expected: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("Wrong return code, expected %v got %v", 204, rec.Code)
+	}
+
+	if s.hit != 1 {
+		t.Errorf("Wrong number of hits to raise event, got %v expected %v", s.hit, 1)
+	}
+
+	if len(s.headers) != 3 {
+		t.Errorf("Headers not set properly from RaiseEvent")
+	}
+
+	expected := []string{"event_type", "x-rh-identity", "x-rh-sources-account-number"}
+	for _, h := range s.headers {
+		if !util.SliceContainsString(expected, h.Key) {
+			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)
+		}
+	}
+}
+
+func TestRaiseEventBody(t *testing.T) {
+	s := mockSender{}
+	producer = events.EventStreamProducer{Sender: &s}
+	c, rec := request.EmptyTestContext()
+
+	f := raiseMiddleware(func(c echo.Context) error {
+		c.Set("resource", map[string]interface{}{"raised": true})
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	err := f(c)
+	if err != nil {
+		t.Errorf("Got an error when none would have been expected: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("Wrong return code, expected %v got %v", 204, rec.Code)
+	}
+
+	if s.hit != 1 {
+		t.Errorf("Wrong number of hits to raise event, got %v expected %v", s.hit, 1)
+	}
+
+	if s.body != `{"raised":true}` {
+		t.Errorf("Raised bad body %v", s.body)
+	}
+}
+
+func TestNoRaiseEvent(t *testing.T) {
+	s := mockSender{}
+	producer = events.EventStreamProducer{Sender: &s}
+	c, rec := request.EmptyTestContext()
+
+	f := raiseMiddleware(func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	err := f(c)
+	if err != nil {
+		t.Errorf("Got an error when none would have been expected: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("Wrong return code, expected %v got %v", 204, rec.Code)
+	}
+
+	if s.hit != 0 {
+		t.Errorf("Wrong number of hits to raise event, got %v expected %v", s.hit, 0)
+	}
+}
+
+func TestSkipOnContext(t *testing.T) {
+	s := mockSender{}
+	producer = events.EventStreamProducer{Sender: &s}
+	c, rec := request.EmptyTestContext()
+
+	f := raiseMiddleware(func(c echo.Context) error {
+		c.Set("skip_raise", struct{}{})
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	err := f(c)
+	if err != nil {
+		t.Errorf("Got an error when none would have been expected: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("Wrong return code, expected %v got %v", 204, rec.Code)
+	}
+
+	if s.hit != 0 {
+		t.Errorf("Wrong number of hits to raise event, got %v expected %v", s.hit, 0)
+	}
+}

--- a/model/application.go
+++ b/model/application.go
@@ -32,7 +32,7 @@ type Application struct {
 	ApplicationAuthentications []ApplicationAuthentication
 }
 
-func (app *Application) ToEvent() *ApplicationEvent {
+func (app *Application) ToEvent() interface{} {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(app.AvailabilityStatus.AvailabilityStatus),
 		LastAvailableAt: util.DateTimeToRecordFormat(app.LastAvailableAt),
 		LastCheckedAt:   util.DateTimeToRecordFormat(app.LastCheckedAt)}

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -33,7 +33,7 @@ type Endpoint struct {
 	Tenant   Tenant
 }
 
-func (endpoint *Endpoint) ToEvent() *EndpointEvent {
+func (endpoint *Endpoint) ToEvent() interface{} {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(endpoint.AvailabilityStatus.AvailabilityStatus),
 		LastAvailableAt: util.DateTimeToRecordFormat(endpoint.LastAvailableAt),
 		LastCheckedAt:   util.DateTimeToRecordFormat(endpoint.LastCheckedAt)}

--- a/model/events.go
+++ b/model/events.go
@@ -8,6 +8,10 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
+type Event interface {
+	ToEvent() interface{}
+}
+
 type EventModelDao interface {
 	BulkMessage(resource util.Resource) (map[string]interface{}, error)
 	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error

--- a/model/source.go
+++ b/model/source.go
@@ -43,7 +43,7 @@ type Source struct {
 	Endpoints        []Endpoint
 }
 
-func (src *Source) ToEvent() *SourceEvent {
+func (src *Source) ToEvent() interface{} {
 	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(src.AvailabilityStatus.AvailabilityStatus),
 		LastAvailableAt: util.DateTimeToRecordFormat(src.LastAvailableAt),
 		LastCheckedAt:   util.DateTimeToRecordFormat(src.LastCheckedAt)}

--- a/routes.go
+++ b/routes.go
@@ -76,6 +76,7 @@ func setupRoutes(e *echo.Echo) {
 	v3.GET("/endpoints", EndpointList, tenancyWithListMiddleware...)
 	v3.GET("/endpoints/:id", EndpointGet, middleware.Tenancy)
 	v3.POST("/endpoints", EndpointCreate, append(permissionMiddleware, middleware.RaiseEndpointCreateEvent)...)
+	v3.DELETE("/endpoints/:id", EndpointDelete, append(permissionMiddleware, middleware.RaiseEndpointDestroyEvent)...)
 	v3.GET("/endpoints/:endpoint_id/authentications", EndpointListAuthentications, tenancyWithListMiddleware...)
 
 	// ApplicationAuthentications

--- a/routes.go
+++ b/routes.go
@@ -43,9 +43,9 @@ func setupRoutes(e *echo.Echo) {
 	// Sources
 	v3.GET("/sources", SourceList, tenancyWithListMiddleware...)
 	v3.GET("/sources/:id", SourceGet, middleware.Tenancy)
-	v3.POST("/sources", SourceCreate, permissionMiddleware...)
-	v3.PATCH("/sources/:id", SourceEdit, permissionMiddleware...)
-	v3.DELETE("/sources/:id", SourceDelete, permissionMiddleware...)
+	v3.POST("/sources", SourceCreate, append(permissionMiddleware, middleware.RaiseSourceCreateEvent)...)
+	v3.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.RaiseSourceUpdateEvent)...)
+	v3.DELETE("/sources/:id", SourceDelete, append(permissionMiddleware, middleware.RaiseSourceDestroyEvent)...)
 	v3.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy)
 	v3.GET("/sources/:source_id/application_types", SourceListApplicationTypes, tenancyWithListMiddleware...)
 	v3.GET("/sources/:source_id/applications", SourceListApplications, tenancyWithListMiddleware...)
@@ -55,17 +55,17 @@ func setupRoutes(e *echo.Echo) {
 	// Applications
 	v3.GET("/applications", ApplicationList, tenancyWithListMiddleware...)
 	v3.GET("/applications/:id", ApplicationGet, middleware.Tenancy)
-	v3.POST("/applications", ApplicationCreate, permissionMiddleware...)
-	v3.PATCH("/applications/:id", ApplicationEdit, permissionMiddleware...)
-	v3.DELETE("/applications/:id", ApplicationDelete, permissionMiddleware...)
+	v3.POST("/applications", ApplicationCreate, append(permissionMiddleware, middleware.RaiseApplicationCreateEvent)...)
+	v3.PATCH("/applications/:id", ApplicationEdit, append(permissionMiddleware, middleware.RaiseApplicationUpdateEvent)...)
+	v3.DELETE("/applications/:id", ApplicationDelete, append(permissionMiddleware, middleware.RaiseApplicationDestroyEvent)...)
 	v3.GET("/applications/:application_id/authentications", ApplicationListAuthentications, tenancyWithListMiddleware...)
 
 	// Authentications
 	v3.GET("/authentications", AuthenticationList, tenancyWithListMiddleware...)
-	v3.POST("/authentications", AuthenticationCreate, permissionMiddleware...)
 	v3.GET("/authentications/:uid", AuthenticationGet, middleware.Tenancy)
-	v3.PATCH("/authentications/:uid", AuthenticationUpdate, permissionMiddleware...)
-	v3.DELETE("/authentications/:uid", AuthenticationDelete, permissionMiddleware...)
+	v3.POST("/authentications", AuthenticationCreate, append(permissionMiddleware, middleware.RaiseAuthenticationCreateEvent)...)
+	v3.PATCH("/authentications/:uid", AuthenticationUpdate, append(permissionMiddleware, middleware.RaiseAuthenticationUpdateEvent)...)
+	v3.DELETE("/authentications/:uid", AuthenticationDelete, append(permissionMiddleware, middleware.RaiseAuthenticationDestroyEvent)...)
 
 	// ApplicationTypes
 	v3.GET("/application_types", ApplicationTypeList, listMiddleware...)
@@ -74,8 +74,8 @@ func setupRoutes(e *echo.Echo) {
 
 	// Endpoints
 	v3.GET("/endpoints", EndpointList, tenancyWithListMiddleware...)
-	v3.POST("/endpoints", EndpointCreate, permissionMiddleware...)
 	v3.GET("/endpoints/:id", EndpointGet, middleware.Tenancy)
+	v3.POST("/endpoints", EndpointCreate, append(permissionMiddleware, middleware.RaiseEndpointCreateEvent)...)
 	v3.GET("/endpoints/:endpoint_id/authentications", EndpointListAuthentications, tenancyWithListMiddleware...)
 
 	// ApplicationAuthentications

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -130,9 +130,7 @@ func SourceCreate(c echo.Context) error {
 		return err
 	}
 
-	// set the resource for raising the event later.
-	c.Set("resource", source.ToEvent())
-
+	setEventStreamResource(c, source)
 	return c.JSON(http.StatusCreated, source.ToResponse())
 }
 
@@ -163,6 +161,7 @@ func SourceEdit(c echo.Context) error {
 		return err
 	}
 
+	setEventStreamResource(c, s)
 	return c.JSON(http.StatusOK, s.ToResponse())
 }
 
@@ -179,11 +178,15 @@ func SourceDelete(c echo.Context) (err error) {
 
 	c.Logger().Infof("Deleting Source Id %v", id)
 
-	err = sourcesDB.Delete(&id)
+	src, err := sourcesDB.Delete(&id)
 	if err != nil {
-		return c.NoContent(http.StatusNotFound)
+		if errors.Is(err, util.ErrNotFoundEmpty) {
+			return err
+		}
+		return c.JSON(http.StatusBadRequest, util.ErrorDoc(err.Error(), "400"))
 	}
 
+	setEventStreamResource(c, src)
 	return c.NoContent(http.StatusNoContent)
 }
 

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -130,6 +130,9 @@ func SourceCreate(c echo.Context) error {
 		return err
 	}
 
+	// set the resource for raising the event later.
+	c.Set("resource", source.ToEvent())
+
 	return c.JSON(http.StatusCreated, source.ToResponse())
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-17055

### So this is the start of raising events on create/update/delete events. 

I implemented it as a middleware component that runs _after_ the handler runs. So basically we just have to add the middleware to the request stack + set the `resource` field for each event in the handler. I commented it a lot so let me know if you have questions.

This is probably easiest reviewed in commit order. 

#### General Flow
1. request goes through stack, gets authenticated, 
2. raiseEvent middleware gets called, passed down the stack
3. request completes (whether error or not) and returns down the stack
4. event middleware looks and sees if there is a resource to raise and does so if needed
5. the request is rendered to the user while the kafka raise happens in the background

I'm debating adding a `go` directive around the raise event part - since we don't bubble that to the user ever. It'll just fail silently and warn us in the logs.

---

\# TODO:
- [x] Add middleware to all request stacks
- [x] change to raise event if since we aren't _always_ supposed to raise events. **EDIT**: added support so we can force skip in the handler
- [x] Add `c.Set("resource", xxx.ToResponse())` in all handlers
- [x] tests!