### PR TITLE
Handle already-registered RHC Connection

### DIFF
--- a/dao/rhc_connection_dao_test.go
+++ b/dao/rhc_connection_dao_test.go
@@ -221,7 +221,7 @@ func TestRhcConnectionCreateAlreadyExistingAssociation(t *testing.T) {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
 
-	want := "cannot link red hat connection to source:"
+	want := "connection already exists"
 
 	_, err = rhcConnectionDao.Create(rhcConnection)
 	if !strings.Contains(err.Error(), want) {


### PR DESCRIPTION
Shim ran into this while integrating - we were returning a 500 if the RHC Connection was registered to the Source. 

---

To fix this we just need to do a `.FirstOrCreate` on the join table record - if the `result.RowsAffected` is 0 then we know nothing was inserted and thus the source is already registered. On that case we return a bad request error rather than just a general 500 error. 