### PR TITLE
Handle Int + String resource_id's in the status listener

### DIFF
--- a/internal/types/status_message.go
+++ b/internal/types/status_message.go
@@ -1,8 +1,9 @@
 package types
 
 type StatusMessage struct {
-	ResourceType string `json:"resource_type"`
-	ResourceID   string `json:"resource_id"`
-	Status       string `json:"status"`
-	Error        string `json:"error"`
+	ResourceType  string      `json:"resource_type"`
+	ResourceIDRaw interface{} `json:"resource_id"`
+	ResourceID    string      `json:"-"`
+	Status        string      `json:"status"`
+	Error         string      `json:"error"`
 }

--- a/kafka/message.go
+++ b/kafka/message.go
@@ -52,3 +52,17 @@ func (message *Message) isEmpty() bool {
 
 	return isEmptyHeaders && message.Value == nil
 }
+
+// translate a kafka message's headers from segmentio/kafka -> our kafka
+func (message *Message) TranslateHeaders() []Header {
+	if len(message.Headers) < 1 {
+		return []Header{}
+	}
+
+	headers := make([]Header, len(message.Headers))
+	for index, header := range message.Headers {
+		headers[index] = Header{Key: header.Key, Value: header.Value}
+	}
+
+	return headers
+}

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -409,16 +409,16 @@ func TestConsumeStatusMessage(t *testing.T) {
 	header2 := kafkaGo.Header{Key: "x-rh-identity", Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
 	header3 := kafkaGo.Header{Key: "x-rh-sources-account-number", Value: []byte("12345")}
 	headers := []kafkaGo.Header{header, header2, header3}
-	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", Status: m.Available}
+	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	sourceTestData := TestData{StatusMessage: statusMessage, MessageHeaders: headers, RaiseEventCalled: true}
 
-	statusMessageApplication := types.StatusMessage{ResourceType: "Application", ResourceID: "1", Status: m.Available}
+	statusMessageApplication := types.StatusMessage{ResourceType: "Application", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	applicationTestData := TestData{StatusMessage: statusMessageApplication, MessageHeaders: headers, RaiseEventCalled: true}
 
-	statusMessageEndpoint := types.StatusMessage{ResourceType: "Endpoint", ResourceID: "1", Status: m.Available}
+	statusMessageEndpoint := types.StatusMessage{ResourceType: "Endpoint", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	endpointTestData := TestData{StatusMessage: statusMessageEndpoint, MessageHeaders: headers, RaiseEventCalled: true}
 
-	statusMessageEndpoint = types.StatusMessage{ResourceType: "Endpoint", ResourceID: "99", Status: m.Available}
+	statusMessageEndpoint = types.StatusMessage{ResourceType: "Endpoint", ResourceID: "1", ResourceIDRaw: "99", Status: m.Available}
 	endpointTestDataNotFound := TestData{StatusMessage: statusMessageEndpoint, MessageHeaders: headers, RaiseEventCalled: false}
 
 	testData = make([]TestData, 4)

--- a/util/parser.go
+++ b/util/parser.go
@@ -80,3 +80,40 @@ func DateTimeToRecordFormat(inputTime time.Time) *string {
 func DateTimeToRFC3339(inputTime time.Time) string {
 	return FormatTimeToString(inputTime, time.RFC3339)
 }
+
+// InterfaceToString takes a number in interface format and converts it to the
+// string representation
+func InterfaceToString(i interface{}) (string, error) {
+	switch value := i.(type) {
+	case float64:
+		return strconv.FormatInt(int64(value), 10), nil
+	case *float64:
+		if value == nil {
+			return "", fmt.Errorf("cannot parse a nil pointer to a string")
+		}
+
+		return strconv.FormatInt(int64(*value), 10), nil
+
+	case int64:
+		return strconv.FormatInt(value, 10), nil
+
+	case *int64:
+		if value == nil {
+			return "", fmt.Errorf("cannot parse a nil pointer to a string")
+		}
+
+		return strconv.FormatInt(*value, 10), nil
+	case string:
+		return value, nil
+
+	case *string:
+		if value == nil {
+			return "", fmt.Errorf("cannot parse a nil pointer to a string")
+		}
+
+		return *value, nil
+
+	default:
+		return "", fmt.Errorf("invalid format provided")
+	}
+}

--- a/util/parser_test.go
+++ b/util/parser_test.go
@@ -134,3 +134,34 @@ func TestPassingInvalidFormats(t *testing.T) {
 		}
 	}
 }
+
+func TestGoodStringValues(t *testing.T) {
+	types := []interface{}{
+		"1",
+		int64(1),
+		new(int64),
+		1.2,
+		new(float64),
+	}
+
+	for i := range types {
+		_, err := InterfaceToString(types[i])
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestNilStringValue(t *testing.T) {
+	var x *float64
+	var y *int64
+	var z *string
+	types := []interface{}{x, y, z, nil}
+
+	for i := range types {
+		_, err := InterfaceToString(types[i])
+		if err == nil {
+			t.Errorf("did not handle nil properly")
+		}
+	}
+}


### PR DESCRIPTION
A few small refactors on the way we parse statusmessages - I tested this on stage and it was erroring out on some payloads. It looks like we seamlessly handles integer and/or string status message resource_id's. 

This PR handles both of them. I also just moved the function that translates headers to a method on the message object - since that is where the state is. 