### PR TITLE
Add dummy port to redis-not-found test

### DIFF
--- a/redis/marketplace_token_test.go
+++ b/redis/marketplace_token_test.go
@@ -81,7 +81,10 @@ func TestGetToken(t *testing.T) {
 // TestSetTokenUnreachableRedis tests that an error is returned when something goes wrong. In this case, an
 // unreachable Redis server is simulated.
 func TestSetTokenUnreachableRedis(t *testing.T) {
-	Client = redis.NewClient(&redis.Options{})
+	Client = redis.NewClient(&redis.Options{
+		Addr:        "127.0.0.1:2345",
+		DialTimeout: time.Millisecond,
+	})
 
 	// Set up a fake token and a fake tenant id
 	fakeToken := setUpFakeToken()


### PR DESCRIPTION
This test was throwing a false-negative for me since I always have a redis cache running locally. By pointing it at a bad port it will fail successfully!

![image](https://user-images.githubusercontent.com/5856504/154992977-1d4b1dc9-deb0-453b-85b2-4c0ddfa7770c.png)
