### PR TITLE
[RHCLOUD-18212] Refactor the way DAOs are created

### DIFF
--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -14,15 +13,13 @@ import (
 var getApplicationAuthenticationDao func(c echo.Context) (dao.ApplicationAuthenticationDao, error)
 
 func getApplicationAuthenticationDaoWithTenant(c echo.Context) (dao.ApplicationAuthenticationDao, error) {
-	var tenantID int64
-	var ok bool
+	tenantId, err := getTenantFromEchoContext(c)
 
-	tenantVal := c.Get("tenantID")
-	if tenantID, ok = tenantVal.(int64); !ok {
-		return nil, fmt.Errorf("failed to pull tenant from request")
+	if err != nil {
+		return nil, err
 	}
 
-	return &dao.ApplicationAuthenticationDaoImpl{TenantID: &tenantID}, nil
+	return &dao.ApplicationAuthenticationDaoImpl{TenantID: &tenantId}, nil
 }
 
 func ApplicationAuthenticationList(c echo.Context) error {

--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -19,7 +19,7 @@ func getApplicationAuthenticationDaoWithTenant(c echo.Context) (dao.ApplicationA
 		return nil, err
 	}
 
-	return &dao.ApplicationAuthenticationDaoImpl{TenantID: &tenantId}, nil
+	return dao.GetApplicationAuthenticationDao(&tenantId), nil
 }
 
 func ApplicationAuthenticationList(c echo.Context) error {

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -22,7 +22,7 @@ func getApplicationDaoWithTenant(c echo.Context) (dao.ApplicationDao, error) {
 		return nil, err
 	}
 
-	return &dao.ApplicationDaoImpl{TenantID: &tenantId}, nil
+	return dao.GetApplicationDao(&tenantId), nil
 }
 
 func ApplicationList(c echo.Context) error {

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -16,15 +16,13 @@ import (
 var getApplicationDao func(c echo.Context) (dao.ApplicationDao, error)
 
 func getApplicationDaoWithTenant(c echo.Context) (dao.ApplicationDao, error) {
-	var tenantID int64
-	var ok bool
+	tenantId, err := getTenantFromEchoContext(c)
 
-	tenantVal := c.Get("tenantID")
-	if tenantID, ok = tenantVal.(int64); !ok {
-		return nil, fmt.Errorf("failed to pull tenant from request")
+	if err != nil {
+		return nil, err
 	}
 
-	return &dao.ApplicationDaoImpl{TenantID: &tenantID}, nil
+	return &dao.ApplicationDaoImpl{TenantID: &tenantId}, nil
 }
 
 func ApplicationList(c echo.Context) error {

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -15,20 +14,16 @@ import (
 var getApplicationTypeDao func(c echo.Context) (dao.ApplicationTypeDao, error)
 
 func getApplicationTypeDaoWithTenant(c echo.Context) (dao.ApplicationTypeDao, error) {
-	var tenantID int64
-	var ok bool
-	tenantVal := c.Get("tenantID")
+	tenantId, err := getTenantFromEchoContext(c)
 
-	// if we set the tenant on this request - include it. otherwise do not.
-	if tenantVal != nil {
-		tenantVal := c.Get("tenantID")
-		if tenantID, ok = tenantVal.(int64); !ok {
-			return nil, fmt.Errorf("failed to pull tenant from request")
-		}
+	if err != nil {
+		return nil, err
+	}
 
-		return &dao.ApplicationTypeDaoImpl{TenantID: &tenantID}, nil
-	} else {
+	if tenantId == 0 && err == nil {
 		return &dao.ApplicationTypeDaoImpl{}, nil
+	} else {
+		return &dao.ApplicationTypeDaoImpl{TenantID: &tenantId}, nil
 	}
 }
 

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -21,9 +21,9 @@ func getApplicationTypeDaoWithTenant(c echo.Context) (dao.ApplicationTypeDao, er
 	}
 
 	if tenantId == 0 && err == nil {
-		return &dao.ApplicationTypeDaoImpl{}, nil
+		return dao.GetApplicationTypeDao(nil), nil
 	} else {
-		return &dao.ApplicationTypeDaoImpl{TenantID: &tenantId}, nil
+		return dao.GetApplicationTypeDao(&tenantId), nil
 	}
 }
 

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -13,15 +13,13 @@ import (
 var getAuthenticationDao func(c echo.Context) (dao.AuthenticationDao, error)
 
 func getAuthenticationDaoWithTenant(c echo.Context) (dao.AuthenticationDao, error) {
-	var tenantID int64
-	var ok bool
+	tenantId, err := getTenantFromEchoContext(c)
 
-	tenantVal := c.Get("tenantID")
-	if tenantID, ok = tenantVal.(int64); !ok {
-		return nil, fmt.Errorf("failed to pull tenant from request")
+	if err != nil {
+		return nil, err
 	}
 
-	return &dao.AuthenticationDaoImpl{TenantID: &tenantID}, nil
+	return &dao.AuthenticationDaoImpl{TenantID: &tenantId}, nil
 }
 
 func AuthenticationList(c echo.Context) error {

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -19,7 +19,7 @@ func getAuthenticationDaoWithTenant(c echo.Context) (dao.AuthenticationDao, erro
 		return nil, err
 	}
 
-	return &dao.AuthenticationDaoImpl{TenantID: &tenantId}, nil
+	return dao.GetAuthenticationDao(&tenantId), nil
 }
 
 func AuthenticationList(c echo.Context) error {

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -7,11 +7,27 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-type ApplicationAuthenticationDaoImpl struct {
+// GetApplicationAuthenticationDao is a function definition that can be replaced in runtime in case some other DAO
+// provider is needed.
+var GetApplicationAuthenticationDao func(*int64) ApplicationAuthenticationDao
+
+// getDefaultApplicationAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
+func getDefaultApplicationAuthenticationDao(tenantId *int64) ApplicationAuthenticationDao {
+	return &applicationAuthenticationDaoImpl{
+		TenantID: tenantId,
+	}
+}
+
+// init sets the default DAO implementation so that other packages can request it easily.
+func init() {
+	GetApplicationAuthenticationDao = getDefaultApplicationAuthenticationDao
+}
+
+type applicationAuthenticationDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplications(applications []m.Application) ([]m.ApplicationAuthentication, error) {
+func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplications(applications []m.Application) ([]m.ApplicationAuthentication, error) {
 	var applicationAuthentications []m.ApplicationAuthentication
 
 	applicationIDs := make([]int64, 0)
@@ -27,7 +43,7 @@ func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplicati
 	return applicationAuthentications, nil
 }
 
-func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByAuthentications(authentications []m.Authentication) ([]m.ApplicationAuthentication, error) {
+func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByAuthentications(authentications []m.Authentication) ([]m.ApplicationAuthentication, error) {
 	var applicationAuthentications []m.ApplicationAuthentication
 
 	authenticationUIDs := make([]string, 0)
@@ -43,7 +59,7 @@ func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByAuthentic
 	return applicationAuthentications, nil
 }
 
-func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByResource(resourceType string, applications []m.Application, authentications []m.Authentication) ([]m.ApplicationAuthentication, error) {
+func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByResource(resourceType string, applications []m.Application, authentications []m.Authentication) ([]m.ApplicationAuthentication, error) {
 	if resourceType == "Source" {
 		return a.ApplicationAuthenticationsByApplications(applications)
 	}
@@ -51,7 +67,7 @@ func (a *ApplicationAuthenticationDaoImpl) ApplicationAuthenticationsByResource(
 	return a.ApplicationAuthenticationsByAuthentications(authentications)
 }
 
-func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
+func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
 	appAuths := make([]m.ApplicationAuthentication, 0, limit)
 	query := DB.Debug().Model(&m.ApplicationAuthentication{}).
 		Offset(offset).
@@ -69,7 +85,7 @@ func (a *ApplicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 	return appAuths, count, result.Error
 }
 
-func (a *ApplicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAuthentication, error) {
+func (a *applicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAuthentication, error) {
 	appAuth := &m.ApplicationAuthentication{ID: *id}
 	result := DB.First(&appAuth)
 	if result.Error != nil {
@@ -78,17 +94,17 @@ func (a *ApplicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAut
 	return appAuth, nil
 }
 
-func (a *ApplicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthentication) error {
+func (a *applicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthentication) error {
 	result := DB.Create(appAuth)
 	return result.Error
 }
 
-func (a *ApplicationAuthenticationDaoImpl) Update(appAuth *m.ApplicationAuthentication) error {
+func (a *applicationAuthenticationDaoImpl) Update(appAuth *m.ApplicationAuthentication) error {
 	result := DB.Updates(appAuth)
 	return result.Error
 }
 
-func (a *ApplicationAuthenticationDaoImpl) Delete(id *int64) error {
+func (a *applicationAuthenticationDaoImpl) Delete(id *int64) error {
 	appAuth := &m.ApplicationAuthentication{ID: *id}
 	if result := DB.Delete(appAuth); result.RowsAffected == 0 {
 		return fmt.Errorf("failed to delete application id %v", *id)
@@ -97,6 +113,6 @@ func (a *ApplicationAuthenticationDaoImpl) Delete(id *int64) error {
 	return nil
 }
 
-func (a *ApplicationAuthenticationDaoImpl) Tenant() *int64 {
+func (a *applicationAuthenticationDaoImpl) Tenant() *int64 {
 	return a.TenantID
 }

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -8,11 +8,27 @@ import (
 	"gorm.io/datatypes"
 )
 
-type ApplicationTypeDaoImpl struct {
+// GetApplicationTypeDao is a function definition that can be replaced in runtime in case some other DAO provider is
+// needed.
+var GetApplicationTypeDao func(*int64) ApplicationTypeDao
+
+// getDefaultApplicationAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
+func getDefaultApplicationTypeDao(tenantId *int64) ApplicationTypeDao {
+	return &applicationTypeDaoImpl{
+		TenantID: tenantId,
+	}
+}
+
+// init sets the default DAO implementation so that other packages can request it easily.
+func init() {
+	GetApplicationTypeDao = getDefaultApplicationTypeDao
+}
+
+type applicationTypeDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *ApplicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
+func (a *applicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
 	// allocating a slice of application types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	applicationTypes := make([]m.ApplicationType, 0, limit)
@@ -37,7 +53,7 @@ func (a *ApplicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}
 	return applicationTypes, count, nil
 }
 
-func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
+func (a *applicationTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
 	// allocating a slice of application types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	appTypes := make([]m.ApplicationType, 0, limit)
@@ -61,7 +77,7 @@ func (a *ApplicationTypeDaoImpl) List(limit, offset int, filters []util.Filter) 
 	return appTypes, count, nil
 }
 
-func (a *ApplicationTypeDaoImpl) GetById(id *int64) (*m.ApplicationType, error) {
+func (a *applicationTypeDaoImpl) GetById(id *int64) (*m.ApplicationType, error) {
 	appType := &m.ApplicationType{Id: *id}
 	result := DB.Debug().First(appType)
 	if result.Error != nil {
@@ -71,19 +87,19 @@ func (a *ApplicationTypeDaoImpl) GetById(id *int64) (*m.ApplicationType, error) 
 	return appType, nil
 }
 
-func (a *ApplicationTypeDaoImpl) Create(_ *m.ApplicationType) error {
+func (a *applicationTypeDaoImpl) Create(_ *m.ApplicationType) error {
 	panic("not needed (yet) due to seeding.")
 }
 
-func (a *ApplicationTypeDaoImpl) Update(_ *m.ApplicationType) error {
+func (a *applicationTypeDaoImpl) Update(_ *m.ApplicationType) error {
 	panic("not needed (yet) due to seeding.")
 }
 
-func (a *ApplicationTypeDaoImpl) Delete(_ *int64) error {
+func (a *applicationTypeDaoImpl) Delete(_ *int64) error {
 	panic("not needed (yet) due to seeding.")
 }
 
-func (at *ApplicationTypeDaoImpl) ApplicationTypeCompatibleWithSource(typeId, sourceId int64) error {
+func (at *applicationTypeDaoImpl) ApplicationTypeCompatibleWithSource(typeId, sourceId int64) error {
 	source := m.Source{ID: sourceId}
 	result := DB.Preload("SourceType").Find(&source)
 	if result.Error != nil {

--- a/dao/common.go
+++ b/dao/common.go
@@ -21,7 +21,7 @@ func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	case "Application":
 		resource = &applicationDaoImpl{}
 	case "Authentication":
-		resource = &AuthenticationDaoImpl{}
+		resource = &authenticationDaoImpl{}
 	default:
 		return nil, fmt.Errorf("invalid resource_type (%s) to get DAO instance", resourceType)
 	}
@@ -65,7 +65,7 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 
 	bulkMessage["applications"] = applications
 
-	authDao := &AuthenticationDaoImpl{TenantID: &source.TenantID}
+	authDao := &authenticationDaoImpl{TenantID: &source.TenantID}
 	authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 	if err != nil {
 		return nil, err

--- a/dao/common.go
+++ b/dao/common.go
@@ -77,7 +77,7 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 		authentications[i] = authenticationsByResource[i].ToEvent()
 	}
 
-	applicationAuthenticationDao := &ApplicationAuthenticationDaoImpl{TenantID: &source.TenantID}
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&source.TenantID)
 	applicationAuthenticationsFromResource, err := applicationAuthenticationDao.ApplicationAuthenticationsByResource(authentication.ResourceType, source.Applications, authenticationsByResource)
 
 	if err != nil {

--- a/dao/common.go
+++ b/dao/common.go
@@ -17,7 +17,7 @@ func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	case "Source":
 		resource = &SourceDaoImpl{}
 	case "Endpoint":
-		resource = &EndpointDaoImpl{}
+		resource = &endpointDaoImpl{}
 	case "Application":
 		resource = &applicationDaoImpl{}
 	case "Authentication":

--- a/dao/common.go
+++ b/dao/common.go
@@ -15,13 +15,13 @@ func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	var resource m.EventModelDao
 	switch resourceType {
 	case "Source":
-		resource = &sourceDaoImpl{}
+		resource = GetSourceDao(nil)
 	case "Endpoint":
-		resource = &endpointDaoImpl{}
+		resource = GetEndpointDao(nil)
 	case "Application":
-		resource = &applicationDaoImpl{}
+		resource = GetApplicationDao(nil)
 	case "Authentication":
-		resource = &authenticationDaoImpl{}
+		resource = GetAuthenticationDao(nil)
 	default:
 		return nil, fmt.Errorf("invalid resource_type (%s) to get DAO instance", resourceType)
 	}
@@ -65,7 +65,7 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 
 	bulkMessage["applications"] = applications
 
-	authDao := &authenticationDaoImpl{TenantID: &source.TenantID}
+	authDao := GetAuthenticationDao(&source.TenantID)
 	authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 	if err != nil {
 		return nil, err

--- a/dao/common.go
+++ b/dao/common.go
@@ -19,7 +19,7 @@ func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	case "Endpoint":
 		resource = &EndpointDaoImpl{}
 	case "Application":
-		resource = &ApplicationDaoImpl{}
+		resource = &applicationDaoImpl{}
 	case "Authentication":
 		resource = &AuthenticationDaoImpl{}
 	default:

--- a/dao/common.go
+++ b/dao/common.go
@@ -15,7 +15,7 @@ func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 	var resource m.EventModelDao
 	switch resourceType {
 	case "Source":
-		resource = &SourceDaoImpl{}
+		resource = &sourceDaoImpl{}
 	case "Endpoint":
 		resource = &endpointDaoImpl{}
 	case "Application":

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -8,11 +8,27 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-type EndpointDaoImpl struct {
+// GetEndpointDao is a function definition that can be replaced in runtime in case some other DAO provider is
+// needed.
+var GetEndpointDao func(*int64) EndpointDao
+
+// getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
+func getDefaultEndpointDao(tenantId *int64) EndpointDao {
+	return &endpointDaoImpl{
+		TenantID: tenantId,
+	}
+}
+
+// init sets the default DAO implementation so that other packages can request it easily.
+func init() {
+	GetEndpointDao = getDefaultEndpointDao
+}
+
+type endpointDaoImpl struct {
 	TenantID *int64
 }
 
-func (a *EndpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
+func (a *endpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
 	sourceType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
@@ -38,7 +54,7 @@ func (a *EndpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit
 	return endpoints, count, nil
 }
 
-func (a *EndpointDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
+func (a *endpointDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
 	query := DB.Debug().Model(&m.Endpoint{}).
 		Offset(offset).
@@ -60,7 +76,7 @@ func (a *EndpointDaoImpl) List(limit int, offset int, filters []util.Filter) ([]
 	return endpoints, count, nil
 }
 
-func (a *EndpointDaoImpl) GetById(id *int64) (*m.Endpoint, error) {
+func (a *endpointDaoImpl) GetById(id *int64) (*m.Endpoint, error) {
 	app := &m.Endpoint{ID: *id}
 	result := DB.First(&app)
 	if result.Error != nil {
@@ -70,19 +86,19 @@ func (a *EndpointDaoImpl) GetById(id *int64) (*m.Endpoint, error) {
 	return app, nil
 }
 
-func (a *EndpointDaoImpl) Create(app *m.Endpoint) error {
+func (a *endpointDaoImpl) Create(app *m.Endpoint) error {
 	app.TenantID = *a.TenantID
 
 	result := DB.Create(app)
 	return result.Error
 }
 
-func (a *EndpointDaoImpl) Update(app *m.Endpoint) error {
+func (a *endpointDaoImpl) Update(app *m.Endpoint) error {
 	result := DB.Updates(app)
 	return result.Error
 }
 
-func (a *EndpointDaoImpl) Delete(id *int64) (*m.Endpoint, error) {
+func (a *endpointDaoImpl) Delete(id *int64) (*m.Endpoint, error) {
 	endpt := &m.Endpoint{ID: *id}
 	result := DB.Where("tenant_id = ?", a.TenantID).First(&endpt)
 	if result.Error != nil {
@@ -96,11 +112,11 @@ func (a *EndpointDaoImpl) Delete(id *int64) (*m.Endpoint, error) {
 	return endpt, nil
 }
 
-func (a *EndpointDaoImpl) Tenant() *int64 {
+func (a *endpointDaoImpl) Tenant() *int64 {
 	return a.TenantID
 }
 
-func (a *EndpointDaoImpl) CanEndpointBeSetAsDefaultForSource(sourceId int64) bool {
+func (a *endpointDaoImpl) CanEndpointBeSetAsDefaultForSource(sourceId int64) bool {
 	endpoint := &m.Endpoint{}
 
 	// add double quotes to the "default" column to avoid any clashes with postgres' "default" keyword
@@ -108,7 +124,7 @@ func (a *EndpointDaoImpl) CanEndpointBeSetAsDefaultForSource(sourceId int64) boo
 	return result.Error != nil
 }
 
-func (a *EndpointDaoImpl) IsRoleUniqueForSource(role string, sourceId int64) bool {
+func (a *endpointDaoImpl) IsRoleUniqueForSource(role string, sourceId int64) bool {
 	endpoint := &m.Endpoint{}
 	result := DB.Where("role = ? AND source_id = ?", role, sourceId).First(&endpoint)
 
@@ -116,7 +132,7 @@ func (a *EndpointDaoImpl) IsRoleUniqueForSource(role string, sourceId int64) boo
 	return result.Error != nil
 }
 
-func (a *EndpointDaoImpl) SourceHasEndpoints(sourceId int64) bool {
+func (a *endpointDaoImpl) SourceHasEndpoints(sourceId int64) bool {
 	endpoint := &m.Endpoint{}
 
 	result := DB.Where("source_id = ?", sourceId).First(&endpoint)
@@ -124,7 +140,7 @@ func (a *EndpointDaoImpl) SourceHasEndpoints(sourceId int64) bool {
 	return result.Error == nil
 }
 
-func (a *EndpointDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
+func (a *endpointDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
 	endpoint := &m.Endpoint{ID: resource.ResourceID}
 	result := DB.Preload("Source").Find(&endpoint)
 
@@ -136,7 +152,7 @@ func (a *EndpointDaoImpl) BulkMessage(resource util.Resource) (map[string]interf
 	return BulkMessageFromSource(&endpoint.Source, authentication)
 }
 
-func (a *EndpointDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {
+func (a *endpointDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {
 	result := DB.Model(&m.Endpoint{ID: resource.ResourceID}).Updates(updateAttributes)
 	if result.RowsAffected == 0 {
 		return fmt.Errorf("endpoint not found %v", resource)
@@ -145,14 +161,14 @@ func (a *EndpointDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttribu
 	return nil
 }
 
-func (a *EndpointDaoImpl) FindWithTenant(id *int64) (*m.Endpoint, error) {
+func (a *endpointDaoImpl) FindWithTenant(id *int64) (*m.Endpoint, error) {
 	endpoint := &m.Endpoint{ID: *id}
 	result := DB.Preload("Tenant").Find(&endpoint)
 
 	return endpoint, result.Error
 }
 
-func (a *EndpointDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
+func (a *endpointDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
 	endpoint, err := a.FindWithTenant(&resource.ResourceID)
 	data, _ := json.Marshal(endpoint.ToEvent())
 

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -21,6 +21,9 @@ type SourceDao interface {
 	GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error)
 	// ListForRhcConnection gets all the sources that are related to a given rhcConnection id.
 	ListForRhcConnection(rhcConnectionId *int64, limit, offset int, filters []util.Filter) ([]m.Source, int64, error)
+	BulkMessage(resource util.Resource) (map[string]interface{}, error)
+	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error
+	ToEventJSON(resource util.Resource) ([]byte, error)
 }
 
 type ApplicationDao interface {
@@ -31,6 +34,9 @@ type ApplicationDao interface {
 	Update(src *m.Application) error
 	Delete(id *int64) (*m.Application, error)
 	Tenant() *int64
+	BulkMessage(resource util.Resource) (map[string]interface{}, error)
+	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error
+	ToEventJSON(resource util.Resource) ([]byte, error)
 }
 
 type AuthenticationDao interface {
@@ -45,6 +51,9 @@ type AuthenticationDao interface {
 	Delete(id string) (*m.Authentication, error)
 	Tenant() *int64
 	AuthenticationsByResource(authentication *m.Authentication) ([]m.Authentication, error)
+	BulkMessage(resource util.Resource) (map[string]interface{}, error)
+	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error
+	ToEventJSON(resource util.Resource) ([]byte, error)
 }
 
 type ApplicationAuthenticationDao interface {
@@ -82,6 +91,9 @@ type EndpointDao interface {
 	IsRoleUniqueForSource(role string, sourceId int64) bool
 	// SourceHasEndpoints returns true if the provided source has any associated endpoints.
 	SourceHasEndpoints(sourceId int64) bool
+	BulkMessage(resource util.Resource) (map[string]interface{}, error)
+	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error
+	ToEventJSON(resource util.Resource) ([]byte, error)
 }
 
 type MetaDataDao interface {

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -53,6 +53,7 @@ type ApplicationAuthenticationDao interface {
 	Update(src *m.ApplicationAuthentication) error
 	Delete(id *int64) error
 	Tenant() *int64
+	ApplicationAuthenticationsByResource(resourceType string, applications []m.Application, authentications []m.Authentication) ([]m.ApplicationAuthentication, error)
 }
 
 type ApplicationTypeDao interface {

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -114,3 +114,8 @@ type RhcConnectionDao interface {
 	// ListForSource gets all the related connections to the given source id.
 	ListForSource(sourceId *int64, limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error)
 }
+
+type TenantDao interface {
+	GetOrCreateTenantID(accountNumber string) (*int64, error)
+	TenantByAccountNumber(accountNumber string) (*m.Tenant, error)
+}

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -44,6 +44,7 @@ type AuthenticationDao interface {
 	Update(src *m.Authentication) error
 	Delete(id string) (*m.Authentication, error)
 	Tenant() *int64
+	AuthenticationsByResource(authentication *m.Authentication) ([]m.Authentication, error)
 }
 
 type ApplicationAuthenticationDao interface {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -478,3 +478,7 @@ func (m MockApplicationAuthenticationDao) Tenant() *int64 {
 	tenant := int64(1)
 	return &tenant
 }
+
+func (m MockApplicationAuthenticationDao) ApplicationAuthenticationsByResource(_ string, _ []m.Application, _ []m.Authentication) ([]m.ApplicationAuthentication, error) {
+	return m.ApplicationAuthentications, nil
+}

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -132,6 +132,18 @@ func (m *MockSourceDao) ListForRhcConnection(id *int64, limit, offset int, filte
 	return m.RelatedSources, count, nil
 }
 
+func (m *MockSourceDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockSourceDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) error {
+	return nil
+}
+
+func (m *MockSourceDao) ToEventJSON(_ util.Resource) ([]byte, error) {
+	return nil, nil
+}
+
 func (a *MockApplicationTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
 	count := int64(len(a.ApplicationTypes))
 	return a.ApplicationTypes, count, nil
@@ -321,6 +333,18 @@ func (a *MockApplicationDao) Tenant() *int64 {
 	return &tenant
 }
 
+func (m *MockApplicationDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockApplicationDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) error {
+	return nil
+}
+
+func (m *MockApplicationDao) ToEventJSON(_ util.Resource) ([]byte, error) {
+	return nil, nil
+}
+
 func (a *MockEndpointDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	var endpoints []m.Endpoint
 
@@ -384,6 +408,18 @@ func (m *MockEndpointDao) IsRoleUniqueForSource(role string, sourceId int64) boo
 
 func (m *MockEndpointDao) SourceHasEndpoints(sourceId int64) bool {
 	return true
+}
+
+func (m *MockEndpointDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockEndpointDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) error {
+	return nil
+}
+
+func (m *MockEndpointDao) ToEventJSON(_ util.Resource) ([]byte, error) {
+	return nil, nil
 }
 
 func (m *MockRhcConnectionDao) List(limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error) {

--- a/dao/rhc_connection_dao_test.go
+++ b/dao/rhc_connection_dao_test.go
@@ -15,8 +15,9 @@ import (
 
 const RHC_CONNECTION_SCHEMA = "rhc_connection"
 
-var rhcConnectionDao = RhcConnectionDaoImpl{
-	TenantID: fixtures.TestTenantData[0].Id,
+var tenantId = fixtures.TestTenantData[0].Id
+var rhcConnectionDao = rhcConnectionDaoImpl{
+	TenantID: &tenantId,
 }
 
 // setUpValidRhcConnection returns a valid RhcConnection object.
@@ -101,7 +102,8 @@ func TestRhcConnectionCreateExistingSourceDifferentTenant(t *testing.T) {
 
 	// Set up a different tenant, which should make the "find source by source ID and Tenant ID" return a not found
 	// error
-	rhcConnectionDao.TenantID = 12345
+	invalidTenantId := int64(12345)
+	rhcConnectionDao.TenantID = &invalidTenantId
 	_, got := rhcConnectionDao.Create(rhcConnection)
 
 	want := "source not found"
@@ -110,7 +112,7 @@ func TestRhcConnectionCreateExistingSourceDifferentTenant(t *testing.T) {
 	}
 
 	// Set the tenant back to its original value
-	rhcConnectionDao.TenantID = fixtures.TestTenantData[0].Id
+	rhcConnectionDao.TenantID = &tenantId
 	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
 }
 

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 )
 
-var sourceDao = SourceDaoImpl{
+var sourceDao = sourceDaoImpl{
 	TenantID: &fixtures.TestTenantData[0].Id,
 }
 

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -5,10 +5,24 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-type SourceTypeDaoImpl struct {
+// GetSourceTypeDao is a function definition that can be replaced in runtime in case some other DAO provider is
+// needed.
+var GetSourceTypeDao func() SourceTypeDao
+
+// getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
+func getDefaultSourceTypeDao() SourceTypeDao {
+	return &sourceTypeDaoImpl{}
 }
 
-func (st *SourceTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
+// init sets the default DAO implementation so that other packages can request it easily.
+func init() {
+	GetSourceTypeDao = getDefaultSourceTypeDao
+}
+
+type sourceTypeDaoImpl struct {
+}
+
+func (st *sourceTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
 	// allocating a slice of source types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	sourceTypes := make([]m.SourceType, 0, limit)
@@ -32,7 +46,7 @@ func (st *SourceTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m
 	return sourceTypes, count, nil
 }
 
-func (st *SourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
+func (st *sourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
 	sourceType := &m.SourceType{Id: *id}
 	result := DB.Debug().First(sourceType)
 	if result.Error != nil {
@@ -41,14 +55,14 @@ func (st *SourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
 	return sourceType, nil
 }
 
-func (st *SourceTypeDaoImpl) Create(_ *m.SourceType) error {
+func (st *sourceTypeDaoImpl) Create(_ *m.SourceType) error {
 	panic("not needed (yet) due to seeding.")
 }
 
-func (st *SourceTypeDaoImpl) Update(_ *m.SourceType) error {
+func (st *sourceTypeDaoImpl) Update(_ *m.SourceType) error {
 	panic("not needed (yet) due to seeding.")
 }
 
-func (st *SourceTypeDaoImpl) Delete(_ *int64) error {
+func (st *sourceTypeDaoImpl) Delete(_ *int64) error {
 	panic("not needed (yet) due to seeding.")
 }

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -4,7 +4,23 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 )
 
-func GetOrCreateTenantID(accountNumber string) (*int64, error) {
+// GetTenantDao is a function definition that can be replaced in runtime in case some other DAO provider is
+// needed.
+var GetTenantDao func() TenantDao
+
+// getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
+func getDefaultTenantDao() TenantDao {
+	return &tenantDaoImpl{}
+}
+
+// init sets the default DAO implementation so that other packages can request it easily.
+func init() {
+	GetTenantDao = getDefaultTenantDao
+}
+
+type tenantDaoImpl struct{}
+
+func (t *tenantDaoImpl) GetOrCreateTenantID(accountNumber string) (*int64, error) {
 	tenant := m.Tenant{ExternalTenant: accountNumber}
 
 	// Find the tenant, scanning into the struct above
@@ -20,7 +36,7 @@ func GetOrCreateTenantID(accountNumber string) (*int64, error) {
 	return &tenant.Id, result.Error
 }
 
-func TenantByAccountNumber(accountNumber string) (*m.Tenant, error) {
+func (t *tenantDaoImpl) TenantByAccountNumber(accountNumber string) (*m.Tenant, error) {
 	tenant := m.Tenant{ExternalTenant: accountNumber}
 
 	result := DB.

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -22,7 +22,7 @@ func getEndpointDaoWithTenant(c echo.Context) (dao.EndpointDao, error) {
 		return nil, err
 	}
 
-	return &dao.EndpointDaoImpl{TenantID: &tenantId}, nil
+	return dao.GetEndpointDao(&tenantId), nil
 }
 
 func SourceListEndpoint(c echo.Context) error {

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -16,15 +16,13 @@ import (
 var getEndpointDao func(c echo.Context) (dao.EndpointDao, error)
 
 func getEndpointDaoWithTenant(c echo.Context) (dao.EndpointDao, error) {
-	var tenantID int64
-	var ok bool
+	tenantId, err := getTenantFromEchoContext(c)
 
-	tenantVal := c.Get("tenantID")
-	if tenantID, ok = tenantVal.(int64); !ok {
-		return nil, fmt.Errorf("failed to pull tenant from request")
+	if err != nil {
+		return nil, err
 	}
 
-	return &dao.EndpointDaoImpl{TenantID: &tenantID}, nil
+	return &dao.EndpointDaoImpl{TenantID: &tenantId}, nil
 }
 
 func SourceListEndpoint(c echo.Context) error {

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -63,4 +64,26 @@ func setEventStreamResource(c echo.Context, model m.Event) {
 
 	c.Set("event_type", m+event)
 	c.Set("resource", model.ToEvent())
+}
+
+// getTenantFromEchoContext tries to extract the tenant from the echo context. If the "tenantID" is missing from the
+// context, then a default value and nil are returned as the int64 and error values.
+func getTenantFromEchoContext(c echo.Context) (int64, error) {
+	tenantValue := c.Get("tenantID")
+
+	// If no tenant is found in the context, that shouldn't imply an error.
+	if tenantValue == nil {
+		return 0, nil
+	}
+
+	// If the tenant is present, though, we must check that it is valid.
+	if tenantId, ok := tenantValue.(int64); ok {
+		if tenantId < 1 {
+			return 0, errors.New("incorrect tenant value provided")
+		}
+
+		return tenantId, nil
+	} else {
+		return 0, errors.New("the tenant was provided in an invalid format")
+	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// TestGetTenantFromEchoContext tests that the tenant id is correctly pulled from the context when the tenant has been
+// passed correctly.
+func TestGetTenantFromEchoContext(t *testing.T) {
+	want := int64(12345)
+
+	c, _ := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/whatever",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": want,
+		},
+	)
+
+	got, err := getTenantFromEchoContext(c)
+	if err != nil {
+		t.Errorf(`want nil error, got "%s"`, err)
+	}
+
+	if want != got {
+		t.Errorf(`incorrect tenant pulled. Want "%d", got "%d"`, want, got)
+	}
+}
+
+// TestGetTenantFromEchoContextBelowEqualsZero tests that when passed a tenant ID which is zero or lower than that,
+// a proper error is returned.
+func TestGetTenantFromEchoContextLowerOrEqualsZero(t *testing.T) {
+	invalidTenantIds := []int64{-5, 0}
+
+	for _, iti := range invalidTenantIds {
+		c, _ := request.CreateTestContext(
+			http.MethodGet,
+			"/api/sources/v3.1/whatever",
+			nil,
+			map[string]interface{}{
+				"limit":    100,
+				"offset":   0,
+				"filters":  []util.Filter{},
+				"tenantID": iti,
+			},
+		)
+
+		_, err := getTenantFromEchoContext(c)
+
+		want := "incorrect tenant value provided"
+		if !strings.Contains(want, err.Error()) {
+			t.Errorf(`want "%s", got "%s"`, want, err)
+		}
+	}
+}
+
+// TestGetTenantFromEchoContextInvalidFormat tests that when a tenant is given in an invalid format, an error is
+// returned.
+func TestGetTenantFromEchoContextInvalidFormat(t *testing.T) {
+	invalidTenantIdFormat := "12345"
+
+	c, _ := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/whatever",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": invalidTenantIdFormat,
+		},
+	)
+
+	want := "the tenant was provided in an invalid format"
+	_, err := getTenantFromEchoContext(c)
+	if !strings.Contains(want, err.Error()) {
+		t.Errorf(`incorrect tenant pulled. Want "%s", got "%s"`, want, err)
+	}
+}
+
+// TestGetTenantFromEchoContextMissing tests that when the tenant is missing from the context the function returns a
+// default value and a nil error.
+func TestGetTenantFromEchoContextMissing(t *testing.T) {
+	c, _ := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/whatever",
+		nil,
+		map[string]interface{}{
+			"limit":   100,
+			"offset":  0,
+			"filters": []util.Filter{},
+		},
+	)
+
+	want := int64(0)
+	got, err := getTenantFromEchoContext(c)
+
+	if want != got {
+		t.Errorf(`incorrect tenant pulled. Want "%d", got "%d`, want, got)
+	}
+
+	if err != nil {
+		t.Errorf(`want nil err, got "%s"`, err)
+	}
+}

--- a/internal_handlers.go
+++ b/internal_handlers.go
@@ -42,7 +42,7 @@ func InternalSourceList(c echo.Context) error {
 	}
 
 	// The DAO doesn't need a tenant set, since the queries won't be filtered by that tenant
-	sourcesDB := &dao.SourceDaoImpl{}
+	sourcesDB := dao.GetSourceDao(nil)
 	sources, count, err := sourcesDB.ListInternal(limit, offset, filters)
 
 	if err != nil {

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -15,19 +14,16 @@ import (
 var getMetaDataDao func(c echo.Context) (dao.MetaDataDao, error)
 
 func getMetaDataDaoWithTenant(c echo.Context) (dao.MetaDataDao, error) {
-	var tenantID int64
-	var ok bool
-	tenantVal := c.Get("tenantID")
+	tenantId, err := getTenantFromEchoContext(c)
 
-	// if we set the tenant on this request - include it. otherwise do not.
-	if tenantVal != nil {
-		if tenantID, ok = tenantVal.(int64); !ok {
-			return nil, fmt.Errorf("failed to pull tenant from request")
-		}
+	if err != nil {
+		return nil, err
+	}
 
-		return &dao.MetaDataDaoImpl{TenantID: &tenantID}, nil
-	} else {
+	if tenantId == 0 && err == nil {
 		return &dao.MetaDataDaoImpl{}, nil
+	} else {
+		return &dao.MetaDataDaoImpl{TenantID: &tenantId}, nil
 	}
 }
 

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -21,9 +21,9 @@ func getMetaDataDaoWithTenant(c echo.Context) (dao.MetaDataDao, error) {
 	}
 
 	if tenantId == 0 && err == nil {
-		return &dao.MetaDataDaoImpl{}, nil
+		return dao.GetMetaDataDao(nil), nil
 	} else {
-		return &dao.MetaDataDaoImpl{TenantID: &tenantId}, nil
+		return dao.GetMetaDataDao(&tenantId), nil
 	}
 }
 

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -34,7 +34,9 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 
 			c.Logger().Debugf("Looking up Tenant ID for account number %v", accountNumber)
-			t, err := dao.GetOrCreateTenantID(accountNumber)
+
+			tenantDao := dao.GetTenantDao()
+			t, err := tenantDao.GetOrCreateTenantID(accountNumber)
 			if err != nil {
 				return fmt.Errorf("failed to get or create tenant for request")
 			}
@@ -52,7 +54,9 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 
 			c.Logger().Debugf("Looking up Tenant ID for account number %v", identity.Identity.AccountNumber)
-			t, err := dao.GetOrCreateTenantID(identity.Identity.AccountNumber)
+
+			tenantDao := dao.GetTenantDao()
+			t, err := tenantDao.GetOrCreateTenantID(identity.Identity.AccountNumber)
 			if err != nil {
 				return fmt.Errorf("failed to get or create tenant for request: %v", err)
 			}

--- a/rhc_connection_handlers.go
+++ b/rhc_connection_handlers.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -16,15 +15,13 @@ import (
 var getRhcConnectionDao func(c echo.Context) (dao.RhcConnectionDao, error)
 
 func getDefaultRhcConnectionDao(c echo.Context) (dao.RhcConnectionDao, error) {
-	var tenantID int64
-	var ok bool
+	tenantId, err := getTenantFromEchoContext(c)
 
-	tenantVal := c.Get("tenantID")
-	if tenantID, ok = tenantVal.(int64); !ok {
-		return nil, fmt.Errorf("failed to pull tenant from request")
+	if err != nil {
+		return nil, err
 	}
 
-	return &dao.RhcConnectionDaoImpl{TenantID: tenantID}, nil
+	return &dao.RhcConnectionDaoImpl{TenantID: tenantId}, nil
 }
 
 func RhcConnectionList(c echo.Context) error {

--- a/rhc_connection_handlers.go
+++ b/rhc_connection_handlers.go
@@ -21,7 +21,7 @@ func getDefaultRhcConnectionDao(c echo.Context) (dao.RhcConnectionDao, error) {
 		return nil, err
 	}
 
-	return &dao.RhcConnectionDaoImpl{TenantID: tenantId}, nil
+	return dao.GetRhcConnectionDao(&tenantId), nil
 }
 
 func RhcConnectionList(c echo.Context) error {

--- a/service/application_validation.go
+++ b/service/application_validation.go
@@ -10,7 +10,7 @@ import (
 
 // by default we'll be using an empty instance of the apptype dao - replacing it
 // in tests.
-var AppTypeDao dao.ApplicationTypeDao = &dao.ApplicationTypeDaoImpl{}
+var AppTypeDao = dao.GetApplicationTypeDao(nil)
 
 /*
 	Go through and validate the application create request.

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -27,7 +27,7 @@ func TestMain(t *testing.M) {
 	} else if flags.Integration {
 		database.ConnectAndMigrateDB("service")
 
-		endpointDao = &dao.EndpointDaoImpl{TenantID: &fixtures.TestTenantData[0].Id}
+		endpointDao = dao.GetEndpointDao(&fixtures.TestTenantData[0].Id)
 		sourceDao = &dao.SourceDaoImpl{TenantID: &fixtures.TestTenantData[0].Id}
 		database.CreateFixtures()
 	} else {

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -28,7 +28,7 @@ func TestMain(t *testing.M) {
 		database.ConnectAndMigrateDB("service")
 
 		endpointDao = dao.GetEndpointDao(&fixtures.TestTenantData[0].Id)
-		sourceDao = &dao.SourceDaoImpl{TenantID: &fixtures.TestTenantData[0].Id}
+		sourceDao = dao.GetSourceDao(&fixtures.TestTenantData[0].Id)
 		database.CreateFixtures()
 	} else {
 		endpointDao = &dao.MockEndpointDao{}

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -23,7 +23,7 @@ func getSourceDaoWithTenant(c echo.Context) (dao.SourceDao, error) {
 		return nil, err
 	}
 
-	return &dao.SourceDaoImpl{TenantID: &tenantId}, nil
+	return dao.GetSourceDao(&tenantId), nil
 }
 
 func SourceList(c echo.Context) error {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -17,15 +17,13 @@ import (
 var getSourceDao func(c echo.Context) (dao.SourceDao, error)
 
 func getSourceDaoWithTenant(c echo.Context) (dao.SourceDao, error) {
-	var tenantID int64
-	var ok bool
+	tenantId, err := getTenantFromEchoContext(c)
 
-	tenantVal := c.Get("tenantID")
-	if tenantID, ok = tenantVal.(int64); !ok {
-		return nil, fmt.Errorf("failed to pull tenant from request")
+	if err != nil {
+		return nil, err
 	}
 
-	return &dao.SourceDaoImpl{TenantID: &tenantID}, nil
+	return &dao.SourceDaoImpl{TenantID: &tenantId}, nil
 }
 
 func SourceList(c echo.Context) error {

--- a/source_type_handlers.go
+++ b/source_type_handlers.go
@@ -15,7 +15,7 @@ var getSourceTypeDao func(c echo.Context) (dao.SourceTypeDao, error)
 func getSourceTypeDaoWithoutTenant(_ echo.Context) (dao.SourceTypeDao, error) {
 	// we do not need tenancy for source type.
 
-	return &dao.SourceTypeDaoImpl{}, nil
+	return dao.GetSourceTypeDao(), nil
 }
 
 func SourceTypeList(c echo.Context) error {

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -116,7 +116,8 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		return
 	}
 
-	tenant, err := dao.TenantByAccountNumber(accountNumber)
+	tenantDao := dao.GetTenantDao()
+	tenant, err := tenantDao.TenantByAccountNumber(accountNumber)
 	if err != nil {
 		l.Log.Error(err)
 		return

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -161,7 +161,7 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 			ApplicationAuthentications: []m.ApplicationAuthentication{},
 		}
 
-		authDao := &dao.AuthenticationDaoImpl{TenantID: &application.TenantID}
+		authDao := dao.GetAuthenticationDao(&application.TenantID)
 		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 		if err != nil {
 			panic("error to fetch authentications: " + err.Error())
@@ -198,7 +198,7 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 			ResourceType:               "Endpoint",
 			ApplicationAuthentications: []m.ApplicationAuthentication{},
 		}
-		authDao := &dao.AuthenticationDaoImpl{TenantID: &endpoint.TenantID}
+		authDao := dao.GetAuthenticationDao(&endpoint.TenantID)
 		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 		if err != nil {
 			return err, nil


### PR DESCRIPTION
The reason behind this change is to decouple the instantiation of the DAOs from the code that needs them, in order to gain more flexibility when switching DAO implementations or when testing. Consider this example:

```go
// dao_file.go
type Dao interface {
	FindByAccountNumber(string accountNumber) (Something, error)
}

type dbDaoImpl struct {}

func (d* dbDaoImpl) FindByAccountNumber(string accountNumber) (Something, error) {
	// call db and return whatever
}

type vaultDaoImpl struct {}

func (d* dbDaoImpl) FindByAccountNumber(string accountNumber) (Something, error) {
	// call Vault and return whatever
}

// my_file_that_uses_the_dao.go
func myFunctionThatNeedsADao(string accountNumber) error {
	dao := dbDaoImpl{} // now this function is coupled to the dbDao, and we
	                   // cannot change to the vaultDao implementation.

	something, err := dao.FindByAccountNumber(&accountNumber)

	// ...

	return nil
}
```
In the above case the implementation is very coupled to the function that uses it, so... what could we do if we wanted to use the `VaultDaoImpl` instead? :thinking: 

```go
// dao_file.go
var GetDao func() Dao // returns the interface!

var getDefaultDao func() Dao {
	if config.VaultIsOnline {
		return &vaultDaoImpl{}
	} else {
		return &dbDaoImpl{}
	}
}

// init will set the function for obtaining the dao to the default one we have
// coded. If you want to use a different one, to return a mock dao for example,
// you only have to set another function to the exported GetDao variable!
func init() {
	GetDao = getDefaultDao
}

// my_file_that_uses_the_dao.go
func myFunctionThatNeedsADao(string accountNumber) error {
	// In this case we don't care which DAO implementation is underlying, since
	// we only care that we will be returned "something".
	dao := GetDao()
	something, err := dao.FindByAccountNumber(&accountNumber)

	// ...

	return nil
}
```

This is one way of doing it. We can override the `GetDao` function whenever we want if we need a different DAO.

---

So, this PR:

- Extracts the "get tenant from context" part of the code that was duplicated in every handler to a helper function.
- Creates a `var GetDao*` function for every DAO, and initializes it with a default DAO provider on the `init()` function, so that every other package has only one way of using DAOs, and so that those packages work against interfaces and not final implementations.
- Makes the `*Impl` structs unexported so that nobody can instantiate a DAO directly.

## Links

[[RHCLOUD-18212]](https://issues.redhat.com/browse/RHCLOUD-18212)