### PR TITLE
Add authentications to records.update event in status listener

### DIFF
--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -99,7 +99,11 @@ func (a *ApplicationDaoImpl) BulkMessage(resource util.Resource) (map[string]int
 		return nil, result.Error
 	}
 
-	return BulkMessageFromSource(&application.Source)
+	authentication := &m.Authentication{ResourceID: application.ID,
+		ResourceType:               "Application",
+		ApplicationAuthentications: []m.ApplicationAuthentication{}}
+
+	return BulkMessageFromSource(&application.Source, authentication)
 }
 
 func (a *ApplicationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -489,15 +489,13 @@ func authFromVault(secret *api.Secret) *m.Authentication {
 }
 
 func (a *AuthenticationDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
-	bulkMessage := map[string]interface{}{}
+	a.TenantID = &resource.TenantID
+	authentication, err := a.GetById(resource.ResourceUID)
+	if err != nil {
+		return nil, err
+	}
 
-	bulkMessage["source"] = m.Source{}
-	bulkMessage["endpoints"] = []m.Endpoint{}
-	bulkMessage["endpoints"] = []m.Application{}
-	bulkMessage["authentications"] = []m.Authentication{}
-	bulkMessage["application_authentications"] = []m.ApplicationAuthenticationEvent{}
-
-	return bulkMessage, nil
+	return BulkMessageFromSource(&authentication.Source, authentication)
 }
 
 func (a *AuthenticationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {
@@ -516,12 +514,21 @@ func (a *AuthenticationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateA
 }
 
 func (a *AuthenticationDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
-	/*
-		TODO: we need to obtain uid
-		app, err := a.GetById(uid)
-		data, _ := json.Marshal(app.ToEvent())
-	*/
-	return []byte{}, nil
+	a.TenantID = &resource.TenantID
+	auth, err := a.GetById(resource.ResourceUID)
+	if err != nil {
+		return nil, err
+	}
+
+	auth.TenantID = resource.TenantID
+	auth.Tenant = m.Tenant{ExternalTenant: resource.AccountNumber}
+	authEvent := auth.ToEvent()
+	data, err := json.Marshal(authEvent)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
 }
 
 // setMarketplaceTokenAuthExtraField tries to put the marketplace token as a JSON string in the "auth.Extra" field
@@ -574,4 +581,26 @@ func setMarketplaceTokenAuthExtraField(auth *m.Authentication) error {
 	logging.Log.Log(logrus.InfoLevel, "marketplace token included in authentication")
 
 	return nil
+}
+
+func (a *AuthenticationDaoImpl) AuthenticationsByResource(authentication *m.Authentication) ([]m.Authentication, error) {
+	var err error
+	var resourceAuthentications []m.Authentication
+
+	switch authentication.ResourceType {
+	case "Source":
+		resourceAuthentications, _, err = a.ListForSource(authentication.ResourceID, defaultLimit, defaultOffset, nil)
+	case "Endpoint":
+		resourceAuthentications, _, err = a.ListForEndpoint(authentication.ResourceID, defaultLimit, defaultOffset, nil)
+	case "Application":
+		resourceAuthentications, _, err = a.ListForApplication(authentication.ResourceID, defaultLimit, defaultOffset, nil)
+	default:
+		return nil, fmt.Errorf("unable to fetch authentications for %s", authentication.ResourceType)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resourceAuthentications, nil
 }

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -589,11 +589,11 @@ func (a *AuthenticationDaoImpl) AuthenticationsByResource(authentication *m.Auth
 
 	switch authentication.ResourceType {
 	case "Source":
-		resourceAuthentications, _, err = a.ListForSource(authentication.ResourceID, defaultLimit, defaultOffset, nil)
+		resourceAuthentications, _, err = a.ListForSource(authentication.ResourceID, DEFAULT_LIMIT, DEFAULT_OFFSET, nil)
 	case "Endpoint":
-		resourceAuthentications, _, err = a.ListForEndpoint(authentication.ResourceID, defaultLimit, defaultOffset, nil)
+		resourceAuthentications, _, err = a.ListForEndpoint(authentication.ResourceID, DEFAULT_LIMIT, DEFAULT_OFFSET, nil)
 	case "Application":
-		resourceAuthentications, _, err = a.ListForApplication(authentication.ResourceID, defaultLimit, defaultOffset, nil)
+		resourceAuthentications, _, err = a.ListForApplication(authentication.ResourceID, DEFAULT_LIMIT, DEFAULT_OFFSET, nil)
 	default:
 		return nil, fmt.Errorf("unable to fetch authentications for %s", authentication.ResourceType)
 	}

--- a/dao/common.go
+++ b/dao/common.go
@@ -73,11 +73,10 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 		return nil, err
 	}
 
-	authentications := make([]m.AuthenticationEvent, len(authenticationsByResource))
-
-	for i, authenticationByResource := range authenticationsByResource {
-		authenticationByResource.Tenant = source.Tenant
-		authentications[i] = *authenticationByResource.ToEvent()
+	authentications := make([]interface{}, len(authenticationsByResource))
+	for i := 0; i < len(authenticationsByResource); i++ {
+		authenticationsByResource[i].Tenant = source.Tenant
+		authentications[i] = authenticationsByResource[i].ToEvent()
 	}
 
 	bulkMessage["authentications"] = authentications

--- a/dao/common.go
+++ b/dao/common.go
@@ -6,6 +6,11 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 )
 
+const (
+	defaultLimit  = 100
+	defaultOffset = 0
+)
+
 func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	var resource m.EventModelDao
 	switch resourceType {
@@ -24,7 +29,15 @@ func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	return &resource, nil
 }
 
-func BulkMessageFromSource(source *m.Source) (map[string]interface{}, error) {
+/*
+	Method generates bulk message for Source record.
+	authentication - specify resource (ResourceID and ResourceType) of
+                     which authentications are fetched to BulkMessage
+                   - specify application_authentications in BulkMessage otherwise
+                     application_authentications are obtained from authentications UIDs
+					 in BulkMessage
+*/
+func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (map[string]interface{}, error) {
 	result := DB.
 		Preload("Tenant").
 		Preload("Applications.Tenant").
@@ -52,8 +65,22 @@ func BulkMessageFromSource(source *m.Source) (map[string]interface{}, error) {
 
 	bulkMessage["applications"] = applications
 
-	bulkMessage["authentications"] = []m.Authentication{}
 	bulkMessage["application_authentications"] = []m.ApplicationAuthenticationEvent{}
+
+	authDao := &AuthenticationDaoImpl{TenantID: &source.TenantID}
+	authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
+	if err != nil {
+		return nil, err
+	}
+
+	authentications := make([]m.AuthenticationEvent, len(authenticationsByResource))
+
+	for i, authenticationByResource := range authenticationsByResource {
+		authenticationByResource.Tenant = source.Tenant
+		authentications[i] = *authenticationByResource.ToEvent()
+	}
+
+	bulkMessage["authentications"] = authentications
 
 	return bulkMessage, nil
 }

--- a/dao/common.go
+++ b/dao/common.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	defaultLimit  = 100
-	defaultOffset = 0
+	DEFAULT_LIMIT  = 100
+	DEFAULT_OFFSET = 0
 )
 
 func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -124,7 +124,8 @@ func (a *EndpointDaoImpl) BulkMessage(resource util.Resource) (map[string]interf
 		return nil, result.Error
 	}
 
-	return BulkMessageFromSource(&endpoint.Source)
+	authentication := &m.Authentication{ResourceID: endpoint.ID, ResourceType: "Endpoint", ApplicationAuthentications: []m.ApplicationAuthentication{}}
+	return BulkMessageFromSource(&endpoint.Source, authentication)
 }
 
 func (a *EndpointDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -149,7 +149,8 @@ func (s *SourceDaoImpl) BulkMessage(resource util.Resource) (map[string]interfac
 		return nil, result.Error
 	}
 
-	return BulkMessageFromSource(&src)
+	authentication := &m.Authentication{ResourceID: src.ID, ResourceType: "Source"}
+	return BulkMessageFromSource(&src, authentication)
 }
 
 func (s *SourceDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -19,3 +19,13 @@ func GetOrCreateTenantID(accountNumber string) (*int64, error) {
 
 	return &tenant.Id, result.Error
 }
+
+func TenantBy(accountNumber string) (*m.Tenant, error) {
+	tenant := m.Tenant{ExternalTenant: accountNumber}
+
+	result := DB.
+		Where("external_tenant = ?", accountNumber).
+		First(&tenant)
+
+	return &tenant, result.Error
+}

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -20,7 +20,7 @@ func GetOrCreateTenantID(accountNumber string) (*int64, error) {
 	return &tenant.Id, result.Error
 }
 
-func TenantBy(accountNumber string) (*m.Tenant, error) {
+func TenantByAccountNumber(accountNumber string) (*m.Tenant, error) {
 	tenant := m.Tenant{ExternalTenant: accountNumber}
 
 	result := DB.

--- a/internal/testutils/mocks/mock_vault.go
+++ b/internal/testutils/mocks/mock_vault.go
@@ -10,15 +10,17 @@ import (
 type MockVault struct {
 }
 
+var VaultPath = []string{fmt.Sprintf("Application_%d_%v", fixtures.TestTenantData[0].Id, fixtures.TestAuthenticationData[0].ID)}
+
 func (m *MockVault) Read(path string) (*api.Secret, error) {
-	if path != fmt.Sprintf("secret/data/%d/%v", fixtures.TestTenantData[0].Id, "") {
+	if path != fmt.Sprintf("secret/data/%d/%v", fixtures.TestTenantData[0].Id, VaultPath[0]) {
 		return nil, nil
 	}
 
 	secret := &api.Secret{}
 	secret.Data = make(map[string]interface{})
-	secret.Data["data"] = map[string]interface{}{}
-	secret.Data["metadata"] = map[string]interface{}{}
+	secret.Data["data"] = fixtures.TestAuthenticationVaultData
+	secret.Data["metadata"] = fixtures.TestAuthenticationVaultMetaData
 
 	return secret, nil
 }
@@ -27,7 +29,7 @@ func (m *MockVault) List(_ string) (*api.Secret, error) {
 	secret := &api.Secret{}
 
 	secret.Data = make(map[string]interface{})
-	secret.Data["keys"] = []interface{}{""}
+	secret.Data["keys"] = []interface{}{VaultPath[0]}
 
 	return secret, nil
 }

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -3,6 +3,8 @@ package model
 import (
 	"strconv"
 	"time"
+
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type Authentication struct {
@@ -85,6 +87,30 @@ func (auth *Authentication) ToVaultMap() (map[string]interface{}, error) {
 
 	// Vault requires the hash to be wrapped in a "data" object in order to be accepted.
 	return map[string]interface{}{"data": data}, nil
+}
+
+func (auth *Authentication) ToEvent() *AuthenticationEvent {
+	asEvent := AvailabilityStatusEvent{AvailabilityStatus: util.StringValueOrNil(auth.AvailabilityStatus.AvailabilityStatus),
+		LastAvailableAt: util.DateTimeToRecordFormat(auth.LastAvailableAt),
+		LastCheckedAt:   util.DateTimeToRecordFormat(auth.LastCheckedAt)}
+
+	authEvent := &AuthenticationEvent{
+		AvailabilityStatusEvent: asEvent,
+		ID:                      auth.ID,
+		CreatedAt:               auth.CreatedAt,
+		Name:                    auth.Name,
+		AuthType:                auth.AuthType,
+		Version:                 auth.Version,
+		Username:                auth.Username,
+		Extra:                   auth.Extra,
+		AvailabilityStatusError: &auth.AvailabilityStatusError,
+		ResourceType:            auth.ResourceType,
+		ResourceID:              auth.ResourceID,
+		Tenant:                  &auth.Tenant.ExternalTenant,
+		SourceID:                auth.SourceID,
+	}
+
+	return authEvent
 }
 
 func (auth *Authentication) UpdateBy(attributes map[string]interface{}) error {

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -110,7 +110,22 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		return
 	}
 
+	accountNumber, err := util.AccountNumberFrom(headers)
+	if err != nil {
+		l.Log.Error(err)
+		return
+	}
+
+	tenant, err := dao.TenantBy(accountNumber)
+	if err != nil {
+		l.Log.Error(err)
+		return
+	}
+
+	resource.TenantID = tenant.Id
+	resource.AccountNumber = tenant.ExternalTenant
 	err = (*modelEventDao).FetchAndUpdateBy(*resource, updateAttributes)
+
 	if err != nil {
 		l.Log.Errorf("Update error in status availability: %s", err)
 		return

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -110,13 +110,13 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		return
 	}
 
-	accountNumber, err := util.AccountNumberFrom(headers)
+	accountNumber, err := util.AccountNumberFromHeaders(headers)
 	if err != nil {
 		l.Log.Error(err)
 		return
 	}
 
-	tenant, err := dao.TenantBy(accountNumber)
+	tenant, err := dao.TenantByAccountNumber(accountNumber)
 	if err != nil {
 		l.Log.Error(err)
 		return

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/events"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/mocks"
 	"github.com/RedHatInsights/sources-api-go/internal/types"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
@@ -139,6 +140,23 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 		res = res.Find(application)
 		bulkMessage["applications"] = application.Source.Applications
 		bulkMessage["endpoints"] = application.Source.Endpoints
+
+		authentication := &m.Authentication{ResourceID: application.ID,
+			ResourceType:               "Application",
+			ApplicationAuthentications: []m.ApplicationAuthentication{},
+		}
+
+		authDao := &dao.AuthenticationDaoImpl{TenantID: &application.TenantID}
+		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
+		if err != nil {
+			return err, nil
+		}
+
+		bulkMessage["authentications"] = authenticationsByResource
+
+		if err != nil {
+			panic("error in adding authentications: " + err.Error())
+		}
 		src = application
 	case "Endpoint":
 		endpoint := &m.Endpoint{ID: id}
@@ -148,6 +166,23 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 		res = res.Find(endpoint)
 		bulkMessage["applications"] = endpoint.Source.Applications
 		bulkMessage["endpoints"] = endpoint.Source.Endpoints
+
+		authentication := &m.Authentication{ResourceID: endpoint.ID,
+			ResourceType:               "Endpoint",
+			ApplicationAuthentications: []m.ApplicationAuthentication{},
+		}
+		authDao := &dao.AuthenticationDaoImpl{TenantID: &endpoint.TenantID}
+		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
+		if err != nil {
+			return err, nil
+		}
+
+		if err != nil {
+			panic("error in adding authentications: " + err.Error())
+		}
+
+		bulkMessage["authentications"] = authenticationsByResource
+
 		src = endpoint
 	default:
 		panic("can't find resource type")
@@ -308,6 +343,8 @@ type TestData struct {
 
 func TestConsumeStatusMessage(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	
+	dao.Vault = &mocks.MockVault{}
 
 	log := logrus.Logger{
 		Out:          os.Stdout,

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -149,7 +149,7 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 		authDao := &dao.AuthenticationDaoImpl{TenantID: &application.TenantID}
 		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 		if err != nil {
-			return err, nil
+			panic("error to fetch authentications: " + err.Error())
 		}
 
 		bulkMessage["authentications"] = authenticationsByResource
@@ -343,7 +343,7 @@ type TestData struct {
 
 func TestConsumeStatusMessage(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	
+
 	dao.Vault = &mocks.MockVault{}
 
 	log := logrus.Logger{

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -38,6 +38,24 @@
     }
   ],
   "authentications": [
+    {
+      "authtype": "test",
+      "availability_status": "available",
+      "availability_status_error": "",
+      "created_at": "2022-01-10T14:58:02.850209Z",
+      "extra": {
+      },
+      "id": "611a8a38-f434-4e62-bda0-78cd45ffae5b",
+      "last_available_at": null,
+      "last_checked_at": null,
+      "name": "OpenShift",
+      "resource_id": 1,
+      "resource_type": "Application",
+      "source_id": 1,
+      "tenant": "12345",
+      "username": "testusr",
+      "version": "2"
+    }
   ],
   "endpoints": [
     {

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -38,6 +38,24 @@
     }
   ],
   "authentications": [
+    {
+      "authtype": "test",
+      "availability_status": "available",
+      "availability_status_error": "",
+      "created_at": "2022-01-10T14:58:02.850209Z",
+      "extra": {
+      },
+      "id": "611a8a38-f434-4e62-bda0-78cd45ffae5b",
+      "last_available_at": null,
+      "last_checked_at": null,
+      "name": "OpenShift",
+      "resource_id": 1,
+      "resource_type": "Application",
+      "source_id": 1,
+      "tenant": "12345",
+      "username": "testusr",
+      "version": "2"
+    }
   ],
   "endpoints": [
     {

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -1,0 +1,45 @@
+package util
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+func ParseXRHIDHeader(inputIdentity string) (XRHIdentity *identity.XRHID, err error) {
+	decodedIdentity, err := base64.StdEncoding.DecodeString(inputIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding Identity: %v", err)
+	}
+
+	err = json.Unmarshal(decodedIdentity, &XRHIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("x-rh-identity header does not contain valid JSON")
+	}
+
+	return XRHIdentity, nil
+}
+
+func AccountNumberFrom(headers []kafka.Header) (string, error) {
+	XRHAccountNumberKey := "x-rh-sources-account-number"
+	XRHIdentityKey := "x-rh-identity"
+
+	for _, header := range headers {
+		if header.Key == XRHAccountNumberKey {
+			return string(header.Value), nil
+		}
+
+		if header.Key == XRHIdentityKey {
+			XRHIdentity, err := ParseXRHIDHeader(string(header.Value))
+			if err != nil {
+				return "", err
+			}
+
+			return XRHIdentity.Identity.AccountNumber, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to get account number from headers, %s and %s are missing", XRHAccountNumberKey, XRHIdentityKey)
+}

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -4,11 +4,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-func ParseXRHIDHeader(inputIdentity string) (XRHIdentity *identity.XRHID, err error) {
+func ParseXRHIDHeader(inputIdentity string) (*identity.XRHID, error) {
+	var XRHIdentity *identity.XRHID
 	decodedIdentity, err := base64.StdEncoding.DecodeString(inputIdentity)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding Identity: %v", err)
@@ -22,7 +24,7 @@ func ParseXRHIDHeader(inputIdentity string) (XRHIdentity *identity.XRHID, err er
 	return XRHIdentity, nil
 }
 
-func AccountNumberFrom(headers []kafka.Header) (string, error) {
+func AccountNumberFromHeaders(headers []kafka.Header) (string, error) {
 	XRHAccountNumberKey := "x-rh-sources-account-number"
 	XRHIdentityKey := "x-rh-identity"
 

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -9,6 +9,11 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
+const (
+	xrhAccountNumberKey string = "x-rh-sources-account-number"
+	xrhIdentityKey      string = "x-rh-identity"
+)
+
 func ParseXRHIDHeader(inputIdentity string) (*identity.XRHID, error) {
 	var XRHIdentity *identity.XRHID
 	decodedIdentity, err := base64.StdEncoding.DecodeString(inputIdentity)
@@ -25,15 +30,12 @@ func ParseXRHIDHeader(inputIdentity string) (*identity.XRHID, error) {
 }
 
 func AccountNumberFromHeaders(headers []kafka.Header) (string, error) {
-	XRHAccountNumberKey := "x-rh-sources-account-number"
-	XRHIdentityKey := "x-rh-identity"
-
 	for _, header := range headers {
-		if header.Key == XRHAccountNumberKey {
+		if header.Key == xrhAccountNumberKey {
 			return string(header.Value), nil
 		}
 
-		if header.Key == XRHIdentityKey {
+		if header.Key == xrhIdentityKey {
 			XRHIdentity, err := ParseXRHIDHeader(string(header.Value))
 			if err != nil {
 				return "", err
@@ -43,5 +45,5 @@ func AccountNumberFromHeaders(headers []kafka.Header) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("unable to get account number from headers, %s and %s are missing", XRHAccountNumberKey, XRHIdentityKey)
+	return "", fmt.Errorf("unable to get account number from headers, %s and %s are missing", xrhAccountNumberKey, xrhIdentityKey)
 }


### PR DESCRIPTION
- get account number from status message's header
- this PR adds method `(a *AuthenticationDaoImpl) BulkMessage` to build `records.update` bulk messages emitted after `Authentication` status messages
-  on others (For source, endpoint ,..) bulk messages are populated "authentications" relations

## Links
Pulled out from https://github.com/RedHatInsights/sources-api-go/pull/76  and this is  6/7 PR

