### PR TITLE
[RHCLOUD-17897] Refactor the way integration tests are skipped right now

### DIFF
--- a/dao/seeding_test.go
+++ b/dao/seeding_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"sigs.k8s.io/yaml"
 )
@@ -19,9 +20,7 @@ func getSeedFilesystemDir() string {
 }
 
 func TestSeedingSourceTypes(t *testing.T) {
-	if !flags.Integration {
-		t.Skip("seeding tests only run during integration tests")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")
@@ -52,9 +51,7 @@ func TestSeedingSourceTypes(t *testing.T) {
 }
 
 func TestSeedingApplicationTypes(t *testing.T) {
-	if !flags.Integration {
-		t.Skip("seeding tests only run during integration tests")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")
@@ -85,9 +82,7 @@ func TestSeedingApplicationTypes(t *testing.T) {
 }
 
 func TestSeedingSuperkeyMetadata(t *testing.T) {
-	if !flags.Integration {
-		t.Skip("seeding tests only run during integration tests")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")
@@ -127,9 +122,7 @@ func TestSeedingSuperkeyMetadata(t *testing.T) {
 }
 
 func TestSeedingApplicationMetadata(t *testing.T) {
-	if !flags.Integration {
-		t.Skip("seeding tests only run during integration tests")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")

--- a/internal/testutils/parser/parser.go
+++ b/internal/testutils/parser/parser.go
@@ -2,6 +2,9 @@ package parser
 
 import "flag"
 
+// RunningIntegrationTests indicates whether the tests will be run as "unit" or "integration" tests.
+var RunningIntegrationTests = false
+
 // Flags holds the flags to control what the tests should be doing.
 type Flags struct {
 	CreateDb    bool
@@ -15,6 +18,9 @@ func ParseFlags() Flags {
 	integration := flag.Bool("integration", false, "run unit or integration tests")
 
 	flag.Parse()
+
+	// Set the "integration tests" variable
+	RunningIntegrationTests = *integration
 
 	return Flags{
 		CreateDb:    *createDb,

--- a/internal/testutils/test_template.go
+++ b/internal/testutils/test_template.go
@@ -7,8 +7,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
+
+// SkipIfNotRunningIntegrationTests is a helper function which skips a test if the integration tests don't want to be
+// run.
+func SkipIfNotRunningIntegrationTests(t *testing.T) {
+	if !parser.RunningIntegrationTests {
+		t.Skip("Skipping integration test")
+	}
+}
 
 func NotFoundTest(t *testing.T, rec *httptest.ResponseRecorder) {
 	if rec.Code != 404 {

--- a/internal_handlers_test.go
+++ b/internal_handlers_test.go
@@ -5,15 +5,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestSourceListInternal(t *testing.T) {
-	if !flags.Integration {
-		t.Skip("Only run during integration tests")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	c, rec := request.CreateTestContext(
 		http.MethodGet,

--- a/main_test.go
+++ b/main_test.go
@@ -23,14 +23,12 @@ var (
 	mockSourceTypeDao      dao.SourceTypeDao
 	mockApplicationDao     dao.ApplicationDao
 	mockMetaDataDao        dao.MetaDataDao
-
-	flags parser.Flags
 )
 
 func TestMain(t *testing.M) {
 	l.InitLogger(conf)
 
-	flags = parser.ParseFlags()
+	flags := parser.ParseFlags()
 
 	if flags.CreateDb {
 		database.CreateTestDB()

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/model"
 )
@@ -35,9 +36,7 @@ func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 // TestValidateEndpointCreateRequest tests that when a proper EndpointCreateRequest is given, the validator doesn't
 // complain.
 func TestValidateEndpointCreateRequest(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 
@@ -85,9 +84,7 @@ func TestInvalidSourceId(t *testing.T) {
 // TestDefaultEndpointAlreadyExists tests if an error is returned when the provided endpoint is marked as default when
 // the also provided source already has a default one.
 func TestDefaultEndpointAlreadyExists(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 	ecr.Default = true
@@ -106,9 +103,7 @@ func TestDefaultEndpointAlreadyExists(t *testing.T) {
 // TestDefaultIsSetBecauseSourceHasNoEndpoints tests if the endpoint is defaulted when the provided source  has no
 // endpoints.
 func TestDefaultIsSetBecauseSourceHasNoEndpoints(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 	ecr.SourceIDRaw = "12345"
@@ -125,9 +120,7 @@ func TestDefaultIsSetBecauseSourceHasNoEndpoints(t *testing.T) {
 
 // TestNonUniqueRole tests if an error is returned when a role already exists for a source.
 func TestNonUniqueRole(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	role := "myRole"
 	newEndpoint := fixtures.TestEndpointData[0]
@@ -155,9 +148,7 @@ func TestNonUniqueRole(t *testing.T) {
 
 // TestSchemeGetsDefaulted tests if the scheme gets properly defaulted when an invalid or missing scheme is provided.
 func TestSchemeGetsDefaulted(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 
@@ -189,9 +180,7 @@ func TestSchemeGetsDefaulted(t *testing.T) {
 
 // TestEmptyHost tests if no error is returned even when an empty host is given.
 func TestEmptyHost(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 	ecr.Host = ""
@@ -204,9 +193,7 @@ func TestEmptyHost(t *testing.T) {
 
 // TestHostFqdnTooLong tests if an error is returned when a host which is too long is given.
 func TestHostFqdnTooLong(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 
@@ -232,9 +219,7 @@ func TestHostFqdnTooLong(t *testing.T) {
 
 // TestValidHosts tests if the validation succeeds when valid hosts are given.
 func TestValidHosts(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	testValues := []string{
 		"redhat.com",
@@ -261,9 +246,7 @@ func TestValidHosts(t *testing.T) {
 
 // TestInvalidHosts tests if an error is returned on invalid hosts.
 func TestInvalidHosts(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	testValues := []string{
 		"-example.com",
@@ -287,9 +270,7 @@ func TestInvalidHosts(t *testing.T) {
 
 // TestLabelNamesTooLong tests if an error is returned when the provided labels are longer than permitted.
 func TestLabelNamesTooLong(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 
@@ -310,9 +291,7 @@ func TestLabelNamesTooLong(t *testing.T) {
 // TestDefaultingPortWhenMissingOrLessThanZero test if the port is given a default value if it's missing or it has been
 // given a value equal or lower than zero.
 func TestDefaultingPortWhenMissingOrLessThanZero(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 
@@ -341,9 +320,7 @@ func TestDefaultingPortWhenMissingOrLessThanZero(t *testing.T) {
 
 // TestPortLargeValue tests if an error is returned when a port that is greater than the maximum allowed port is given.
 func TestPortLargeValue(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 	largePort := 999999
@@ -363,9 +340,7 @@ func TestPortLargeValue(t *testing.T) {
 
 // TestDefaultVerifySsl tests if the default value is set when no "VerifySSL" value is provided.
 func TestDefaultVerifySsl(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 	ecr.VerifySsl = nil
@@ -383,9 +358,7 @@ func TestDefaultVerifySsl(t *testing.T) {
 // TestEmptyCertificateAuthority tests if an error is returned when ssl verification is turned on but no certificate
 // authority is given.
 func TestEmptyCertificateAuthority(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 
@@ -411,9 +384,7 @@ func TestEmptyCertificateAuthority(t *testing.T) {
 
 // TestValidAvailabilityStatuses tests if no error is returned when valid availability statuses are given.
 func TestValidAvailabilityStatuses(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 
@@ -430,9 +401,7 @@ func TestValidAvailabilityStatuses(t *testing.T) {
 
 // TestInvalidAvailabilityStatuses tests if an error is returned when passing invalid availability statuses.
 func TestInvalidAvailabilityStatuses(t *testing.T) {
-	if !runningIntegration {
-		t.Skip("skipping integration tests...")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	ecr := setUpEndpointCreateRequest()
 

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 var (
-	// runningIntegration is used to skip integration tests if we're just running unit tests.
-	runningIntegration = false
-
 	endpointDao dao.EndpointDao
 	sourceDao   dao.SourceDao
 )
@@ -28,7 +25,6 @@ func TestMain(t *testing.M) {
 	if flags.CreateDb {
 		database.CreateTestDB()
 	} else if flags.Integration {
-		runningIntegration = true
 		database.ConnectAndMigrateDB("service")
 
 		endpointDao = &dao.EndpointDaoImpl{TenantID: &fixtures.TestTenantData[0].Id}

--- a/service/source_validation_test.go
+++ b/service/source_validation_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/model"
 )
 
@@ -64,9 +65,7 @@ func TestInvalidName(t *testing.T) {
 // fixture that is inserted in the main function. The reason is that it is easier to control this new fixture here
 // than having to track the name of the previously inserted fixture, or exporting it to variable or whatever.
 func TestInvalidDuplicatedNameInTenant(t *testing.T) {
-	if !runningIntegration {
-		t.Skipf("not running integration tests")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	sourceName := "Source350"
 	newSource := model.Source{ID: 350, Name: sourceName, SourceTypeID: 1, TenantID: 1}

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -237,9 +237,7 @@ func TestSourceList(t *testing.T) {
 }
 
 func TestSourceListSatellite(t *testing.T) {
-	if !flags.Integration {
-		t.Skip("Only runs during integration tests")
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	c, rec := request.CreateTestContext(
 		http.MethodGet,

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/events"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/types"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
@@ -306,9 +307,7 @@ type TestData struct {
 }
 
 func TestConsumeStatusMessage(t *testing.T) {
-	if !runningIntegration {
-		return
-	}
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	log := logrus.Logger{
 		Out:          os.Stdout,


### PR DESCRIPTION
Instead of having to define a variable on each "main_test" file to track whether the integration tests are running or not, this helper function takes care of that.

## Links
[[RHCLOUD-17897]](https://issues.redhat.com/browse/RHCLOUD-17897)