### PR TITLE
[RHCLOUD-18192] fix: rows are closed error when listing RhcConnections

### DIFF
--- a/dao/rhc_connection_dao.go
+++ b/dao/rhc_connection_dao.go
@@ -40,7 +40,9 @@ func (s *RhcConnectionDaoImpl) List(limit, offset int, filters []util.Filter) ([
 	// We call next as otherwise "ScanRows" complains, but since we're going to map the results to an array of
 	// map[string]interface{}, "ScanRows" will already scan every row into that array, thus freeing us from calling
 	// result.Next() again.
-	result.Next()
+	if !result.Next() {
+		return []m.RhcConnection{}, 0, nil
+	}
 
 	// Loop through the rows to map both the connection and its related sources.
 	var rows []map[string]interface{}


### PR DESCRIPTION
The result of the "Next()" function —which checks if there are any more rows to process from the result set— was being ignored, therefore when there were no results when listing the Rhc Connections, the functions that came afterwards threw the "Rows are closed" error.

It also adds a test to avoid regressions.

## Links

[[RHCLOUD-18192]](https://issues.redhat.com/browse/RHCLOUD-18192)