### PR TITLE
[RHCLOUD-18182] Database DAO for authentications

### DIFF
--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
@@ -86,7 +87,7 @@ func AuthenticationCreate(c echo.Context) error {
 	var extra map[string]interface{}
 	var extraDb datatypes.JSON
 
-	if conf.VaultOn {
+	if config.IsVaultOn() {
 		extra = createRequest.Extra
 	} else {
 		extraDb, err = json.Marshal(createRequest.Extra)

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -59,19 +61,45 @@ func TestAuthenticationList(t *testing.T) {
 		t.Error("model did not deserialize as a source")
 	}
 
-	if auth1["id"] != fixtures.TestAuthenticationData[0].ID {
-		t.Error("ghosts infected the return")
+	if conf.VaultOn {
+		if auth1["id"] != fixtures.TestAuthenticationData[0].ID {
+			t.Errorf(`wrong authentication list fetched. Want authentications from the fixtures, got: %s`, auth1)
+		}
+	} else {
+		outIdStr, ok := auth1["id"].(string)
+		if !ok {
+			t.Errorf(`Want "string", got "%s"`, auth1)
+		}
+
+		outId, err := strconv.ParseInt(outIdStr, 10, 64)
+		if err != nil {
+			t.Errorf(`The ID of the payload could not be converted to int64: %s`, err)
+		}
+
+		if fixtures.TestAuthenticationData[0].DbID != outId {
+			t.Errorf(`wrong authentication list fetched. Want authentications from the fixtures, got: %s`, auth1)
+		}
 	}
 
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
 func TestAuthenticationGet(t *testing.T) {
-	uid := fixtures.TestAuthenticationData[0].ID
+	var id string
+
+	// If we're running integration tests without Vault...
+	if parser.RunningIntegrationTests && !conf.VaultOn {
+		id = strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
+	} else {
+		// If we're either running unit tests, or integration tests with Vault, we force the "VaultOn" configuration to
+		// be true, since there are multiple places where this "if conf.VaultOn" check is run.
+		conf.VaultOn = true
+		id = fixtures.TestAuthenticationData[0].ID
+	}
 
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
-		"/api/sources/v3.1/authentications/"+uid,
+		"/api/sources/v3.1/authentications/"+id,
 		nil,
 		map[string]interface{}{
 			"tenantID": int64(1),
@@ -79,7 +107,7 @@ func TestAuthenticationGet(t *testing.T) {
 	)
 
 	c.SetParamNames("uid")
-	c.SetParamValues(uid)
+	c.SetParamValues(id)
 
 	err := AuthenticationGet(c)
 	if err != nil {
@@ -96,8 +124,14 @@ func TestAuthenticationGet(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if outAuthentication.ID != uid {
-		t.Error("ghosts infected the return")
+	if conf.VaultOn {
+		if outAuthentication.ID != id {
+			t.Error("ghosts infected the return")
+		}
+	} else {
+		if outAuthentication.ID != id {
+			t.Errorf(`wrong authentication fetched. Want "%s", got "%s"`, id, outAuthentication.ID)
+		}
 	}
 }
 
@@ -237,7 +271,12 @@ func TestAuthenticationUpdate(t *testing.T) {
 	)
 
 	c.SetParamNames("uid")
-	c.SetParamValues(fixtures.TestAuthenticationData[0].ID)
+	if conf.VaultOn {
+		c.SetParamValues(fixtures.TestAuthenticationData[0].ID)
+	} else {
+		id := strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
+		c.SetParamValues(id)
+	}
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	err = AuthenticationUpdate(c)
@@ -339,7 +378,13 @@ func TestAuthenticationDelete(t *testing.T) {
 	)
 
 	c.SetParamNames("uid")
-	c.SetParamValues(fixtures.TestAuthenticationData[0].ID)
+
+	if conf.VaultOn {
+		c.SetParamValues(fixtures.TestAuthenticationData[0].ID)
+	} else {
+		id := strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
+		c.SetParamValues(id)
+	}
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	err := AuthenticationDelete(c)

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
@@ -61,7 +62,7 @@ func TestAuthenticationList(t *testing.T) {
 		t.Error("model did not deserialize as a source")
 	}
 
-	if conf.VaultOn {
+	if config.IsVaultOn() {
 		if auth1["id"] != fixtures.TestAuthenticationData[0].ID {
 			t.Errorf(`wrong authentication list fetched. Want authentications from the fixtures, got: %s`, auth1)
 		}
@@ -88,12 +89,12 @@ func TestAuthenticationGet(t *testing.T) {
 	var id string
 
 	// If we're running integration tests without Vault...
-	if parser.RunningIntegrationTests && !conf.VaultOn {
+	if parser.RunningIntegrationTests && !config.IsVaultOn() {
 		id = strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
 	} else {
-		// If we're either running unit tests, or integration tests with Vault, we force the "VaultOn" configuration to
-		// be true, since there are multiple places where this "if conf.VaultOn" check is run.
-		conf.VaultOn = true
+		// If we're either running unit tests, or integration tests with Vault, we force the secret store to be "vault"
+		// since there are multiple places where this "if config.IsVaultOn()" check is run.
+		conf.SecretStore = "vault"
 		id = fixtures.TestAuthenticationData[0].ID
 	}
 
@@ -124,7 +125,7 @@ func TestAuthenticationGet(t *testing.T) {
 		t.Error("Failed unmarshaling output")
 	}
 
-	if conf.VaultOn {
+	if config.IsVaultOn() {
 		if outAuthentication.ID != id {
 			t.Error("ghosts infected the return")
 		}
@@ -271,7 +272,7 @@ func TestAuthenticationUpdate(t *testing.T) {
 	)
 
 	c.SetParamNames("uid")
-	if conf.VaultOn {
+	if config.IsVaultOn() {
 		c.SetParamValues(fixtures.TestAuthenticationData[0].ID)
 	} else {
 		id := strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
@@ -379,7 +380,7 @@ func TestAuthenticationDelete(t *testing.T) {
 
 	c.SetParamNames("uid")
 
-	if conf.VaultOn {
+	if config.IsVaultOn() {
 		c.SetParamValues(fixtures.TestAuthenticationData[0].ID)
 	} else {
 		id := strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ type SourcesApiConfig struct {
 	StatusListener            bool
 	MigrationsSetup           bool
 	MigrationsReset           bool
-	VaultOn                   bool
+	SecretStore               string
 }
 
 // Get - returns the config parsed from runtime vars
@@ -114,8 +114,12 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("MarketplaceHost", os.Getenv("MARKETPLACE_HOST"))
 	options.SetDefault("SlowSQLThreshold", 2) //seconds
 	options.SetDefault("BypassRbac", os.Getenv("BYPASS_RBAC") == "true")
-	// We assume that if the "VAULT_ADDR" environment variable is set, Vault is online
-	options.Set("VaultOn", os.Getenv("VAULT_ADDR") != "")
+	// The secret store defaults to the database in case an empty or an incorrect value are provided.
+	secretStore := os.Getenv("SECRET_STORE")
+	if secretStore != "database" && secretStore != "vault" {
+		secretStore = "database"
+	}
+	options.SetDefault("SecretStore", secretStore)
 
 	// Parse any Flags (using our own flag set to not conflict with the global flag)
 	fs := flag.NewFlagSet("runtime", flag.ContinueOnError)
@@ -173,7 +177,7 @@ func Get() *SourcesApiConfig {
 		StatusListener:            options.GetBool("StatusListener"),
 		MigrationsSetup:           options.GetBool("MigrationsSetup"),
 		MigrationsReset:           options.GetBool("MigrationsReset"),
-		VaultOn:                   options.GetBool("VaultOn"),
+		SecretStore:               options.GetString("SecretStore"),
 	}
 
 	return parsedConfig
@@ -186,4 +190,9 @@ func (sourceConfig *SourcesApiConfig) KafkaTopic(requestedTopic string) string {
 	}
 
 	return topic
+}
+
+// IsVaultOn returns true if the authentications are backed by Vault. False, if they are backed by the database.
+func IsVaultOn() bool {
+	return parsedConfig.SecretStore == "vault"
 }

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type SourcesApiConfig struct {
 	StatusListener            bool
 	MigrationsSetup           bool
 	MigrationsReset           bool
+	VaultOn                   bool
 }
 
 // Get - returns the config parsed from runtime vars
@@ -113,6 +114,8 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("MarketplaceHost", os.Getenv("MARKETPLACE_HOST"))
 	options.SetDefault("SlowSQLThreshold", 2) //seconds
 	options.SetDefault("BypassRbac", os.Getenv("BYPASS_RBAC") == "true")
+	// We assume that if the "VAULT_ADDR" environment variable is set, Vault is online
+	options.Set("VaultOn", os.Getenv("VAULT_ADDR") != "")
 
 	// Parse any Flags (using our own flag set to not conflict with the global flag)
 	fs := flag.NewFlagSet("runtime", flag.ContinueOnError)
@@ -170,6 +173,7 @@ func Get() *SourcesApiConfig {
 		StatusListener:            options.GetBool("StatusListener"),
 		MigrationsSetup:           options.GetBool("MigrationsSetup"),
 		MigrationsReset:           options.GetBool("MigrationsReset"),
+		VaultOn:                   options.GetBool("VaultOn"),
 	}
 
 	return parsedConfig

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -626,12 +626,7 @@ func setMarketplaceTokenAuthExtraField(auth *m.Authentication) error {
 			auth.Extra = make(map[string]interface{})
 		}
 
-		serializedToken, err := json.Marshal(token)
-		if err != nil {
-			return fmt.Errorf("could not serialize marketplace token as JSON: %s", err)
-		}
-
-		auth.Extra["marketplace"] = serializedToken
+		auth.Extra["marketplace"] = token
 	} else {
 		if auth.ExtraDb == nil {
 			// In case there is no content in the database we can safely marshal the token and return it directly.

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/marketplace"
 	m "github.com/RedHatInsights/sources-api-go/model"
@@ -24,7 +25,7 @@ var GetAuthenticationDao func(*int64) AuthenticationDao
 
 // getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultAuthenticationDao(tenantId *int64) AuthenticationDao {
-	if conf.VaultOn {
+	if config.IsVaultOn() {
 		return &authenticationDaoImpl{
 			TenantID: tenantId,
 		}
@@ -621,7 +622,7 @@ func setMarketplaceTokenAuthExtraField(auth *m.Authentication) error {
 		}
 	}
 
-	if conf.VaultOn {
+	if config.IsVaultOn() {
 		if auth.Extra == nil {
 			auth.Extra = make(map[string]interface{})
 		}

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -24,8 +24,14 @@ var GetAuthenticationDao func(*int64) AuthenticationDao
 
 // getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultAuthenticationDao(tenantId *int64) AuthenticationDao {
-	return &authenticationDaoImpl{
-		TenantID: tenantId,
+	if conf.VaultOn {
+		return &authenticationDaoImpl{
+			TenantID: tenantId,
+		}
+	} else {
+		return &authenticationDaoDbImpl{
+			TenantID: tenantId,
+		}
 	}
 }
 

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -127,7 +127,7 @@ func TestNotMarketplaceAuthNotProcessed(t *testing.T) {
 // returns the token on the "extra" field.
 func TestAuthFromVaultMarketplaceCacheHit(t *testing.T) {
 	// We need to simulate that the Vault is online.
-	conf.VaultOn = true
+	conf.SecretStore = "vault"
 
 	// For this test we need to simulate that there is a cache hit, so the token cacher must return a proper fake
 	// bearer token
@@ -457,7 +457,7 @@ func TestAuthFromVault(t *testing.T) {
 // previous content.
 func TestAuthFromDbExtraNoContent(t *testing.T) {
 	// Simulate that the Vault instance is off, and that we're pulling authentications from the database.
-	conf.VaultOn = false
+	conf.SecretStore = "database"
 
 	// In this test we need to simulate a cache miss, and then a proper token caching. So the fake TokenCacher should
 	// both miss the cache and be able to cache the provided token.
@@ -504,7 +504,7 @@ func TestAuthFromDbExtraNoContent(t *testing.T) {
 // content.
 func TestAuthFromDbExtraPreviousContent(t *testing.T) {
 	// Simulate that the Vault instance is off, and that we're pulling authentications from the database.
-	conf.VaultOn = false
+	conf.SecretStore = "database"
 
 	// In this test we need to simulate a cache miss, and then a proper token caching. So the fake TokenCacher should
 	// both miss the cache and be able to cache the provided token.

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"encoding/json"
 	"fmt"
+
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -1,0 +1,433 @@
+package dao
+
+import (
+	"encoding/json"
+	"fmt"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type authenticationDaoDbImpl struct {
+	TenantID *int64
+}
+
+func (add *authenticationDaoDbImpl) List(limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	query := DB.
+		Debug().
+		Model(&m.Authentication{})
+
+	query, err := applyFilters(query, filters)
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	// getting the total count (filters included) for pagination
+	count := int64(0)
+	query.Count(&count)
+
+	// limiting + running the actual query.
+	authentications := make([]m.Authentication, 0, limit)
+	err = query.
+		Debug().
+		Where("tenant_id = ?", add.TenantID).
+		Limit(limit).
+		Offset(offset).
+		Find(&authentications).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	marketplaceTokenCacher = GetMarketplaceTokenCacher(add.TenantID)
+	for i := 0; i < len(authentications); i++ {
+		err := setMarketplaceTokenAuthExtraField(&authentications[i])
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return authentications, count, nil
+}
+
+func (add *authenticationDaoDbImpl) GetById(id string) (*m.Authentication, error) {
+	authentication := &m.Authentication{}
+
+	err := DB.
+		Debug().
+		Where("id = ?", id).
+		Where("tenant_id = ?", add.TenantID).
+		First(&authentication).
+		Error
+
+	if err != nil {
+		return nil, util.NewErrNotFound("authentication")
+	}
+
+	err = setMarketplaceTokenAuthExtraField(authentication)
+	if err != nil {
+		return nil, err
+	}
+
+	return authentication, nil
+}
+
+func (add *authenticationDaoDbImpl) ListForSource(sourceID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	// Check that the source exists before continuing.
+	var sourceExists bool
+	err := DB.Debug().
+		Model(&m.Source{}).
+		Select(`1`).
+		Where(`id = ?`, sourceID).
+		Where(`tenant_id = ?`, add.TenantID).
+		Scan(&sourceExists).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	if !sourceExists {
+		return nil, 0, util.NewErrNotFound("source")
+	}
+
+	// List and count all the authentications from the given source.
+	query := DB.
+		Debug().
+		Model(&m.Authentication{})
+
+	query, err = applyFilters(query, filters)
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	// getting the total count (filters included) for pagination
+	count := int64(0)
+	query.
+		Where("resource_id = ?", sourceID).
+		Where("resource_type = 'Source'").
+		Where("tenant_id = ?", add.TenantID).
+		Count(&count)
+
+	// limiting + running the actual query.
+	authentications := make([]m.Authentication, 0, limit)
+	err = query.
+		Limit(limit).
+		Offset(offset).
+		Find(&authentications).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	for _, auth := range authentications {
+		err := setMarketplaceTokenAuthExtraField(&auth)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return authentications, count, nil
+}
+
+func (add *authenticationDaoDbImpl) ListForApplication(applicationID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	// Check that the application exists before continuing.
+	var applicationExists bool
+	err := DB.Debug().
+		Model(&m.Application{}).
+		Select(`1`).
+		Where(`id = ?`, applicationID).
+		Where(`tenant_id = ?`, add.TenantID).
+		Scan(&applicationExists).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	if !applicationExists {
+		return nil, 0, util.NewErrNotFound("application")
+	}
+
+	// List and count all the authentications from the given application.
+	query := DB.
+		Debug().
+		Model(&m.Authentication{})
+
+	query, err = applyFilters(query, filters)
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	// getting the total count (filters included) for pagination
+	count := int64(0)
+	query.
+		Where("resource_id = ?", applicationID).
+		Where("resource_type = 'Application'").
+		Where("tenant_id = ?", add.TenantID).
+		Count(&count)
+
+	// limiting + running the actual query.
+	authentications := make([]m.Authentication, 0, limit)
+	err = query.
+		Where("resource_id = ?", applicationID).
+		Where("resource_type = 'Application'").
+		Where("tenant_id = ?", add.TenantID).
+		Limit(limit).
+		Offset(offset).
+		Find(&authentications).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	for _, auth := range authentications {
+		err := setMarketplaceTokenAuthExtraField(&auth)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return authentications, count, nil
+}
+
+func (add *authenticationDaoDbImpl) ListForApplicationAuthentication(appAuthID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	// Check that the application authentication exists before continuing.
+	var applicationAuthenticationExists bool
+	err := DB.Debug().
+		Model(&m.ApplicationAuthentication{}).
+		Select(`1`).
+		Where(`id = ?`, appAuthID).
+		Where(`tenant_id = ?`, add.TenantID).
+		Scan(&applicationAuthenticationExists).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	if !applicationAuthenticationExists {
+		return nil, 0, util.NewErrNotFound("application authentication")
+	}
+
+	// List and count all the authentications from the given application authentications.
+	query := DB.Debug().
+		Model(&m.Authentication{})
+
+	query, err = applyFilters(query, filters)
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	// getting the total count (filters included) for pagination
+	count := int64(0)
+	query.
+		Where("resource_id = ?", appAuthID).
+		Where("resource_type = 'ApplicationAuthentication'").
+		Where("tenant_id = ?", add.TenantID).
+		Count(&count)
+
+	// limiting + running the actual query.
+	authentications := make([]m.Authentication, 0, limit)
+	err = query.
+		Where("resource_id = ?", appAuthID).
+		Where("resource_type = 'ApplicationAuthentication'").
+		Where("tenant_id = ?", add.TenantID).
+		Limit(limit).
+		Offset(offset).
+		Find(&authentications).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	for _, auth := range authentications {
+		err := setMarketplaceTokenAuthExtraField(&auth)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return authentications, count, nil
+}
+
+func (add *authenticationDaoDbImpl) ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	// Check that the endpoint exists before continuing.
+	var endpointExists bool
+	err := DB.Debug().
+		Model(&m.Endpoint{}).
+		Select(`1`).
+		Where(`id = ?`, endpointID).
+		Where(`tenant_id = ?`, add.TenantID).
+		Scan(&endpointExists).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	if !endpointExists {
+		return nil, 0, util.NewErrNotFound("endpoint")
+	}
+
+	// List and count all the authentications from the given endpoint.
+	query := DB.Debug().
+		Model(&m.Authentication{})
+
+	query, err = applyFilters(query, filters)
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	// getting the total count (filters included) for pagination
+	count := int64(0)
+	query.
+		Where("resource_id = ?", endpointID).
+		Where("resource_type = 'Endpoint'").
+		Where("tenant_id = ?", add.TenantID).
+		Count(&count)
+
+	// limiting + running the actual query.
+	authentications := make([]m.Authentication, 0, limit)
+	err = query.
+		Where("resource_id = ?", endpointID).
+		Where("resource_type = 'Endpoint'").
+		Where("tenant_id = ?", add.TenantID).
+		Limit(limit).
+		Offset(offset).
+		Find(&authentications).
+		Error
+
+	if err != nil {
+		return nil, 0, util.NewErrBadRequest(err)
+	}
+
+	for _, auth := range authentications {
+		err := setMarketplaceTokenAuthExtraField(&auth)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+
+	return authentications, count, nil
+}
+
+func (add *authenticationDaoDbImpl) Create(authentication *m.Authentication) error {
+	authentication.TenantID = *add.TenantID // the TenantID gets injected in the middleware
+
+	return DB.
+		Debug().
+		Create(authentication).
+		Error
+}
+
+// BulkCreate method _without_ checking if the resource exists. Basically since this is the bulk-create method the
+// resource doesn't exist yet and we know the source ID is set beforehand.
+func (add *authenticationDaoDbImpl) BulkCreate(auth *m.Authentication) error {
+	return add.Create(auth)
+}
+
+func (add *authenticationDaoDbImpl) Update(authentication *m.Authentication) error {
+	return DB.
+		Debug().
+		Updates(authentication).
+		Error
+}
+
+func (add *authenticationDaoDbImpl) Delete(id string) (*m.Authentication, error) {
+	var authentication m.Authentication
+
+	err := DB.
+		Debug().
+		Where("id = ?", id).
+		Where("tenant_id = ?", add.TenantID).
+		First(&authentication).
+		Error
+
+	if err != nil {
+		return nil, util.NewErrNotFound("authentication")
+	}
+
+	err = DB.
+		Debug().
+		Delete(authentication).
+		Error
+
+	if err != nil {
+		return nil, fmt.Errorf(`failed to delete authentication with id "%s"`, id)
+	}
+
+	return &authentication, nil
+}
+
+func (add *authenticationDaoDbImpl) Tenant() *int64 {
+	return add.TenantID
+}
+
+func (add *authenticationDaoDbImpl) AuthenticationsByResource(authentication *m.Authentication) ([]m.Authentication, error) {
+	var err error
+	var resourceAuthentications []m.Authentication
+
+	switch authentication.ResourceType {
+	case "Source":
+		resourceAuthentications, _, err = add.ListForSource(authentication.ResourceID, DEFAULT_LIMIT, DEFAULT_OFFSET, nil)
+	case "Endpoint":
+		resourceAuthentications, _, err = add.ListForEndpoint(authentication.ResourceID, DEFAULT_LIMIT, DEFAULT_OFFSET, nil)
+	case "Application":
+		resourceAuthentications, _, err = add.ListForApplication(authentication.ResourceID, DEFAULT_LIMIT, DEFAULT_OFFSET, nil)
+	default:
+		return nil, fmt.Errorf("unable to fetch authentications for %s", authentication.ResourceType)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resourceAuthentications, nil
+}
+
+func (add *authenticationDaoDbImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
+	add.TenantID = &resource.TenantID
+	authentication, err := add.GetById(resource.ResourceUID)
+	if err != nil {
+		return nil, err
+	}
+
+	return BulkMessageFromSource(&authentication.Source, authentication)
+}
+
+func (add *authenticationDaoDbImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {
+	add.TenantID = &resource.TenantID
+	authentication, err := add.GetById(resource.ResourceUID)
+	if err != nil {
+		return err
+	}
+
+	err = authentication.UpdateBy(updateAttributes)
+	if err != nil {
+		return err
+	}
+
+	return add.Update(authentication)
+}
+
+func (add *authenticationDaoDbImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
+	add.TenantID = &resource.TenantID
+	auth, err := add.GetById(resource.ResourceUID)
+	if err != nil {
+		return nil, err
+	}
+
+	auth.TenantID = resource.TenantID
+	auth.Tenant = m.Tenant{ExternalTenant: resource.AccountNumber}
+	authEvent := auth.ToEvent()
+	data, err := json.Marshal(authEvent)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -1,0 +1,820 @@
+package dao
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// TestAuthType is an authentication type used in the fixtures to perform checks.
+const TestAuthType = "test-my-test-auth-type"
+
+// setUpValidAuthentication returns a minimum valid authentication.
+func setUpValidAuthentication() *model.Authentication {
+	return &model.Authentication{
+		AuthType: TestAuthType,
+		SourceID: fixtures.TestSourceData[0].ID,
+		TenantID: fixtures.TestTenantData[0].Id,
+	}
+}
+
+// createAuthenticationFixture inserts a new authentication fixture in the database.
+func createAuthenticationFixture(t *testing.T) {
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+
+	auth := setUpValidAuthentication()
+
+	err := dao.Create(auth)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+}
+
+// TestAuthenticationDbCreate tests that the "create" function does not present any problems at creating new entities
+// if the minimum data is provided for an authentication.
+func TestAuthenticationDbCreate(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+
+	auth := setUpValidAuthentication()
+
+	err := dao.Create(auth)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestAuthenticationDbBulkCreate tests that the "BulkCreate" function does not present any problems at creating new
+// entities if the minimum data is provided for an authentication.
+func TestAuthenticationDbBulkCreate(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+
+	auth := setUpValidAuthentication()
+
+	err := dao.BulkCreate(auth)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestAuthenticationDbList tests that the "list" operation returns the expected number of authentications.
+func TestAuthenticationDbList(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+
+	// Create another authentication to see if the listing function also brings it back.
+	createAuthenticationFixture(t)
+
+	authentications, count, err := dao.List(100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`could not fetch the authentications from the database: %s`, err)
+	}
+
+	// We should have the authentication from the fixtures plus the one we just created.
+	want := len(fixtures.TestAuthenticationData) + 1
+	got := int(count)
+	if want != got {
+		t.Errorf(`incorrect number of authentications fetched. Want "%d", got "%d"`, want, got)
+	}
+
+	// Check that we can find the inserted fixture in the list.
+	var foundInsertedFixture bool
+	for _, auth := range authentications {
+		if auth.AuthType == TestAuthType {
+			foundInsertedFixture = true
+		}
+	}
+
+	if !foundInsertedFixture {
+		t.Errorf(`the fixture that was inserted did not come in the authentications list. Something went wrong.`)
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestAuthenticationDbGet tests that the "get" operation is able to fetch the expected authentication.
+func TestAuthenticationDbGetById(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create the authentication fixture that we will be fetching.
+	authFixture := setUpValidAuthentication()
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	err := dao.Create(authFixture)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	id := strconv.FormatInt(authFixture.DbID, 10)
+
+	dbAuth, err := dao.GetById(id)
+	if err != nil {
+		t.Errorf(`could not fetch the authentication from the database: %s`, err)
+	}
+
+	want := TestAuthType
+	got := dbAuth.AuthType
+	if want != got {
+		t.Errorf(`wrong authentication fetched. Want "%s" authtype, got "%s"`, want, got)
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestAuthenticationDbUpdate tests that the "update" operation is able to properly update the authentication.
+func TestAuthenticationDbUpdate(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create the authentication fixture that we will be fetching.
+	authFixture := setUpValidAuthentication()
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	err := dao.Create(authFixture)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	// Update the authentication type.
+	updatedAuthType := "new-fresh-authtype"
+	authFixture.AuthType = updatedAuthType
+
+	err = dao.Update(authFixture)
+	if err != nil {
+		t.Errorf(`error updating the authentication: %s`, err)
+	}
+
+	id := strconv.FormatInt(authFixture.DbID, 10)
+
+	// Fetch the updated authentication.
+	updatedAuthentication, err := dao.GetById(id)
+	if err != nil {
+		t.Errorf(`error fetching the authentication: %s`, err)
+	}
+
+	want := updatedAuthType
+	got := updatedAuthentication.AuthType
+	if want != got {
+		t.Errorf(`deleted the wrong authentication. Want authtype "%s", got "%s"`, want, got)
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestAuthenticationDbGet tests that the "delete" operation is able to delete the expected authentication.
+func TestAuthenticationDbDelete(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create the authentication fixture that we will be fetching.
+	authFixture := setUpValidAuthentication()
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	err := dao.Create(authFixture)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	id := strconv.FormatInt(authFixture.DbID, 10)
+
+	deletedAuth, err := dao.Delete(id)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	{
+		want := TestAuthType
+		got := deletedAuth.AuthType
+		if want != got {
+			t.Errorf(`deleted the wrong authentication. Want authtype "%s", got "%s"`, want, got)
+		}
+	}
+
+	_, err = dao.GetById(id)
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestAuthenticationDbGet tests the "delete" operation returns a "not found" error when trying to delete a
+// non-existing authentication.
+func TestAuthenticationDbDeleteNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	_, err := dao.Delete("12345")
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestTenantId is a trivial test which tests that a correct tenant ID is returned in the function.
+func TestTenantId(t *testing.T) {
+	tenantId := int64(12345)
+	dao := GetAuthenticationDao(&tenantId)
+
+	want := tenantId
+	got := dao.Tenant()
+
+	if want != *got {
+		t.Errorf(`incorrect tenant ID returned. Want "%d", got "%d"`, want, got)
+	}
+}
+
+// TestListForSource tests if "list for source" only lists the authentications of the related source, and no more.
+func TestListForSource(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create a new source the new fixtures will be attached to.
+	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
+	source := model.Source{
+		Name:         "new source in new tenant",
+		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
+		TenantID:     fixtures.TestTenantData[1].Id,
+	}
+
+	err := sourceDao.Create(&source)
+	if err != nil {
+		t.Errorf(`error creating a source: %s`, err)
+	}
+
+	// Create three new authentications for the new source.
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	var i int
+	var maxAuths = 3
+	for i < maxAuths {
+		auth := &model.Authentication{
+			AuthType:     TestAuthType,
+			ResourceID:   source.ID,
+			ResourceType: "Source",
+			// We must pass the "SourceID" as well because Gorm automatically generates a FK for the authentications
+			// table, even though the production table doesn't have one.
+			SourceID: source.ID,
+			TenantID: fixtures.TestTenantData[1].Id,
+		}
+
+		if err = dao.Create(auth); err != nil {
+			t.Errorf(`error creating authentication: %s`, err)
+		}
+
+		i++
+	}
+
+	// Call the function under test.
+	authentications, count, err := dao.ListForSource(source.ID, 100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`[source_id: %d] error listing the authentications for the source: %s`, source.ID, err)
+	}
+
+	want := maxAuths
+	got := int(count)
+	if want != got {
+		t.Errorf(`incorrect amount of authentications fetched. Want "%d", got "%d"`, want, got)
+	}
+
+	for _, auth := range authentications {
+		if auth.AuthType != TestAuthType {
+			t.Errorf(`incorrect authentication fetched. Want authtype "%s", got "%s"`, TestAuthType, auth.AuthType)
+		}
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestListForSourceNotFound tests if a not found error is returned when a nonexistent source is given to the function
+// under test.
+func TestListForSourceNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+
+	// Call the function under test.
+	_, _, err := dao.ListForSource(12345, 100, 0, []util.Filter{})
+
+	if err == nil {
+		t.Errorf(`want error, got nil`)
+	}
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestListForApplication tests if "list for Application" only lists the authentications of the related application, and no
+// more.
+func TestListForApplication(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create a new source the new fixtures will be attached to.
+	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
+	source := model.Source{
+		Name:         "new source in new tenant",
+		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
+		TenantID:     fixtures.TestTenantData[1].Id,
+	}
+
+	err := sourceDao.Create(&source)
+	if err != nil {
+		t.Errorf(`error creating a source: %s`, err)
+	}
+
+	// Create an application fixture.
+	applicationDao := GetApplicationDao(&fixtures.TestTenantData[1].Id)
+	application := model.Application{
+		ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
+		SourceID:          source.ID,
+	}
+
+	err = applicationDao.Create(&application)
+	if err != nil {
+		t.Errorf(`error creating an application: %s`, err)
+	}
+
+	// Create three new authentications for the new application.
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	var i int
+	var maxAuths = 3
+	for i < maxAuths {
+		auth := &model.Authentication{
+			AuthType:     TestAuthType,
+			ResourceID:   application.ID,
+			ResourceType: "Application",
+			// We must pass the "SourceID" as well because Gorm automatically generates a FK for the authentications
+			// table, even though the production table doesn't have one.
+			SourceID: source.ID,
+			TenantID: fixtures.TestTenantData[1].Id,
+		}
+
+		if err = dao.Create(auth); err != nil {
+			t.Errorf(`error creating authentication: %s`, err)
+		}
+
+		i++
+	}
+
+	// Call the function under test.
+	authentications, count, err := dao.ListForApplication(application.ID, 100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`[application_id: %d] error listing the authentications for the application: %s`, application.ID, err)
+	}
+
+	want := maxAuths
+	got := int(count)
+	if want != got {
+		t.Errorf(`incorrect amount of authentications fetched. Want "%d", got "%d"`, want, got)
+	}
+
+	for _, auth := range authentications {
+		if auth.AuthType != TestAuthType {
+			t.Errorf(`incorrect authentication fetched. Want authtype "%s", got "%s"`, TestAuthType, auth.AuthType)
+		}
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestListForApplicationNotFound tests if a not found error is returned when a nonexistent application is given to the
+// function under test.
+func TestListForApplicationNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+
+	// Call the function under test.
+	_, _, err := dao.ListForApplication(12345, 100, 0, []util.Filter{})
+
+	if err == nil {
+		t.Errorf(`want error, got nil`)
+	}
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestListForApplicationAuthentication tests if "list for ApplicationAuthentication" only lists the authentications of
+// the related ApplicationAuthentication, and no more.
+func TestListForApplicationAuthentication(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create a new source the new fixtures will be attached to.
+	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
+	source := model.Source{
+		Name:         "new source in new tenant",
+		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
+		TenantID:     fixtures.TestTenantData[1].Id,
+	}
+
+	err := sourceDao.Create(&source)
+	if err != nil {
+		t.Errorf(`error creating a source: %s`, err)
+	}
+
+	// Create an application fixture.
+	applicationDao := GetApplicationDao(&fixtures.TestTenantData[1].Id)
+	application := model.Application{
+		ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
+		SourceID:          source.ID,
+	}
+
+	err = applicationDao.Create(&application)
+	if err != nil {
+		t.Errorf(`error creating an application: %s`, err)
+	}
+
+	// Create a new authentication for the new application authentication. The "ResourceId" is missing since we still
+	// don't have the ID of the application authentication object.
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	auth := &model.Authentication{
+		AuthType:     TestAuthType,
+		ResourceType: "ApplicationAuthentication",
+		SourceID:     source.ID,
+		TenantID:     fixtures.TestTenantData[1].Id,
+	}
+
+	if err = dao.Create(auth); err != nil {
+		t.Errorf(`error creating authentication: %s`, err)
+	}
+
+	// Create the application authentication.
+	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	appAuth := model.ApplicationAuthentication{
+		TenantID:         fixtures.TestTenantData[1].Id,
+		ApplicationID:    application.ID,
+		AuthenticationID: auth.DbID,
+	}
+
+	err = appAuthDao.Create(&appAuth)
+	if err != nil {
+		t.Errorf(`error creating application authentication: %s`, err)
+	}
+
+	// Update the authentication's appauth ID.
+	auth.ResourceID = appAuth.ID
+	err = dao.Update(auth)
+	if err != nil {
+		t.Errorf(`could not update authentication to set it's resource ID: %s`, err)
+	}
+
+	// Call the function under test.
+	authentications, count, err := dao.ListForApplicationAuthentication(appAuth.ID, 100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`[application_authentication_id: %d] error listing the authentications for the application authentication: %s`, appAuth.ID, err)
+	}
+
+	want := 1
+	got := int(count)
+	if want != got {
+		t.Errorf(`incorrect amount of authentications fetched. Want "%d", got "%d"`, want, got)
+	}
+
+	for _, auth := range authentications {
+		if auth.AuthType != TestAuthType {
+			t.Errorf(`incorrect authentication fetched. Want authtype "%s", got "%s"`, TestAuthType, auth.AuthType)
+		}
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestListForApplicationAuthenticationNotFound tests if a not found error is returned when a nonexistent application
+// authentication is given to the function under test.
+func TestListForApplicationAuthenticationNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+
+	// Call the function under test.
+	_, _, err := dao.ListForApplicationAuthentication(12345, 100, 0, []util.Filter{})
+
+	if err == nil {
+		t.Errorf(`want error, got nil`)
+	}
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestListForEndpoint tests if "list for Endpoint" only lists the authentications of the related endpoint, and no more.
+func TestListForEndpoint(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create a new source the new fixtures will be attached to.
+	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
+	source := model.Source{
+		Name:         "new source in new tenant",
+		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
+		TenantID:     fixtures.TestTenantData[1].Id,
+	}
+
+	err := sourceDao.Create(&source)
+	if err != nil {
+		t.Errorf(`error creating a source: %s`, err)
+	}
+
+	// Create an endpoint fixture.
+	endpointDao := GetEndpointDao(&fixtures.TestTenantData[1].Id)
+	endpoint := model.Endpoint{
+		SourceID: source.ID,
+	}
+
+	err = endpointDao.Create(&endpoint)
+	if err != nil {
+		t.Errorf(`error creating an endpoint: %s`, err)
+	}
+
+	// Create three new authentications for the new application authentication.
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	var i int
+	var maxAuths = 3
+	for i < maxAuths {
+		auth := &model.Authentication{
+			AuthType:     TestAuthType,
+			ResourceID:   endpoint.ID,
+			ResourceType: "Endpoint",
+			// We must pass the "SourceID" as well because Gorm automatically generates a FK for the authentications
+			// table, even though the production table doesn't have one.
+			SourceID: source.ID,
+			TenantID: fixtures.TestTenantData[1].Id,
+		}
+
+		if err = dao.Create(auth); err != nil {
+			t.Errorf(`error creating authentication: %s`, err)
+		}
+
+		i++
+	}
+
+	// Call the function under test.
+	authentications, count, err := dao.ListForEndpoint(endpoint.ID, 100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`[endpoint_id: %d] error listing the authentications for the endpoint authentication: %s`, endpoint.ID, err)
+	}
+
+	want := maxAuths
+	got := int(count)
+	if want != got {
+		t.Errorf(`incorrect amount of authentications fetched. Want "%d", got "%d"`, want, got)
+	}
+
+	for _, auth := range authentications {
+		if auth.AuthType != TestAuthType {
+			t.Errorf(`incorrect authentication fetched. Want authtype "%s", got "%s"`, TestAuthType, auth.AuthType)
+		}
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestListForEndpointNotFound tests if a not found error is returned when a nonexistent endpoint is given to the
+// function under test.
+func TestListForEndpointNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+
+	// Call the function under test.
+	_, _, err := dao.ListForEndpoint(12345, 0, 0, []util.Filter{})
+
+	if err == nil {
+		t.Errorf(`want error, got nil`)
+	}
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestFetchAndUpdateBy tests if "FetchAndUpdateBy" updates the timestamps as expected.
+func TestFetchAndUpdateBy(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create the authentication fixture that we will be fetching.
+	authFixture := setUpValidAuthentication()
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	err := dao.Create(authFixture)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	// Convert the ID to a string format to be able to update/fetch it.
+	id := strconv.FormatInt(authFixture.DbID, 10)
+
+	// Create the attributes that we will be updating in the authentication.
+	now := time.Now()
+	availabilityStatus := "inventedStatus"
+	availabilityStatusError := "inventedError"
+
+	attributes := map[string]interface{}{
+		"last_checked_at":           now.Format(time.RFC3339Nano),
+		"last_available_at":         now.Format(time.RFC3339Nano),
+		"availability_status":       availabilityStatus,
+		"availability_status_error": availabilityStatusError,
+	}
+
+	resource := util.Resource{
+		ResourceUID: id,
+		TenantID:    fixtures.TestTenantData[0].Id,
+	}
+
+	// Call the function under test.
+	err = dao.FetchAndUpdateBy(resource, attributes)
+	if err != nil {
+		t.Errorf(`error with "FetchAndUpdateBy" function: %s`, err)
+	}
+
+	// Fetch the authentication and check if it was correctly updated.
+	dbAuth, err := dao.GetById(id)
+	if err != nil {
+		t.Errorf(`could not fetch the authentication from the database: %s`, err)
+	}
+
+	{
+		want := now
+		got := dbAuth.AvailabilityStatus.LastCheckedAt
+
+		if !dateTimesAreSimilar(want, got) {
+			t.Errorf(`authentication was not updated. Want "last checked at" "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := now
+		got := dbAuth.AvailabilityStatus.LastAvailableAt
+
+		if !dateTimesAreSimilar(want, got) {
+			t.Errorf(`authentication was not updated. Want "last available at" "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := availabilityStatus
+		got := dbAuth.AvailabilityStatus.AvailabilityStatus
+
+		if want != got {
+			t.Errorf(`authentication was not updated. Want "availability status" "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := availabilityStatusError
+		got := dbAuth.AvailabilityStatusError
+
+		if want != got {
+			t.Errorf(`authentication was not updated. Want "availability status error" "%s", got "%s"`, want, got)
+		}
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestToEventJSON tests if "FetchAndUpdateBy" returns the expected output for the given resource.
+func TestToEventJSON(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create the authentication fixture that we will be fetching.
+	authFixture := setUpValidAuthentication()
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	err := dao.Create(authFixture)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	// Convert the ID to a string format to be able to fetch it.
+	id := strconv.FormatInt(authFixture.DbID, 10)
+
+	// Fetch the authentication and "convert it to an event", to then check the output from the function under test.
+	dbAuth, err := dao.GetById(id)
+	if err != nil {
+		t.Errorf(`could not fetch the authentication from the database: %s`, err)
+	}
+	want, err := json.Marshal(dbAuth.ToEvent())
+	if err != nil {
+		t.Errorf(`error marshalling the authentication fixture to JSON: %s`, err)
+	}
+
+	// Call the function under test.
+	resource := util.Resource{
+		ResourceUID: id,
+		TenantID:    fixtures.TestTenantData[0].Id,
+	}
+	got, err := dao.ToEventJSON(resource)
+	if err != nil {
+		t.Errorf(`error on "ToEventJSON": %s`, err)
+	}
+
+	if !bytes.Equal(want, got) {
+		t.Errorf(`"ToEventJSON" didn't return the expected result. Want "%s", got "%s"'`, want, got)
+	}
+
+	DoneWithFixtures("authentications_db")
+}
+
+// TestBulkMessage tests if "BulkMessage" returns the expected output for the given resource. It simply calls the
+// function under test and "BulkMessageFromSource", and then compares outputs, since it's not the aim of this test to
+// test also "BulkMessageFromSource".
+func TestBulkMessage(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("authentications_db")
+
+	// Create the authentication fixture that we will be fetching.
+	authFixture := setUpValidAuthentication()
+	authFixture.ResourceID = fixtures.TestSourceData[0].ID
+	authFixture.ResourceType = "Source"
+
+	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	err := dao.Create(authFixture)
+	if err != nil {
+		t.Errorf(`error creating the authentication: %s`, err)
+	}
+
+	// Convert the ID to a string format to be able to fetch it.
+	id := strconv.FormatInt(authFixture.DbID, 10)
+
+	// Fetch the authentication to be able to use it in the "BulkMessageFromSource" function.
+	dbAuth, err := dao.GetById(id)
+	if err != nil {
+		t.Errorf(`could not fetch the authentication from the database: %s`, err)
+	}
+	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
+	source, err := sourceDao.GetById(&authFixture.SourceID)
+	if err != nil {
+		t.Errorf(`could not fetch source: %s`, err)
+	}
+
+	// Call the service function and store the expected output to compare it later.
+	serviceOutput, err := BulkMessageFromSource(source, dbAuth)
+	if err != nil {
+		t.Errorf(`unexpected error in "BulkMessageFromSource": %s`, err)
+	}
+
+	// Call the function under test.
+	resource := util.Resource{
+		ResourceUID: id,
+		TenantID:    fixtures.TestTenantData[0].Id,
+	}
+	bulkMessageOutput, err := dao.BulkMessage(resource)
+	if err != nil {
+		t.Errorf(`error on "ToEventJSON": %s`, err)
+	}
+
+	want, err := json.Marshal(serviceOutput)
+	if err != nil {
+		t.Errorf(`unexpected error when generating the expected output from the service function: %s`, err)
+	}
+
+	got, err := json.Marshal(bulkMessageOutput)
+	if err != nil {
+		t.Errorf(`unexpected error when generating the result output from the "BulkMessage" function: %s`, err)
+	}
+
+	if !bytes.Equal(want, got) {
+		t.Errorf(`"BulkMessage" didn't return the expected result. Want "%s", got "%s"'`, want, got)
+	}
+
+	DoneWithFixtures("authentications_db")
+}

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -271,10 +271,7 @@ func TestListForSource(t *testing.T) {
 			AuthType:     TestAuthType,
 			ResourceID:   source.ID,
 			ResourceType: "Source",
-			// We must pass the "SourceID" as well because Gorm automatically generates a FK for the authentications
-			// table, even though the production table doesn't have one.
-			SourceID: source.ID,
-			TenantID: fixtures.TestTenantData[1].Id,
+			TenantID:     fixtures.TestTenantData[1].Id,
 		}
 
 		if err = dao.Create(auth); err != nil {
@@ -367,10 +364,7 @@ func TestListForApplication(t *testing.T) {
 			AuthType:     TestAuthType,
 			ResourceID:   application.ID,
 			ResourceType: "Application",
-			// We must pass the "SourceID" as well because Gorm automatically generates a FK for the authentications
-			// table, even though the production table doesn't have one.
-			SourceID: source.ID,
-			TenantID: fixtures.TestTenantData[1].Id,
+			TenantID:     fixtures.TestTenantData[1].Id,
 		}
 
 		if err = dao.Create(auth); err != nil {
@@ -569,10 +563,7 @@ func TestListForEndpoint(t *testing.T) {
 			AuthType:     TestAuthType,
 			ResourceID:   endpoint.ID,
 			ResourceType: "Endpoint",
-			// We must pass the "SourceID" as well because Gorm automatically generates a FK for the authentications
-			// table, even though the production table doesn't have one.
-			SourceID: source.ID,
-			TenantID: fixtures.TestTenantData[1].Id,
+			TenantID:     fixtures.TestTenantData[1].Id,
 		}
 
 		if err = dao.Create(auth); err != nil {

--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"gorm.io/datatypes"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
@@ -109,6 +110,27 @@ func DropSchema(dbSchema string) {
 
 // MigrateSchema migrates all the models.
 func MigrateSchema() {
+	// Use a custom "authentication" table to avoid Gorm creating FKs when the real databases don't have them.
+	type authentication struct {
+		Id                      int64          `gorm:"primaryKey"`
+		Name                    string         `gorm:"column:name"`
+		AuthType                string         `gorm:"column:authtype"`
+		Username                string         `gorm:"column:username"`
+		Password                string         `gorm:"column:password"`
+		Extra                   datatypes.JSON `gorm:"column:extra"`
+		Version                 string         `gorm:"column:version"`
+		AvailabilityStatus      string         `gorm:"column:availability_status"`
+		AvailabilityStatusError string         `gorm:"column:availability_status_error"`
+		LastCheckedAt           time.Time      `gorm:"column:last_checked_at"`
+		LastAvailableAt         time.Time      `gorm:"column:last_available_at"`
+		SourceId                int64          `gorm:"column:source_id"`
+		TenantId                int64          `gorm:"column:tenant_id"`
+		ResourceType            string         `gorm:"column:resource_type"`
+		ResourceId              int64          `gorm:"column:resource_id"`
+		CreatedAt               time.Time      `gorm:"column:created_at"`
+		UpdatedAt               time.Time      `gorm:"column:updated_at"`
+	}
+
 	err := DB.AutoMigrate(
 		&m.SourceType{},
 		&m.ApplicationType{},
@@ -119,7 +141,7 @@ func MigrateSchema() {
 		&m.RhcConnection{},
 		&m.SourceRhcConnection{},
 		&m.Application{},
-		&m.Authentication{},
+		&authentication{},
 		&m.ApplicationAuthentication{},
 	)
 

--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -86,6 +86,8 @@ func CreateFixtures(schema string) {
 	DB.Create(&fixtures.TestApplicationData)
 	DB.Create(&fixtures.TestApplicationAuthenticationData)
 
+	DB.Create(&fixtures.TestAuthenticationData)
+
 	UpdateTablesSequences(schema)
 }
 
@@ -117,6 +119,7 @@ func MigrateSchema() {
 		&m.RhcConnection{},
 		&m.SourceRhcConnection{},
 		&m.Application{},
+		&m.Authentication{},
 		&m.ApplicationAuthentication{},
 	)
 
@@ -165,6 +168,7 @@ func UpdateTablesSequences(schema string) {
 		"applications",
 		"endpoints",
 		"rhc_connections",
+		"authentications",
 		"application_authentications",
 	}
 

--- a/internal/testutils/fixtures/application_authentication.go
+++ b/internal/testutils/fixtures/application_authentication.go
@@ -12,6 +12,7 @@ var TestApplicationAuthenticationData = []m.ApplicationAuthentication{
 		VaultPath:         fmt.Sprintf("Application_%d_%v", TestTenantData[0].Id, TestAuthenticationData[0].ID),
 		TenantID:          TestTenantData[0].Id,
 		ApplicationID:     1,
+		AuthenticationID:  1,
 		AuthenticationUID: TestAuthenticationData[0].ID,
 	},
 }

--- a/internal/testutils/fixtures/authentication.go
+++ b/internal/testutils/fixtures/authentication.go
@@ -8,9 +8,12 @@ import (
 
 var TestAuthenticationData = []m.Authentication{
 	{
-		ID:       "611a8a38-f434-4e62-bda0-78cd45ffae5b",
-		TenantID: TestTenantData[0].Id,
-		SourceID: 1,
+		ID:           "611a8a38-f434-4e62-bda0-78cd45ffae5b",
+		DbID:         1,
+		TenantID:     TestTenantData[0].Id,
+		SourceID:     1,
+		ResourceType: "Source",
+		ResourceID:   1,
 	},
 }
 

--- a/internal/testutils/fixtures/tenant.go
+++ b/internal/testutils/fixtures/tenant.go
@@ -7,4 +7,8 @@ var TestTenantData = []m.Tenant{
 		Id:             1,
 		ExternalTenant: "12345",
 	},
+	{
+		Id:             2,
+		ExternalTenant: "67890",
+	},
 }

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -15,8 +15,7 @@ type ApplicationAuthentication struct {
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
-	// TODO: this doesn't exist yet
-	VaultPath string `json:"vault_path" gorm:"-"`
+	VaultPath string `json:"vault_path"`
 
 	TenantID int64
 	Tenant   Tenant

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -167,7 +167,7 @@ func (auth *Authentication) Path() string {
 func mapIdExtraFields(auth *Authentication) (string, map[string]interface{}) {
 	var id string
 	var extra map[string]interface{}
-	if config.Get().VaultOn {
+	if config.IsVaultOn() {
 		id = auth.ID
 		extra = auth.Extra
 	} else {

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -20,7 +20,7 @@ type Authentication struct {
 	CreatedAt time.Time `json:"created_at"`
 
 	Name                    string                 `json:"name,omitempty"`
-	AuthType                string                 `json:"authtype"`
+	AuthType                string                 `gorm:"column:authtype" json:"authtype"`
 	Username                string                 `json:"username"`
 	Password                string                 `json:"password"`
 	Extra                   map[string]interface{} `gorm:"-" json:"extra,omitempty"`

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -1,7 +1,10 @@
 package model
 
 import (
+	"encoding/json"
 	"time"
+
+	"github.com/RedHatInsights/sources-api-go/config"
 )
 
 type AuthenticationResponse struct {
@@ -61,7 +64,7 @@ type AuthenticationEditRequest struct {
 	AvailabilityStatusError *string                 `json:"availability_status_error,omitempty"`
 }
 
-func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest) {
+func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest) error {
 	if update.Name != nil {
 		auth.Name = *update.Name
 	}
@@ -74,13 +77,26 @@ func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest)
 	if update.Password != nil {
 		auth.Password = *update.Password
 	}
+
 	if update.Extra != nil {
-		auth.Extra = *update.Extra
+		if config.Get().VaultOn {
+			auth.Extra = *update.Extra
+		} else {
+			var err error
+			auth.ExtraDb, err = json.Marshal(*update.Extra)
+
+			if err != nil {
+				return err
+			}
+		}
 	}
+
 	if update.AvailabilityStatus != nil {
 		auth.AvailabilityStatus.AvailabilityStatus = *update.AvailabilityStatus
 	}
 	if update.AvailabilityStatusError != nil {
 		auth.AvailabilityStatusError = *update.AvailabilityStatusError
 	}
+
+	return nil
 }

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -1,6 +1,8 @@
 package model
 
-import "time"
+import (
+	"time"
+)
 
 type AuthenticationResponse struct {
 	ID        string `json:"id"`

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -79,7 +79,7 @@ func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest)
 	}
 
 	if update.Extra != nil {
-		if config.Get().VaultOn {
+		if config.IsVaultOn() {
 			auth.Extra = *update.Extra
 		} else {
 			var err error

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/events"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
@@ -28,7 +29,7 @@ func TestSourceListAuthentications(t *testing.T) {
 	tenantId := fixtures.TestTenantData[0].Id
 
 	// If we're running integration tests without Vault...
-	if parser.RunningIntegrationTests && !conf.VaultOn {
+	if parser.RunningIntegrationTests && !config.IsVaultOn() {
 		// Create one authentication for the database tests, to make sure that we at least have one we can fetch.
 		authsDao := dao.GetAuthenticationDao(&tenantId)
 		err := authsDao.Create(&fixtures.TestAuthenticationData[0])
@@ -36,9 +37,9 @@ func TestSourceListAuthentications(t *testing.T) {
 			t.Errorf(`could not create the authentication fixture for the test`)
 		}
 	} else {
-		// If we're either running unit tests, or integration tests with Vault, we force the "VaultOn" configuration to
-		// be true, since there are multiple places where this "if conf.VaultOn" check is run.
-		conf.VaultOn = true
+		// If we're either running unit tests, or integration tests with Vault, we force the secret store to be "vault"
+		// since there are multiple places where this "if config.IsVaultOn()" check is run.
+		conf.SecretStore = "vault"
 	}
 
 	c, rec := request.CreateTestContext(
@@ -84,7 +85,7 @@ func TestSourceListAuthentications(t *testing.T) {
 		t.Error("model did not deserialize as a source")
 	}
 
-	if conf.VaultOn {
+	if config.IsVaultOn() {
 		want := fixtures.TestAuthenticationData[0].ID
 		got := auth1["id"]
 

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -391,7 +391,7 @@ type TestData struct {
 
 func TestConsumeStatusMessage(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	config.VaultOn = true
+	config.SecretStore = "vault"
 
 	dao.Vault = &mocks.MockVault{}
 

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -391,6 +391,7 @@ type TestData struct {
 
 func TestConsumeStatusMessage(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	config.VaultOn = true
 
 	dao.Vault = &mocks.MockVault{}
 

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -2,7 +2,7 @@
   "application_authentications": [
     {
       "application_id": 1,
-      "authentication_id": 0,
+      "authentication_id": 1,
       "authentication_uid": "611a8a38-f434-4e62-bda0-78cd45ffae5b",
       "created_at": "2022-01-19 11:57:23 CET",
       "id": 1,

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -2,7 +2,7 @@
   "application_authentications": [
     {
       "application_id": 1,
-      "authentication_id": 0,
+      "authentication_id": 1,
       "authentication_uid": "611a8a38-f434-4e62-bda0-78cd45ffae5b",
       "created_at": "2022-01-19 11:57:23 CET",
       "id": 1,


### PR DESCRIPTION
This PR:

- Creates a new config option, "VaultOn", which gets set to `true` if the `VAULT_ADDR` environment variable has been set.
- Creates a database DAO to query the authentications table.
- Adapts the response depending on whether Vault is online or not. The only difference in the model is the `ID` field, which will either be filled with Vault's ID or the database's auto generated ID.

## Links

[[RHCLOUD-18182]](https://issues.redhat.com/browse/RHCLOUD-18182)