### PR TITLE
Add ApplicationAuthentications to BulkMessageFromSource

### DIFF
--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -19,9 +19,9 @@ func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplicati
 		applicationIDs = append(applicationIDs, value.ID)
 	}
 
-	result := DB.Preload("Tenant").Where("application_id IN ?", applicationIDs).Find(&applicationAuthentications)
-	if result.Error != nil {
-		return nil, result.Error
+	err := DB.Preload("Tenant").Where("application_id IN ?", applicationIDs).Find(&applicationAuthentications).Error
+	if err != nil {
+		return nil, err
 	}
 
 	return applicationAuthentications, nil

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -11,6 +11,46 @@ type ApplicationAuthenticationDaoImpl struct {
 	TenantID *int64
 }
 
+func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplications(applications []m.Application) ([]m.ApplicationAuthentication, error) {
+	var applicationAuthentications []m.ApplicationAuthentication
+
+	applicationIDs := make([]int64, 0)
+	for _, value := range applications {
+		applicationIDs = append(applicationIDs, value.ID)
+	}
+
+	result := DB.Preload("Tenant").Where("application_id IN ?", applicationIDs).Find(&applicationAuthentications)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return applicationAuthentications, nil
+}
+
+func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByAuthentications(authentications []m.Authentication) ([]m.ApplicationAuthentication, error) {
+	var applicationAuthentications []m.ApplicationAuthentication
+
+	authenticationUIDs := make([]string, 0)
+	for _, value := range authentications {
+		authenticationUIDs = append(authenticationUIDs, value.ID)
+	}
+
+	result := DB.Preload("Tenant").Where("authentication_uid IN ?", authenticationUIDs).Find(&applicationAuthentications)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return applicationAuthentications, nil
+}
+
+func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByResource(resourceType string, applications []m.Application, authentications []m.Authentication) ([]m.ApplicationAuthentication, error) {
+	if resourceType == "Source" {
+		return a.ApplicationAuthenticationsByApplications(applications)
+	}
+
+	return a.ApplicationAuthenticationsByAuthentications(authentications)
+}
+
 func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
 	appAuths := make([]m.ApplicationAuthentication, 0, limit)
 	query := DB.Debug().Model(&m.ApplicationAuthentication{}).

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -277,18 +277,16 @@ func TransformDateFieldsInJSONForBulkMessage(resourceType string, resourceID str
 
 	var applicationAuthentications []interface{}
 
-	applicationAuthenticationsBulkMessage, success := bulkMessage["application_authentications"].([]m.ApplicationAuthentication)
-
-	if success {
+	if applicationAuthenticationsBulkMessage, ok := bulkMessage["application_authentications"].([]m.ApplicationAuthentication); ok {
 		for index, applicationAuthentication := range applicationAuthenticationsBulkMessage {
 			dateFields = PopulateDateFieldsFrom(&applicationAuthentication)
-			ap, success := contentMap["application_authentications"].([]interface{})
-			if !success {
+			if ap, ok := contentMap["application_authentications"].([]interface{}); ok {
+				upd := UpdateDateFieldsTo(ap[index].(map[string]interface{}), dateFields)
+				applicationAuthentications = append(applicationAuthentications, upd)
+			} else {
 				panic("type assertion error: + " + err.Error())
 			}
 
-			upd := UpdateDateFieldsTo(ap[index].(map[string]interface{}), dateFields)
-			applicationAuthentications = append(applicationAuthentications, upd)
 		}
 	}
 

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -103,6 +103,9 @@ func PopulateDateFieldsFrom(resource interface{}) DateFields {
 		dateFields.LastAvailableAt = typedResource.LastAvailableAt
 		dateFields.LastCheckedAt = typedResource.LastCheckedAt
 		dateFields.UpdatedAt = typedResource.UpdatedAt
+	case *m.ApplicationAuthentication:
+		dateFields.CreatedAt = typedResource.CreatedAt
+		dateFields.UpdatedAt = typedResource.UpdatedAt
 	default:
 		panic("unable to find type")
 	}
@@ -130,6 +133,18 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 		res = res.Find(source)
 		bulkMessage["applications"] = source.Applications
 		bulkMessage["endpoints"] = source.Endpoints
+
+		appIDs := make([]int64, len(source.Applications))
+		for index, application := range source.Applications {
+			appIDs[index] = application.ID
+		}
+
+		var aa []m.ApplicationAuthentication
+		if len(appIDs) > 0 {
+			dao.DB.Where("application_id IN ?", appIDs).Find(&aa)
+			bulkMessage["application_authentications"] = aa
+		}
+
 		src = source
 	case "Application":
 		application := &m.Application{ID: id}
@@ -157,6 +172,18 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 		if err != nil {
 			panic("error in adding authentications: " + err.Error())
 		}
+
+		appIDs := make([]int64, len(application.Source.Applications))
+		for index, app := range application.Source.Applications {
+			appIDs[index] = app.ID
+		}
+
+		var aa []m.ApplicationAuthentication
+		if len(appIDs) > 0 {
+			dao.DB.Where("application_id IN ?", appIDs).Find(&aa)
+			bulkMessage["application_authentications"] = aa
+		}
+
 		src = application
 	case "Endpoint":
 		endpoint := &m.Endpoint{ID: id}
@@ -247,6 +274,29 @@ func TransformDateFieldsInJSONForBulkMessage(resourceType string, resourceID str
 	}
 
 	contentMap["endpoints"] = endpoints
+
+	var applicationAuthentications []interface{}
+
+	applicationAuthenticationsBulkMessage, success := bulkMessage["application_authentications"].([]m.ApplicationAuthentication)
+
+	if success {
+		for index, applicationAuthentication := range applicationAuthenticationsBulkMessage {
+			dateFields = PopulateDateFieldsFrom(&applicationAuthentication)
+			ap, success := contentMap["application_authentications"].([]interface{})
+			if !success {
+				panic("type assertion error: + " + err.Error())
+			}
+
+			upd := UpdateDateFieldsTo(ap[index].(map[string]interface{}), dateFields)
+			applicationAuthentications = append(applicationAuthentications, upd)
+		}
+	}
+
+	if applicationAuthentications != nil {
+		contentMap["application_authentications"] = applicationAuthentications
+	} else {
+		contentMap["application_authentications"] = []m.ApplicationAuthentication{}
+	}
 
 	contentJSON, err := json.Marshal(contentMap)
 	if err != nil {

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -1,5 +1,16 @@
 {
   "application_authentications": [
+    {
+      "application_id": 1,
+      "authentication_id": 0,
+      "authentication_uid": "611a8a38-f434-4e62-bda0-78cd45ffae5b",
+      "created_at": "2022-01-19 11:57:23 CET",
+      "id": 1,
+      "paused_at": null,
+      "tenant": "12345",
+      "updated_at": "2022-01-19 11:57:23 CET",
+      "vault_path": "Application_1_611a8a38-f434-4e62-bda0-78cd45ffae5b"
+    }
   ],
   "applications": [
     {

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -1,5 +1,16 @@
 {
   "application_authentications": [
+    {
+      "application_id": 1,
+      "authentication_id": 0,
+      "authentication_uid": "611a8a38-f434-4e62-bda0-78cd45ffae5b",
+      "created_at": "2022-01-19 11:57:23 CET",
+      "id": 1,
+      "paused_at": null,
+      "tenant": "12345",
+      "updated_at": "2022-01-19 11:57:23 CET",
+      "vault_path": "Application_1_611a8a38-f434-4e62-bda0-78cd45ffae5b"
+    }
   ],
   "applications": [
     {


### PR DESCRIPTION
- pull out from https://github.com/RedHatInsights/sources-api-go/pull/76(but code is mostly changed) as last thing of  https://issues.redhat.com/browse/RHCLOUD-17059

This adds `ApplicationAuthentications` relations to bulk message which is build here in [UpdateMessage](https://github.com/RedHatInsights/sources-api-go/blob/cbd8755cc54d9701e8e363a40f939bed91a25c8c/internal/events/event_stream_producer.go) method 

This bulk message is send to Kafka topic `platform.sources.event-stream`  by [raise event](https://github.com/RedHatInsights/sources-api-go/blob/cbd8755cc54d9701e8e363a40f939bed91a25c8c/internal/events/event_stream_producer.go) function.

Bulk message is built [here](https://github.com/RedHatInsights/sources-api/blob/19cf1aa2f6f2ba7f0ce8c17dc8a4662cfabc368d/app/models/concerns/event_concern.rb) in ruby project.
