### PR TITLE
[RHCLOUD-17832] Internal authentication endpoint

### DIFF
--- a/internal_handlers.go
+++ b/internal_handlers.go
@@ -8,6 +8,21 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// InternalAuthenticationGet fetches one authentication and returns it with the password exposed. Internal use only.
+func InternalAuthenticationGet(c echo.Context) error {
+	authDao, err := getAuthenticationDao(c)
+	if err != nil {
+		return err
+	}
+
+	auth, err := authDao.GetById(c.Param("uuid"))
+	if err != nil {
+		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
+	}
+
+	return c.JSON(http.StatusOK, auth.ToInternalResponse())
+}
+
 // InternalSourceList lists all the sources in a compact format —since the client that will use it,
 // "sources-monitor-go" only requires a small set of fields—.
 func InternalSourceList(c echo.Context) error {

--- a/internal_handlers.go
+++ b/internal_handlers.go
@@ -20,7 +20,12 @@ func InternalAuthenticationGet(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
 	}
 
-	return c.JSON(http.StatusOK, auth.ToInternalResponse())
+	exposeEncryptedAttribute := c.QueryParam("expose_encrypted_attribute[]")
+	if exposeEncryptedAttribute == "password" {
+		return c.JSON(http.StatusOK, auth.ToInternalResponse())
+	}
+
+	return c.JSON(http.StatusOK, auth.ToResponse())
 }
 
 // InternalSourceList lists all the sources in a compact format —since the client that will use it,

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -45,14 +45,12 @@ func (auth *Authentication) BulkMessage() map[string]interface{} {
 func (auth *Authentication) ToResponse() *AuthenticationResponse {
 	resourceID := strconv.FormatInt(auth.ResourceID, 10)
 	return &AuthenticationResponse{
-		ID:        auth.ID,
-		CreatedAt: auth.CreatedAt,
-		Name:      auth.Name,
-		Version:   auth.Version,
-		AuthType:  auth.AuthType,
-		Username:  auth.Username,
-		// TODO: remove this?
-		Password:                auth.Password,
+		ID:                      auth.ID,
+		CreatedAt:               auth.CreatedAt,
+		Name:                    auth.Name,
+		Version:                 auth.Version,
+		AuthType:                auth.AuthType,
+		Username:                auth.Username,
 		Extra:                   auth.Extra,
 		AvailabilityStatus:      auth.AvailabilityStatus.AvailabilityStatus,
 		AvailabilityStatusError: auth.AvailabilityStatusError,

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -59,6 +59,24 @@ func (auth *Authentication) ToResponse() *AuthenticationResponse {
 	}
 }
 
+func (auth *Authentication) ToInternalResponse() *AuthenticationInternalResponse {
+	resourceID := strconv.FormatInt(auth.ResourceID, 10)
+	return &AuthenticationInternalResponse{
+		ID:                      auth.ID,
+		CreatedAt:               auth.CreatedAt,
+		Name:                    auth.Name,
+		Version:                 auth.Version,
+		AuthType:                auth.AuthType,
+		Username:                auth.Username,
+		Password:                auth.Password,
+		Extra:                   auth.Extra,
+		AvailabilityStatus:      auth.AvailabilityStatus.AvailabilityStatus,
+		AvailabilityStatusError: auth.AvailabilityStatusError,
+		ResourceType:            auth.ResourceType,
+		ResourceID:              resourceID,
+	}
+}
+
 /*
 	This method translates an Authentication struct to a hash that will be
 	accepted by vault, this format will also be deserialized properly by

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -20,6 +20,23 @@ type AuthenticationResponse struct {
 	ResourceID   string `json:"resource_id"`
 }
 
+type AuthenticationInternalResponse struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+
+	Name                    string                 `json:"name,omitempty"`
+	AuthType                string                 `json:"authtype"`
+	Username                string                 `json:"username"`
+	Password                string                 `json:"password,omitempty"`
+	Extra                   map[string]interface{} `json:"extra,omitempty"`
+	Version                 string                 `json:"version"`
+	AvailabilityStatus      string                 `json:"availability_status,omitempty"`
+	AvailabilityStatusError string                 `json:"availability_status_error,omitempty"`
+
+	ResourceType string `json:"resource_type"`
+	ResourceID   string `json:"resource_id"`
+}
+
 type AuthenticationCreateRequest struct {
 	Name                    string                 `json:"name,omitempty"`
 	AuthType                string                 `json:"authtype"`

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -11,7 +11,6 @@ type AuthenticationResponse struct {
 	Name                    string                 `json:"name,omitempty"`
 	AuthType                string                 `json:"authtype"`
 	Username                string                 `json:"username"`
-	Password                string                 `json:"password,omitempty"`
 	Extra                   map[string]interface{} `json:"extra,omitempty"`
 	Version                 string                 `json:"version"`
 	AvailabilityStatus      string                 `json:"availability_status,omitempty"`

--- a/private/openapi-3-v2.0.json
+++ b/private/openapi-3-v2.0.json
@@ -14,6 +14,10 @@
   },
   "tags": [
     {
+      "description": "Internal endpoints for authentications",
+      "name": "authentications"
+    },
+    {
       "description": "Internal endpoints for sources",
       "name": "sources"
     }
@@ -33,6 +37,45 @@
     }
   ],
   "paths": {
+    "/authentications/{uuid}": {
+      "get": {
+        "description": "Returns an authentication with the password exposed",
+        "operationId": "getInternalAuthentication",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Uuid"
+          },
+          {
+            "$ref": "#/components/parameters/x-rh-identity"
+          },
+          {
+            "$ref": "#/components/parameters/x-rh-sources-psk"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authentication object",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Authentication"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Get authentication by its UUID",
+        "tags": [
+          "authentications"
+        ]
+      }
+    },
     "/sources": {
       "get": {
         "description": "Returns an array of Source objects",
@@ -134,6 +177,17 @@
           ]
         }
       },
+      "Uuid": {
+        "description": "UUID of the resource",
+        "in": "path",
+        "name": "uuid",
+        "required": true,
+        "schema": {
+          "description": "Universally Unique IDentifier of the resource",
+          "example": "f4cc4acc-8428-11ec-a8a3-0242ac120002",
+          "type": "string"
+        }
+      },
       "x-rh-identity": {
         "description": "RH-Identity header, base64 encoded",
         "in": "header",
@@ -155,6 +209,16 @@
       }
     },
     "responses": {
+      "NotFound": {
+        "description": "Resource was not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Errors"
+            }
+          }
+        }
+      },
       "Unauthorized": {
         "description": "Authorization required by either [x-rh-identity] or [x-rh-sources-psk] headers",
         "content": {
@@ -167,6 +231,56 @@
       }
     },
     "schemas": {
+      "Authentication": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "UUID of the authentication",
+            "example": "f4cc4acc-8428-11ec-a8a3-0242ac120002",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the authentication",
+            "example": "Authentication for AWS source",
+            "type": "string"
+          },
+          "authtype": {
+            "description": "Type of the authentication",
+            "example": "token-string",
+            "type": "string"
+          },
+          "username": {
+            "description": "Username of the authentication",
+            "example": "my-user",
+            "type": "string"
+          },
+          "password": {
+            "description": "Password of the authentication",
+            "example": "MyP4$$w0rD",
+            "type": "string"
+          },
+          "resource_id": {
+            "description": "Id of the resource the authentication belongs to",
+            "example": 10,
+            "type": "string"
+          },
+          "resource_type": {
+            "description": "Type of resource the authentication belongs to",
+            "example": "Source",
+            "type": "string"
+          },
+          "version": {
+            "description": "Version of the authentication",
+            "example": 5,
+            "type": "string"
+          },
+          "created_at": {
+            "description": "Timestamp of the creation of the authentication with the RFC3339Nano format",
+            "example": "2021-01-01T00:00:00.000Z",
+            "type": "string"
+          }
+        }
+      },
       "CollectionLinks": {
         "type": "object",
         "properties": {

--- a/routes.go
+++ b/routes.go
@@ -100,5 +100,9 @@ func setupRoutes(e *echo.Echo) {
 	\**            **/
 	internal := e.Group("/internal/v2.0", middleware.HandleErrors, middleware.ParseHeaders)
 
+	// Authentications
+	internal.GET("/authentications/:uuid", InternalAuthenticationGet, permissionMiddleware...)
+
+	// Sources
 	internal.GET("/sources", InternalSourceList, permissionWithListMiddleware...)
 }


### PR DESCRIPTION
Creates a new internal "Authentications" endpoint which exposes the password of the authentication.

* It also removes the `password` field from the public `AuthenticationResponse` objects.

## Links

[RHCLOUD-17832](https://issues.redhat.com/browse/RHCLOUD-17832)