### PR TITLE
Add the marketplace extra fields to the openapi spec

### DIFF
--- a/public/openapi-3-v3.1.json
+++ b/public/openapi-3-v3.1.json
@@ -2132,6 +2132,18 @@
                   }
                 },
                 "type": "object"
+              },
+              "marketplace": {
+                "additionalProperties": false,
+                "properties": {
+                  "expiration": {
+                    "type": "number"
+                  },
+                  "access_token": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
               }
             },
             "type": "object"


### PR DESCRIPTION
I'm not sure if this is right or not.  Based on [1], it looks like the extra object can contain a "marketplace" entry.

[1] https://issues.redhat.com/browse/RHCLOUD-17515