### PR TITLE
Use go:embed to embed the seed yaml files

### DIFF
--- a/dao/seeding_test.go
+++ b/dao/seeding_test.go
@@ -9,6 +9,15 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+func getSeedFilesystemDir() string {
+	// if we're in the `dao` directory running the tests directly
+	if strings.HasSuffix(os.Getenv("PWD"), "dao") {
+		return "./seeds/"
+	}
+
+	return "./dao/seeds"
+}
+
 func TestSeedingSourceTypes(t *testing.T) {
 	if !flags.Integration {
 		t.Skip("seeding tests only run during integration tests")
@@ -18,15 +27,8 @@ func TestSeedingSourceTypes(t *testing.T) {
 		t.Fatal("DB is nil - cannot continue test.")
 	}
 
-	var err error
-	var seedsDir string
-	if strings.HasSuffix(os.Getenv("PWD"), "dao") {
-		seedsDir = "./seeds/"
-	} else {
-		seedsDir = DEFAULT_SEEDS_DIR
-	}
-
-	err = seedSourceTypes(seedsDir)
+	seedsDir := getSeedFilesystemDir()
+	err := seedSourceTypes()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,15 +60,8 @@ func TestSeedingApplicationTypes(t *testing.T) {
 		t.Fatal("DB is nil - cannot continue test.")
 	}
 
-	var err error
-	var seedsDir string
-	if strings.HasSuffix(os.Getenv("PWD"), "dao") {
-		seedsDir = "./seeds/"
-	} else {
-		seedsDir = DEFAULT_SEEDS_DIR
-	}
-
-	err = seedApplicationTypes(seedsDir)
+	seedsDir := getSeedFilesystemDir()
+	err := seedApplicationTypes()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,17 +93,10 @@ func TestSeedingSuperkeyMetadata(t *testing.T) {
 		t.Fatal("DB is nil - cannot continue test.")
 	}
 
-	var err error
-	var seedsDir string
-	if strings.HasSuffix(os.Getenv("PWD"), "dao") {
-		seedsDir = "./seeds/"
-	} else {
-		seedsDir = DEFAULT_SEEDS_DIR
-	}
-
+	seedsDir := getSeedFilesystemDir()
 	appTypes := loadApplicationTypeSeeds()
 
-	err = seedSuperkeyMetadata(seedsDir, appTypes)
+	err := seedSuperkeyMetadata(appTypes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,17 +135,10 @@ func TestSeedingApplicationMetadata(t *testing.T) {
 		t.Fatal("DB is nil - cannot continue test.")
 	}
 
-	var err error
-	var seedsDir string
-	if strings.HasSuffix(os.Getenv("PWD"), "dao") {
-		seedsDir = "./seeds/"
-	} else {
-		seedsDir = DEFAULT_SEEDS_DIR
-	}
-
+	seedsDir := getSeedFilesystemDir()
 	appTypes := loadApplicationTypeSeeds()
 
-	err = seedAppMetadata(seedsDir, appTypes)
+	err := seedAppMetadata(appTypes)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
So after merging seeding we are seeing a `CrashLoopBackOff` in stage - related to the seed files not being present in the container. This is due to the fact I didn't copy them into the actual container after building.

Rather than copy them into the container and add another layer I decided to use the [embed](https://pkg.go.dev/embed) package which embeds files into the binary itself, it is pretty cool. We just read from it like a normal filesystem but we don't have to worry about which directory we're in etc. The tests are more effective now as well since the tests are checking to see that the files that were on the FS match the ones that were embedded + seeded into the database.

example logs from the pod.:
```
{"@timestamp":"2022-02-01T16:31:46.779Z","@version":1,"app":"source-api-go","caller":"github.com/RedHatInsights/sources-api-go/dao.seedDatabaseFromDirectory","filename":"/build/dao/seeding.go:23","hostname":"sources-api-go-svc-7d49cb6ff6-mndvw","labels":{"app":"source-api-go"},"level":"info","message":"Seeding SourceType Table","tags":["source-api-go"]}
{"@timestamp":"2022-02-01T16:31:46.78Z","@version":1,"app":"source-api-go","caller":"github.com/RedHatInsights/sources-api-go/dao.Init","filename":"/build/dao/db.go:63","hostname":"sources-api-go-svc-7d49cb6ff6-mndvw","labels":{"app":"source-api-go"},"level":"fatal","message":"Failed to seed db: open ./dao/seeds/source_types.yml: no such file or directory","tags":["source-api-go"]}
```