### PR TITLE
[RHCLOUD-17897] fix: incorrect Vault key formatting in "GetById"

### DIFF
--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -211,7 +211,7 @@ func (a *AuthenticationDaoImpl) GetById(uid string) (*m.Authentication, error) {
 	// The token cacher is initialized here because "getKey" has a call to "authFromvault", and it's the only
 	// way of getting the tenant id without passing it around.
 	marketplaceTokenCacher = GetMarketplaceTokenCacher(a.TenantID)
-	return a.getKey(fmt.Sprintf("secret/data/%d/%s", *a.TenantID, fullKey))
+	return a.getKey(fullKey)
 }
 
 func (a *AuthenticationDaoImpl) Create(auth *m.Authentication) error {


### PR DESCRIPTION
There is no need to pass an "Sprintf"d string to the "getKey" function, since that one already builds the Vault's full key there. This was causing "GetById" function to not work properly.

## Links

[[RHCLOUD-17897]](https://issues.redhat.com/browse/RHCLOUD-17897)