### PR TITLE
Use loop with counter in ToResponse conversion

### DIFF
--- a/application_handlers.go
+++ b/application_handlers.go
@@ -58,8 +58,8 @@ func ApplicationList(c echo.Context) error {
 	c.Logger().Infof("tenant: %v", *applicationDB.Tenant())
 
 	out := make([]interface{}, len(applications))
-	for i, a := range applications {
-		out[i] = *a.ToResponse()
+	for i := 0; i < len(applications); i++ {
+		out[i] = applications[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
@@ -232,8 +232,8 @@ func SourceListApplications(c echo.Context) error {
 	c.Logger().Infof("tenant: %v", *applicationDB.Tenant())
 
 	out := make([]interface{}, len(applications))
-	for i, a := range applications {
-		out[i] = *a.ToResponse()
+	for i := 0; i < len(applications); i++ {
+		out[i] = applications[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -59,16 +59,24 @@ func TestSourceApplicationSubcollectionList(t *testing.T) {
 		t.Error("not enough objects passed back from DB")
 	}
 
-	for _, src := range out.Data {
-		s, ok := src.(map[string]interface{})
+	SortByStringValueOnKey("id", out.Data)
 
-		if !ok {
-			t.Error("model did not deserialize as a source")
-		}
+	a1, ok := out.Data[0].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
 
-		if s["id"] != "1" && s["id"] != "2" {
-			t.Error("ghosts infected the return")
-		}
+	if a1["id"] != "1" {
+		t.Error("ghosts infected the return")
+	}
+
+	a2, ok := out.Data[1].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if a2["id"] != "2" {
+		t.Error("ghosts infected the return")
 	}
 
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
@@ -139,15 +147,32 @@ func TestApplicationList(t *testing.T) {
 		t.Error("not enough objects passed back from DB")
 	}
 
-	for _, src := range out.Data {
-		s, ok := src.(map[string]interface{})
-		if !ok {
-			t.Error("model did not deserialize as a application")
-		}
+	SortByStringValueOnKey("id", out.Data)
 
-		if s["extra"] == nil {
-			t.Error("ghosts infected the return")
-		}
+	a1, ok := out.Data[0].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if a1["id"] != "1" {
+		t.Error("ghosts infected the return")
+	}
+
+	if a1["extra"] == nil {
+		t.Error("ghosts infected the return")
+	}
+
+	a2, ok := out.Data[1].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if a2["id"] != "2" {
+		t.Error("ghosts infected the return")
+	}
+
+	if a2["extra"] == nil {
+		t.Error("ghosts infected the return")
 	}
 
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -71,8 +71,8 @@ func SourceListApplicationTypes(c echo.Context) error {
 	// converting the objects to the interface type so the collection response can process it
 	// allocating the length of our collection (so it doesn't have to resize)
 	out := make([]interface{}, len(apptypes))
-	for i, s := range apptypes {
-		out[i] = *s.ToResponse()
+	for i := 0; i < len(apptypes); i++ {
+		out[i] = apptypes[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
@@ -108,8 +108,8 @@ func ApplicationTypeList(c echo.Context) error {
 	// converting the objects to the interface type so the collection response can process it
 	// allocating the length of our collection (so it doesn't have to resize)
 	out := make([]interface{}, len(apptypes))
-	for i, s := range apptypes {
-		out[i] = *s.ToResponse()
+	for i := 0; i < len(apptypes); i++ {
+		out[i] = apptypes[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -66,8 +66,8 @@ func SourceListEndpoint(c echo.Context) error {
 	c.Logger().Infof("tenant: %v", *endpointDB.Tenant())
 
 	out := make([]interface{}, len(endpoints))
-	for i, a := range endpoints {
-		out[i] = *a.ToResponse()
+	for i := 0; i < len(endpoints); i++ {
+		out[i] = endpoints[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
@@ -102,8 +102,8 @@ func EndpointList(c echo.Context) error {
 	c.Logger().Infof("tenant: %v", *endpointDB.Tenant())
 
 	out := make([]interface{}, len(endpoints))
-	for i, a := range endpoints {
-		out[i] = *a.ToResponse()
+	for i := 0; i < len(endpoints); i++ {
+		out[i] = endpoints[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -56,16 +56,24 @@ func TestSourceEndpointSubcollectionList(t *testing.T) {
 		t.Error("not enough objects passed back from DB")
 	}
 
-	for _, src := range out.Data {
-		s, ok := src.(map[string]interface{})
+	SortByStringValueOnKey("id", out.Data)
 
-		if !ok {
-			t.Error("model did not deserialize as a source")
-		}
+	e1, ok := out.Data[0].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
 
-		if s["id"] != "1" && s["id"] != "2" {
-			t.Error("ghosts infected the return")
-		}
+	if e1["id"] != "1" {
+		t.Error("ghosts infected the return")
+	}
+
+	e2, ok := out.Data[1].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if e2["id"] != "2" {
+		t.Error("ghosts infected the return")
 	}
 
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
@@ -136,11 +144,24 @@ func TestEndpointList(t *testing.T) {
 		t.Error("not enough objects passed back from DB")
 	}
 
-	for _, src := range out.Data {
-		_, ok := src.(map[string]interface{})
-		if !ok {
-			t.Error("model did not deserialize as a endpoint")
-		}
+	SortByStringValueOnKey("id", out.Data)
+
+	e1, ok := out.Data[0].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if e1["id"] != "1" {
+		t.Error("ghosts infected the return")
+	}
+
+	e2, ok := out.Data[1].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if e2["id"] != "2" {
+		t.Error("ghosts infected the return")
 	}
 
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"sort"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
@@ -84,6 +85,14 @@ func AssertLinks(t *testing.T, path string, links util.Links, limit int, offset 
 	if links.Last != expectedLastLink {
 		t.Error("last link is not correct for " + path)
 	}
+}
+
+func SortByStringValueOnKey(field string, data []interface{}) {
+	sort.SliceStable(data, func(i, j int) bool {
+		dataI := data[i].(map[string]interface{})
+		dataJ := data[j].(map[string]interface{})
+		return dataI[field].(string) < dataJ[field].(string)
+	})
 }
 
 func ErrorHandlingContext(handler echo.HandlerFunc) func(echo.Context) error {

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -60,8 +60,8 @@ func MetaDataList(c echo.Context) error {
 	}
 
 	out := make([]interface{}, len(metaDatas))
-	for i, a := range metaDatas {
-		out[i] = *a.ToResponse()
+	for i := 0; i < len(metaDatas); i++ {
+		out[i] = metaDatas[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
@@ -103,8 +103,8 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 	}
 
 	out := make([]interface{}, len(metaDatas))
-	for i, a := range metaDatas {
-		out[i] = *a.ToResponse()
+	for i := 0; i < len(metaDatas); i++ {
+		out[i] = metaDatas[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))

--- a/meta_data_handlers_test.go
+++ b/meta_data_handlers_test.go
@@ -54,16 +54,24 @@ func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
 		t.Error("not enough objects passed back from DB")
 	}
 
-	for _, src := range out.Data {
-		s, ok := src.(map[string]interface{})
+	SortByStringValueOnKey("id", out.Data)
 
-		if !ok {
-			t.Error("model did not deserialize as a source")
-		}
+	m1, ok := out.Data[0].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
 
-		if s["id"] != "1" && s["id"] != "2" {
-			t.Error("ghosts infected the return")
-		}
+	if m1["id"] != "1" {
+		t.Error("ghosts infected the return")
+	}
+
+	m2, ok := out.Data[1].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if m2["id"] != "2" {
+		t.Error("ghosts infected the return")
 	}
 
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -64,8 +64,8 @@ func SourceList(c echo.Context) error {
 	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
 
 	out := make([]interface{}, len(sources))
-	for i, s := range sources {
-		out[i] = *s.ToResponse()
+	for i := 0; i < len(sources); i++ {
+		out[i] = sources[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
@@ -246,8 +246,8 @@ func SourceTypeListSource(c echo.Context) error {
 	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
 
 	out := make([]interface{}, len(sources))
-	for i, s := range sources {
-		out[i] = *s.ToResponse()
+	for i := 0; i < len(sources); i++ {
+		out[i] = sources[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
@@ -291,8 +291,8 @@ func ApplicationTypeListSource(c echo.Context) error {
 	c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())
 
 	out := make([]interface{}, len(sources))
-	for i, s := range sources {
-		out[i] = *s.ToResponse()
+	for i := 0; i < len(sources); i++ {
+		out[i] = sources[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -213,15 +213,24 @@ func TestSourceList(t *testing.T) {
 		t.Error("not enough objects passed back from DB")
 	}
 
-	for _, src := range out.Data {
-		s, ok := src.(map[string]interface{})
-		if !ok {
-			t.Error("model did not deserialize as a source")
-		}
+	SortByStringValueOnKey("name", out.Data)
 
-		if s["name"] != "Source1" && s["name"] != "Source2" {
-			t.Error("ghosts infected the return")
-		}
+	s1, ok := out.Data[0].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if s1["name"] != "Source1" {
+		t.Error("ghosts infected the return")
+	}
+
+	s2, ok := out.Data[1].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if s2["name"] != "Source2" {
+		t.Error("ghosts infected the return")
 	}
 
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)

--- a/source_type_handlers.go
+++ b/source_type_handlers.go
@@ -44,8 +44,8 @@ func SourceTypeList(c echo.Context) error {
 	// converting the objects to the interface type so the collection response can process it
 	// allocating the length of our collection (so it doesn't have to resize)
 	out := make([]interface{}, len(sourceTypes))
-	for i, s := range sourceTypes {
-		out[i] = *s.ToResponse()
+	for i := 0; i < len(sourceTypes); i++ {
+		out[i] = sourceTypes[i].ToResponse()
 	}
 
 	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))


### PR DESCRIPTION
This converts loops like this:

```go
for i, a := range applications {
  out[i] = *a.ToResponse()
}
```

to 

```go
for i := 0; i < len(applications); i++ {
  out[i] = applications[i].ToResponse()
}

```

`for i, a := range` - fields in `a` struct has same address and in this case we stores pointers in `out[I]` and when new value is assigned inside loop to `a` it is reflected in all elements in `out`. 

Issue is reproducible in endpoint `/api/sources/v3.1/sources` when names are same  (I am not sure why only `name`) but this change prevents this behaviour.
