### PR TITLE
refactor: pull "RaiseEvent" function from the middleware closure

### DIFF
--- a/middleware/event_stream.go
+++ b/middleware/event_stream.go
@@ -1,20 +1,14 @@
 package middleware
 
 import (
-	"encoding/json"
-
-	"github.com/RedHatInsights/sources-api-go/internal/events"
-	"github.com/RedHatInsights/sources-api-go/kafka"
 	l "github.com/RedHatInsights/sources-api-go/logger"
-	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/labstack/echo/v4"
 )
 
-// producer instance used to send messages - default just an empty instance of
-// the struct.
-var producer = events.EventStreamProducer{Sender: &events.EventStreamSender{}}
-
-// RaiseEventMiddleware calls the "RaiseEvent" function once the previous handler has succeeded.
+// RaiseEventMiddleware calls the "RaiseEvent" function once the previous handler has succeeded. It grabs the resource
+// and the event type from the context.
 func RaiseEventMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// first call the handler function (or the next middlware)
@@ -23,98 +17,43 @@ func RaiseEventMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 			return err
 		}
 
-		return RaiseEvent(c)
-	}
-}
-
-// RaiseEvent raises an event with the resource specified in the context. That resource must implement the "Event"
-// interface. Either set the resource manually or use the helper function "helper.go#setEventStreamResource".
-func RaiseEvent(c echo.Context) error {
-	// specifically skip raising an event if this is set - usually when
-	// a create action happened but we do not want to re-raise the
-	// event.
-	if c.Get("skip_raise") != nil {
-		l.Log.Infof("skipping raise event per skip_raise set on context")
-		return nil
-	}
-
-	// pull the "event" resource from the context, which needs to be set
-	// in the handler for this to work.
-	resource := c.Get("resource")
-	if resource == nil {
-		l.Log.Infof("failed to pull event resource from context - skipping raise event")
-		return nil
-	}
-
-	eventType, ok := c.Get("event_type").(string)
-	if !ok {
-		l.Log.Warnf("Failed to cast event_type to string - exiting")
-		return nil
-	}
-
-	if c.Get("event_override") != nil {
-		event, ok := c.Get("event_override").(string)
-		if !ok {
-			l.Log.Warnf("Failed to cast event_override from request - ditching post to kafka")
+		// specifically skip raising an event if this is set - usually when
+		// a create action happened but we do not want to re-raise the
+		// event.
+		if c.Get("skip_raise") != nil {
+			l.Log.Infof("skipping raise event per skip_raise set on context")
 			return nil
 		}
 
-		l.Log.Infof("Using overridden event_type %v instead of %v", c.Get("event_override"), eventType)
-		eventType = event
-	}
-
-	l.Log.Infof("Raising Event %v", eventType)
-
-	msg, err := json.Marshal(resource)
-	if err != nil {
-		return err
-	}
-
-	// TODO: make this async? Run this in a goroutine that way the
-	// request isn't effectively blocked by kafka .
-	headers := append(getRequestHeaders(c), kafka.Header{Key: "event_type", Value: []byte(eventType)})
-	err = producer.RaiseEvent(eventType, msg, headers)
-	if err != nil {
-		l.Log.Warnf("failed to raise event to kafka: %v", err)
-		return nil
-	}
-
-	return nil
-}
-
-/*
-    Fetch the headers from the requeset that are needed to forward along
-
-	1. x-rh-identity -- a generated one if it wasn't passed along (e.g. psk)
-
-	2. x-rh-sources-psk -- always passed if present, and used for generation.
-*/
-func getRequestHeaders(c echo.Context) []kafka.Header {
-	headers := make([]kafka.Header, 0)
-
-	if c.Get("psk-account") != nil {
-		psk, ok := c.Get("psk-account").(string)
-		if ok {
-			headers = append(headers, kafka.Header{Key: "x-rh-sources-account-number", Value: []byte(psk)})
+		// pull the "event" resource from the context, which needs to be set
+		// in the handler for this to work.
+		resource, ok := c.Get("resource").(model.Event)
+		if !ok {
+			l.Log.Infof("failed to pull event resource from context - skipping raise event")
+			return nil
 		}
-	}
 
-	if c.Get("x-rh-identity") != nil {
-		xrhid, ok := c.Get("x-rh-identity").(string)
-		if ok {
-			headers = append(headers, kafka.Header{Key: "x-rh-identity", Value: []byte(xrhid)})
+		eventType, ok := c.Get("event_type").(string)
+		if !ok {
+			l.Log.Warnf("Failed to cast event_type to string - exiting")
+			return nil
 		}
-	} else {
-		psk, ok := c.Get("psk-account").(string)
-		if ok {
-			// the only way this would be nil is if psk auth was used - so lets
-			// generate a dummy header for services that still rely on it.
-			headers = append(headers, kafka.Header{
-				Key:   "x-rh-identity",
-				Value: []byte(util.XRhIdentityWithAccountNumber(psk)),
-			})
-		}
-	}
 
-	return headers
+		if c.Get("event_override") != nil {
+			event, ok := c.Get("event_override").(string)
+			if !ok {
+				l.Log.Warnf("Failed to cast event_override from request - ditching post to kafka")
+				return nil
+			}
+
+			l.Log.Infof("Using overridden event_type %v instead of %v", c.Get("event_override"), eventType)
+			eventType = event
+		}
+
+		l.Log.Infof("Raising Event %v", eventType)
+
+		headers := service.ForwadableHeeaders(c)
+
+		return service.RaiseEvent(eventType, resource, headers)
+	}
 }

--- a/middleware/event_stream.go
+++ b/middleware/event_stream.go
@@ -52,7 +52,7 @@ func RaiseEvent(next echo.HandlerFunc) echo.HandlerFunc {
 
 		l.Log.Infof("Raising Event %v", eventType)
 
-		headers := service.ForwadableHeeaders(c)
+		headers := service.ForwadableHeaders(c)
 
 		return service.RaiseEvent(eventType, resource, headers)
 	}

--- a/middleware/event_stream.go
+++ b/middleware/event_stream.go
@@ -7,9 +7,9 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// RaiseEventMiddleware calls the "RaiseEvent" function once the previous handler has succeeded. It grabs the resource
-// and the event type from the context.
-func RaiseEventMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+// RaiseEvent calls the "RaiseEvent" function once the previous handler has succeeded. It grabs the resource and the
+// event type from the context.
+func RaiseEvent(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// first call the handler function (or the next middlware)
 		err := next(c)

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-var raiseMiddleware = RaiseEvent
+var raiseMiddleware = RaiseEventMiddleware
 
 type mockSender struct {
 	hit     int

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-var raiseMiddleware = RaiseEventMiddleware
+var raiseMiddleware = RaiseEvent
 
 type mockSender struct {
 	hit     int

--- a/routes.go
+++ b/routes.go
@@ -14,7 +14,7 @@ var listMiddleware = []echo.MiddlewareFunc{
 }
 
 var tenancyWithListMiddleware = append([]echo.MiddlewareFunc{middleware.Tenancy}, listMiddleware...)
-var permissionMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.PermissionCheck, middleware.RaiseEventMiddleware}
+var permissionMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.PermissionCheck, middleware.RaiseEvent}
 var permissionWithListMiddleware = append(listMiddleware, middleware.PermissionCheck)
 
 func setupRoutes(e *echo.Echo) {

--- a/routes.go
+++ b/routes.go
@@ -14,7 +14,7 @@ var listMiddleware = []echo.MiddlewareFunc{
 }
 
 var tenancyWithListMiddleware = append([]echo.MiddlewareFunc{middleware.Tenancy}, listMiddleware...)
-var permissionMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.PermissionCheck, middleware.RaiseEvent}
+var permissionMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.PermissionCheck, middleware.RaiseEventMiddleware}
 var permissionWithListMiddleware = append(listMiddleware, middleware.PermissionCheck)
 
 func setupRoutes(e *echo.Echo) {

--- a/service/events.go
+++ b/service/events.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"encoding/json"
+
+	"github.com/RedHatInsights/sources-api-go/internal/events"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	l "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
+)
+
+// Producer instance used to send messages - default just an empty instance of the struct.
+var Producer = events.EventStreamProducer{Sender: &events.EventStreamSender{}}
+
+// RaiseEvent raises an event with the provided resource.
+func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) error {
+	msg, err := json.Marshal(resource.ToEvent())
+	if err != nil {
+		return err
+	}
+
+	// TODO: make this async? Run this in a goroutine that way the
+	// request isn't effectively blocked by kafka .
+	headers = append(headers, kafka.Header{Key: "event_type", Value: []byte(eventType)})
+	err = Producer.RaiseEvent(eventType, msg, headers)
+	if err != nil {
+		l.Log.Warnf("failed to raise event to kafka: %v", err)
+		return nil
+	}
+
+	return nil
+}
+
+// ForwadableHeeaders fetches the required identity headers from the request that are needed to forward along:
+// 	1. x-rh-identity -- a generated one if it wasn't passed along (e.g. psk)
+//	2. x-rh-sources-psk -- always passed if present, and used for generation.
+func ForwadableHeeaders(c echo.Context) []kafka.Header {
+	headers := make([]kafka.Header, 0)
+
+	if c.Get("psk-account") != nil {
+		psk, ok := c.Get("psk-account").(string)
+		if ok {
+			headers = append(headers, kafka.Header{Key: "x-rh-sources-account-number", Value: []byte(psk)})
+		}
+	}
+
+	if c.Get("x-rh-identity") != nil {
+		xrhid, ok := c.Get("x-rh-identity").(string)
+		if ok {
+			headers = append(headers, kafka.Header{Key: "x-rh-identity", Value: []byte(xrhid)})
+		}
+	} else {
+		psk, ok := c.Get("psk-account").(string)
+		if ok {
+			// the only way this would be nil is if psk auth was used - so lets
+			// generate a dummy header for services that still rely on it.
+			headers = append(headers, kafka.Header{
+				Key:   "x-rh-identity",
+				Value: []byte(util.XRhIdentityWithAccountNumber(psk)),
+			})
+		}
+	}
+
+	return headers
+}

--- a/service/events.go
+++ b/service/events.go
@@ -33,10 +33,10 @@ func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) 
 	return nil
 }
 
-// ForwadableHeeaders fetches the required identity headers from the request that are needed to forward along:
+// ForwadableHeaders fetches the required identity headers from the request that are needed to forward along:
 // 	1. x-rh-identity -- a generated one if it wasn't passed along (e.g. psk)
 //	2. x-rh-sources-psk -- always passed if present, and used for generation.
-func ForwadableHeeaders(c echo.Context) []kafka.Header {
+func ForwadableHeaders(c echo.Context) []kafka.Header {
 	headers := make([]kafka.Header, 0)
 
 	if c.Get("psk-account") != nil {


### PR DESCRIPTION
The reason for pulling it from the closure is that we might want to use the "RaiseEvent" function in a place where multiple events must be raised, and therefore if it is embedded in the closure that would be difficult to do.