### PR TITLE
Add Custom Echo Binder to catch not-allowed fields during POST requests

### DIFF
--- a/binder.go
+++ b/binder.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
+)
+
+// struct containing our custom "bind" logic
+type NoUnknownFieldsBinder struct{}
+
+/*
+	The single "Bind" method implements the echo.Binder interface.
+
+	For our custom binder we want to not allow any fields that aren't declared
+	on the `*CreateRequest` structs. This is easily achieved by switching on the
+	`DisallowUnknownFields` Decoder setting for unmarshaling json.
+*/
+func (binder *NoUnknownFieldsBinder) Bind(i interface{}, c echo.Context) error {
+	// if there is no body on the request - return early
+	if c.Request().Body == http.NoBody || c.Request().Body == nil {
+		return util.NewErrBadRequest("no body")
+	}
+
+	// create a new decoder for the request body
+	dec := json.NewDecoder(c.Request().Body)
+	// return an error if any non-declared fields are included in the request
+	dec.DisallowUnknownFields()
+
+	err := dec.Decode(i)
+	if err != nil {
+		c.Logger().Warnf("Failed to decode request: %v", err)
+		return util.NewErrBadRequest(err)
+	}
+
+	return nil
+}

--- a/binder_test.go
+++ b/binder_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/labstack/echo/v4"
+)
+
+var binder echo.Binder = &NoUnknownFieldsBinder{}
+
+type TestStruct struct {
+	YesIamAField bool `json:"good_field"`
+}
+
+func TestGoodPayload(t *testing.T) {
+	c, _ := request.CreateTestContext(
+		http.MethodPost,
+		"/",
+		bytes.NewBufferString(`{"good_field": true}`),
+		nil,
+	)
+	// set the binder to our custom instance.
+	c.Echo().Binder = binder
+
+	err := c.Bind(&TestStruct{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	// resetting due to messing with other tests.
+	c.Echo().Binder = &echo.DefaultBinder{}
+}
+
+func TestBadPayload(t *testing.T) {
+	c, _ := request.CreateTestContext(
+		http.MethodPost,
+		"/",
+		bytes.NewBufferString(`{"good_field": true, "oops": "yes"}`),
+		nil,
+	)
+	c.Echo().Binder = binder
+
+	err := c.Bind(&TestStruct{})
+	if err == nil {
+		t.Error("No error was found when there should have been an extra field error")
+	}
+
+	c.Echo().Binder = &echo.DefaultBinder{}
+}
+
+func TestNilBody(t *testing.T) {
+	c, _ := request.CreateTestContext(
+		http.MethodPost,
+		"/",
+		nil,
+		nil,
+	)
+	c.Echo().Binder = binder
+
+	err := c.Bind(&TestStruct{})
+	if err == nil {
+		t.Error("No error was found when there should have been a no body error")
+	}
+
+	c.Echo().Binder = &echo.DefaultBinder{}
+}
+
+func TestNoBody(t *testing.T) {
+	c, _ := request.CreateTestContext(
+		http.MethodPost,
+		"/",
+		http.NoBody,
+		nil,
+	)
+	c.Echo().Binder = binder
+
+	err := c.Bind(&TestStruct{})
+	if err == nil {
+		t.Error("No error was found when there should have been a no body error")
+	}
+
+	c.Echo().Binder = &echo.DefaultBinder{}
+}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,9 @@ func runServer() {
 	e := echo.New()
 	logging.InitEchoLogger(e, conf)
 
+	// set the binder to the one that does not allow extra parameters in payload
+	e.Binder = &NoUnknownFieldsBinder{}
+
 	e.Use(middleware.Recover())
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		Format: logging.FormatForMiddleware(conf),


### PR DESCRIPTION
There isn't a ticket for this yet - but this is somethign I've been wanting to do for a while so I took a bit of time this hackathon to do it. 

Basically we need to return `400` when extra fields are returned in a request, this was all handled via metaprogramming (and via the openapi spec) on the ruby side, but thankfully there is an easier way here on the Go side. 

The "allowed" fields are all codified on the `*CreateRequest` structs - those struct are the control of what we allow in on POST calls. So if we can just validate the JSON bodies against the tagged fields in those structs we basically have codified field validation.

---

Basically we can use a custom `echo.Binder` instance to decode the json bodies, and in doing so we have control of the decoder which has a setting to [disallow unknown fields](https://github.com/golang/go/blob/58804ea67a28c1d8e37ed548b685bc0c09638886/src/encoding/json/stream.go#L39-L42). 

The default behavior is just to discard them and not error out, which is what we do not want. Luckily we can limit this only to the `context#Bind(interface{})` calls as well - so we don't have to change any other code. 

Here is what the response looks like now with an "extra" field passed into `POST /sources`:
![image](https://user-images.githubusercontent.com/5856504/156632717-7b6021eb-103a-4429-8e74-6c36c5d72445.png)


---

I'm debating setting the test echo instance's binder to our custom one but am not having luck there. Some tests fail if it is set, I will look at it more next week. 