### PR TITLE
Only Seed the database when running the API Pod

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,9 +106,14 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("SlowSQLThreshold", 2) //seconds
 	options.SetDefault("BypassRbac", os.Getenv("BYPASS_RBAC") == "true")
 
-	// Parse any Flags
-	availabilityListener := flag.Bool("listener", false, "run availability status listener")
-	flag.Parse()
+	// Parse any Flags (using our own flag set to not conflict with the global flag)
+	fs := flag.NewFlagSet("runtime", flag.ContinueOnError)
+	availabilityListener := fs.Bool("listener", false, "run availability status listener")
+
+	err := fs.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing flags: %v", err)
+	}
 
 	options.SetDefault("StatusListener", *availabilityListener)
 

--- a/dao/db.go
+++ b/dao/db.go
@@ -58,9 +58,18 @@ func Init() {
 
 	Vault = vaultClient.Logical()
 
-	err = seedDatabase()
+	// we only want to seed the database when running the api pod - not the status listener
+	if !conf.StatusListener {
+		err = seedDatabase()
+		if err != nil {
+			logging.Log.Fatalf("Failed to seed db: %v", err)
+		}
+	}
+
+	// Set up the TypeCache
+	err = PopulateStaticTypeCache()
 	if err != nil {
-		logging.Log.Fatalf("Failed to seed db: %v", err)
+		logging.Log.Fatalf("Failed to populate static type cache: %v", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
@@ -23,10 +21,7 @@ func main() {
 	dao.Init()
 	redis.Init()
 
-	availabilityListener := flag.Bool("listener", false, "run availability status listener")
-	flag.Parse()
-
-	if *availabilityListener {
+	if config.Get().StatusListener {
 		statuslistener.Run()
 	} else {
 		runServer()
@@ -73,12 +68,6 @@ func runServer() {
 
 	// setting up the "http.Client" for the marketplace token provider
 	marketplace.GetHttpClient = marketplace.GetHttpClientStdlib
-
-	// Set up the TypeCache
-	err := dao.PopulateStaticTypeCache()
-	if err != nil {
-		e.Logger.Fatal(err)
-	}
 
 	// launch 2 listeners - one for metrics and one for the actual application,
 	// one on 8000 and one on 9000 (per clowder)


### PR DESCRIPTION
I noticed this when testing the statuslistener on stage - we are seeding the database on startup on both the API pod AND the availability status listener. 

We only want to see the DB one time per rollout, and the API pod makes the most sense to handle that. 

---

This involved moving the flag parsing to the `config/` package - which makes sense due to the fact that we parse the config once and we can refer to that struct for everything from then on. 

---

I also moved the type cache initialization to the dao init function - makes more sense there. 