### PR TITLE
[RHCLOUD-17958] Pause / unpause a source or application. Raise event tests.

### DIFF
--- a/application_handlers.go
+++ b/application_handlers.go
@@ -266,8 +266,8 @@ func ApplicationPause(c echo.Context) error {
 	return c.JSON(http.StatusNoContent, nil)
 }
 
-// ApplicationResume resumes a given application by setting its "paused_at" column to "NULL".
-func ApplicationResume(c echo.Context) error {
+// ApplicationUnpause resumes a given application by setting its "paused_at" column to "NULL".
+func ApplicationUnpause(c echo.Context) error {
 	applicationId, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
 		return util.NewErrBadRequest(err)
@@ -278,7 +278,7 @@ func ApplicationResume(c echo.Context) error {
 		return err
 	}
 
-	err = applicationDao.Resume(applicationId)
+	err = applicationDao.Unpause(applicationId)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -257,7 +257,7 @@ func ApplicationPause(c echo.Context) error {
 	// Get the Kafka headers we will need to be forwarding.
 	kafkaHeaders := service.ForwadableHeaders(c)
 
-	// Raise the resume event for the source.
+	// Raise the pause event for the application.
 	err = service.RaiseEvent("Application.pause", application, kafkaHeaders)
 	if err != nil {
 		return err
@@ -291,7 +291,7 @@ func ApplicationUnpause(c echo.Context) error {
 	// Get the Kafka headers we will need to be forwarding.
 	kafkaHeaders := service.ForwadableHeaders(c)
 
-	// Raise the resume event for the source.
+	// Raise the unpause event for the application.
 	err = service.RaiseEvent("Application.unpause", application, kafkaHeaders)
 	if err != nil {
 		return err

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -258,7 +258,7 @@ func ApplicationPause(c echo.Context) error {
 	kafkaHeaders := service.ForwadableHeaders(c)
 
 	// Raise the resume event for the source.
-	err = service.RaiseEvent("Application.Pause", application, kafkaHeaders)
+	err = service.RaiseEvent("Application.pause", application, kafkaHeaders)
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func ApplicationResume(c echo.Context) error {
 	kafkaHeaders := service.ForwadableHeaders(c)
 
 	// Raise the resume event for the source.
-	err = service.RaiseEvent("Application.Unpause", application, kafkaHeaders)
+	err = service.RaiseEvent("Application.unpause", application, kafkaHeaders)
 	if err != nil {
 		return err
 	}

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -667,7 +667,7 @@ func TestResumeApplication(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 
-	err := ApplicationResume(c)
+	err := ApplicationUnpause(c)
 	if err != nil {
 		t.Error(err)
 	}

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -163,7 +163,7 @@ func (a *applicationDaoImpl) Pause(id int64) error {
 	return err
 }
 
-func (a *applicationDaoImpl) Resume(id int64) error {
+func (a *applicationDaoImpl) Unpause(id int64) error {
 	err := DB.Debug().
 		Model(&m.Application{}).
 		Where("id = ?", id).

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -43,7 +43,7 @@ func TestResumeApplication(t *testing.T) {
 	CreateFixtures("pause_unpause")
 
 	applicationDao := GetApplicationDao(&testApplication.TenantID)
-	err := applicationDao.Resume(testApplication.ID)
+	err := applicationDao.Unpause(testApplication.ID)
 
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -26,8 +26,8 @@ type SourceDao interface {
 	ToEventJSON(resource util.Resource) ([]byte, error)
 	// Pause pauses the given source and all its dependant applications.
 	Pause(id int64) error
-	// Resume resumes the given source and all its dependant applications.
-	Resume(id int64) error
+	// Unpause resumes the given source and all its dependant applications.
+	Unpause(id int64) error
 }
 
 type ApplicationDao interface {
@@ -43,8 +43,8 @@ type ApplicationDao interface {
 	ToEventJSON(resource util.Resource) ([]byte, error)
 	// Pause pauses the application.
 	Pause(id int64) error
-	// Resume resumes the application.
-	Resume(id int64) error
+	// Unpause resumes the application.
+	Unpause(id int64) error
 }
 
 type AuthenticationDao interface {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -148,7 +148,7 @@ func (s *MockSourceDao) Pause(_ int64) error {
 	return nil
 }
 
-func (s *MockSourceDao) Resume(_ int64) error {
+func (s *MockSourceDao) Unpause(_ int64) error {
 	return nil
 }
 
@@ -357,7 +357,7 @@ func (a *MockApplicationDao) Pause(_ int64) error {
 	return nil
 }
 
-func (a *MockApplicationDao) Resume(_ int64) error {
+func (a *MockApplicationDao) Unpause(_ int64) error {
 	return nil
 }
 

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -265,7 +265,7 @@ func (s *sourceDaoImpl) Pause(id int64) error {
 	return err
 }
 
-func (s *sourceDaoImpl) Resume(id int64) error {
+func (s *sourceDaoImpl) Unpause(id int64) error {
 	err := DB.Debug().Transaction(func(tx *gorm.DB) error {
 		err := tx.Debug().
 			Model(&m.Source{}).

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -96,7 +96,7 @@ func TestResumingSource(t *testing.T) {
 	CreateFixtures("pause_unpause")
 
 	sourceDao := GetSourceDao(&testSource.TenantID)
-	err := sourceDao.Resume(fixtures.TestSourceData[0].ID)
+	err := sourceDao.Unpause(fixtures.TestSourceData[0].ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}

--- a/routes.go
+++ b/routes.go
@@ -38,7 +38,7 @@ func setupRoutes(e *echo.Echo) {
 	v3.GET("/sources/:source_id/authentications", SourceListAuthentications, tenancyWithListMiddleware...)
 	v3.GET("/sources/:source_id/rhc_connections", SourcesRhcConnectionList, tenancyWithListMiddleware...)
 	v3.POST("/sources/:source_id/pause", SourcePause, middleware.Tenancy)
-	v3.POST("/sources/:source_id/unpause", SourceResume, middleware.Tenancy)
+	v3.POST("/sources/:source_id/unpause", SourceUnpause, middleware.Tenancy)
 
 	// Applications
 	v3.GET("/applications", ApplicationList, tenancyWithListMiddleware...)
@@ -48,7 +48,7 @@ func setupRoutes(e *echo.Echo) {
 	v3.DELETE("/applications/:id", ApplicationDelete, permissionMiddleware...)
 	v3.GET("/applications/:application_id/authentications", ApplicationListAuthentications, tenancyWithListMiddleware...)
 	v3.POST("/applications/:id/pause", ApplicationPause, middleware.Tenancy)
-	v3.POST("/applications/:id/unpause", ApplicationResume, middleware.Tenancy)
+	v3.POST("/applications/:id/unpause", ApplicationUnpause, middleware.Tenancy)
 
 	// Authentications
 	v3.GET("/authentications", AuthenticationList, tenancyWithListMiddleware...)

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -439,13 +439,13 @@ func SourceUnpause(c echo.Context) error {
 	// Get the Kafka headers we will need to be forwarding.
 	kafkaHeaders := service.ForwadableHeaders(c)
 
-	// Raise the resume event for the source.
+	// Raise the unpause event for the source.
 	err = service.RaiseEvent("Source.unpause", source, kafkaHeaders)
 	if err != nil {
 		return err
 	}
 
-	// Raise the resume event for its applications
+	// Raise the unpause event for its applications
 	for _, app := range source.Applications {
 		err := service.RaiseEvent("Application.unpause", &app, kafkaHeaders)
 		if err != nil {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -413,9 +413,9 @@ func SourcePause(c echo.Context) error {
 	return c.JSON(http.StatusNoContent, nil)
 }
 
-// SourceResume "unpauses" a source and all its dependant applications, by setting the former's and the latter's
+// SourceUnpause "unpauses" a source and all its dependant applications, by setting the former's and the latter's
 // "paused_at" columns to "null".
-func SourceResume(c echo.Context) error {
+func SourceUnpause(c echo.Context) error {
 	sourceId, err := strconv.ParseInt(c.Param("source_id"), 10, 64)
 	if err != nil {
 		return util.NewErrBadRequest(err)
@@ -426,7 +426,7 @@ func SourceResume(c echo.Context) error {
 		return err
 	}
 
-	err = sourceDao.Resume(sourceId)
+	err = sourceDao.Unpause(sourceId)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -397,14 +397,14 @@ func SourcePause(c echo.Context) error {
 	kafkaHeaders := service.ForwadableHeaders(c)
 
 	// Raise the pause event for the source.
-	err = service.RaiseEvent("Source.Pause", source, kafkaHeaders)
+	err = service.RaiseEvent("Source.pause", source, kafkaHeaders)
 	if err != nil {
 		return err
 	}
 
 	// Raise the pause event for its applications
 	for _, app := range source.Applications {
-		err := service.RaiseEvent("Application.Pause", &app, kafkaHeaders)
+		err := service.RaiseEvent("Application.pause", &app, kafkaHeaders)
 		if err != nil {
 			return err
 		}
@@ -440,14 +440,14 @@ func SourceResume(c echo.Context) error {
 	kafkaHeaders := service.ForwadableHeaders(c)
 
 	// Raise the resume event for the source.
-	err = service.RaiseEvent("Source.Unpause", source, kafkaHeaders)
+	err = service.RaiseEvent("Source.unpause", source, kafkaHeaders)
 	if err != nil {
 		return err
 	}
 
 	// Raise the resume event for its applications
 	for _, app := range source.Applications {
-		err := service.RaiseEvent("Application.Unpause", &app, kafkaHeaders)
+		err := service.RaiseEvent("Application.unpause", &app, kafkaHeaders)
 		if err != nil {
 			return err
 		}

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -911,7 +911,7 @@ func TestResumeSourceAndItsApplications(t *testing.T) {
 	c.SetParamNames("source_id")
 	c.SetParamValues("1")
 
-	err := SourceResume(c)
+	err := SourceUnpause(c)
 	if err != nil {
 		t.Error(err)
 	}

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -3,17 +3,22 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strconv"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/internal/events"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/kafka"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
 )
 
 func TestSourceTypeSourceSubcollectionList(t *testing.T) {
@@ -919,4 +924,215 @@ func TestResumeSourceAndItsApplications(t *testing.T) {
 	if rec.Code != http.StatusNoContent {
 		t.Errorf(`want status "%d", got "%d"`, http.StatusNoContent, rec.Code)
 	}
+}
+
+// MockSender is just a mock which will allow us to control how the "RaiseEvent" function gets executed.
+type MockSender struct {
+}
+
+// raiseEventFunc is an overrideable function which gets executed when the sender's "RaiseEvent" is called. This helps
+// keeping the test logic inside each test.
+var raiseEventFunc func(eventType string, payload []byte, headers []kafka.Header) error
+
+// RaiseEvent is a placeholder function which simulates a call to the "RaiseEvent" function.
+func (p MockSender) RaiseEvent(eventType string, payload []byte, headers []kafka.Header) error {
+	return raiseEventFunc(eventType, payload, headers)
+}
+
+// TestSourcePauseRaiseEventCheck tests that a proper "raise event" is raised when a source is paused.
+func TestSourcePauseRaiseEventCheck(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues("1")
+
+	// We back up the producer so that we can restore it once the test has finished. This way we don't mess up with
+	// other tests that may need to raise events.
+	backupProducer := service.Producer
+	service.Producer = events.EventStreamProducer{Sender: MockSender{}}
+
+	var sourceRaiseEventCallCount int
+	var applicationRaiseEventCallCount int
+	raiseEventFunc = func(eventType string, payload []byte, headers []kafka.Header) error {
+		// Set up an error which will get returned. Probably will get overwritten if there are multiple errors, but
+		// we don't mind since we are logging every failure. Essentially, it just to satisfy the function signature.
+		var err error
+
+		switch eventType {
+		case "Source.pause":
+			err = sourceEventTestHelper(t, c, "Source.pause", payload, headers)
+
+			sourceRaiseEventCallCount++
+		case "Application.pause":
+			err = applicationEventTestHelper(t, c, "Application.pause", eventType, payload, headers)
+
+			applicationRaiseEventCallCount++
+		default:
+			t.Errorf(`incorrect event type when raising the event. Want "Source.pause" or "Application.pause", got "%s"`, eventType)
+			err = errors.New(`incorrect event type raised`)
+		}
+
+		return err
+	}
+
+	err := SourcePause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	{
+		// We are pausing a single source, therefore there should only have been 1 call to the "RaiseEvent" function.
+		want := 1
+		got := sourceRaiseEventCallCount
+		if want != got {
+			t.Errorf(`raise event was called an incorrect number of times for the source event. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		// The source has 2 related application in the fixtures, so the "RaiseEvent" function should have been called
+		// twice.
+		want := 2
+		got := applicationRaiseEventCallCount
+		if want != got {
+			t.Errorf(`raise event was called an incorrect number of times for the application event. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf(`want status "%d", got "%d"`, http.StatusNoContent, rec.Code)
+	}
+
+	// Restore the producer back to the original.
+	service.Producer = backupProducer
+}
+
+// TestSourceUnpauseRaiseEventCheck tests that a proper "raise event" is raised when a source is unpaused.
+func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues("1")
+
+	// We back up the producer so that we can restore it once the test has finished. This way we don't mess up with
+	// other tests that may need to raise events.
+	backupProducer := service.Producer
+	service.Producer = events.EventStreamProducer{Sender: MockSender{}}
+
+	var sourceRaiseEventCallCount int
+	var applicationRaiseEventCallCount int
+	raiseEventFunc = func(eventType string, payload []byte, headers []kafka.Header) error {
+		// Set up an error which will get returned. Probably will get overwritten if there are multiple errors, but
+		// we don't mind since we are logging every failure. Essentially, it just to satisfy the function signature.
+		var err error
+
+		switch eventType {
+		case "Source.unpause":
+			err = sourceEventTestHelper(t, c, "Source.unpause", payload, headers)
+
+			sourceRaiseEventCallCount++
+		case "Application.unpause":
+			err = applicationEventTestHelper(t, c, "Application.unpause", eventType, payload, headers)
+
+			applicationRaiseEventCallCount++
+		default:
+			t.Errorf(`incorrect event type when raising the event. Want "Source.pause" or "Application.pause", got "%s"`, eventType)
+			err = errors.New(`incorrect event type raised`)
+		}
+
+		return err
+	}
+
+	err := SourceUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	{
+		// We are resuming a single source, therefore there should only have been 1 call to the "RaiseEvent" function.
+		want := 1
+		got := sourceRaiseEventCallCount
+		if want != got {
+			t.Errorf(`raise event was called an incorrect number of times for the source event. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		// The source has 2 related application in the fixtures, so the "RaiseEvent" function should have been called
+		// twice.
+		want := 2
+		got := applicationRaiseEventCallCount
+		if want != got {
+			t.Errorf(`raise event was called an incorrect number of times for the application event. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf(`want status "%d", got "%d"`, http.StatusNoContent, rec.Code)
+	}
+
+	// Restore the producer back to the original.
+	service.Producer = backupProducer
+}
+
+// sourceEventTestHelper helps to test whether the received payload and the headers from the "RaiseEvent" function
+// correspond to what we are expecting.
+func sourceEventTestHelper(t *testing.T, c echo.Context, expectedEventType string, payload []byte, headers []kafka.Header) error {
+	sourceDao, err := getSourceDao(c)
+	if err != nil {
+		t.Errorf(`could not get the source dao: %s`, err)
+		return err
+	}
+
+	// Grab the source from the fixtures.
+	expectedSource, err := sourceDao.GetById(&fixtures.TestSourceData[0].ID)
+	if err != nil {
+		t.Errorf(`could not fetch the source: %s`, err)
+		return err
+	}
+
+	{
+		// Turn the source into JSON.
+		want, err := json.Marshal(expectedSource.ToEvent())
+		if err != nil {
+			t.Errorf(`error marshalling the event: %s`, err)
+			return err
+		}
+
+		got := payload
+		if !bytes.Equal(want, got) {
+			t.Errorf(`incorrect payload received on raise event.Want "%s", got "%s"`, want, got)
+			return err
+		}
+	}
+
+	{
+		// The header should contain the expected event type as well.
+		want := expectedEventType
+		got := string(headers[0].Value)
+		if want != got {
+			t.Errorf(`incorrect header on raise event. Want "%s", got "%s"`, want, got)
+			return errors.New(`incorrect header on raise event`)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
1. Refactors the `Resume` named functions to `Unpaused` for consistency.
2. Adds tests to check that `RaiseEvent` gets called with the correct event types, payloads and headers when pausing / unpausing sources and/or applications.

## Links

[[RHCLOUD-17958]](https://issues.redhat.com/browse/RHCLOUD-17958)