### PR TITLE
Add timing middleware to keep track of timings on response headers

### DIFF
--- a/middleware/timings.go
+++ b/middleware/timings.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+func Timing(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		begin := time.Now()
+
+		c.Response().Before(func() {
+			stopwatch := time.Since(begin)
+			c.Response().Header().Set("X-Request-Duration-Ms", strconv.FormatInt(stopwatch.Milliseconds(), 10))
+		})
+
+		return next(c)
+	}
+}

--- a/middleware/timings_test.go
+++ b/middleware/timings_test.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/labstack/echo/v4"
+)
+
+var sleepyFunc echo.HandlerFunc = func(c echo.Context) error {
+	time.Sleep(50 * time.Millisecond)
+	return c.NoContent(http.StatusOK)
+}
+
+func TestTiming(t *testing.T) {
+	c, _ := request.EmptyTestContext()
+
+	err := Timing(sleepyFunc)(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	duration := c.Response().Header().Get("X-Request-Duration-Ms")
+	if duration == "" {
+		t.Errorf("Failed to pull Duration from request")
+	}
+
+	timing, err := strconv.ParseInt(duration, 10, 64)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if timing < 50 {
+		t.Errorf("Timing was not more than 50ms as expected: %vms", timing)
+	}
+}

--- a/routes.go
+++ b/routes.go
@@ -20,7 +20,7 @@ func setupRoutes(e *echo.Echo) {
 		return c.String(http.StatusOK, "OK")
 	})
 
-	v3 := e.Group("/api/sources/v3.1", middleware.HandleErrors, middleware.ParseHeaders)
+	v3 := e.Group("/api/sources/v3.1", middleware.Timing, middleware.HandleErrors, middleware.ParseHeaders)
 
 	//openapi
 	v3.GET("/openapi.json", PublicOpenApiv31)


### PR DESCRIPTION
This will be useful to keep an eye on which requests are taking longer than others. 