### PR TITLE
Fix Availability Status Warn condition

### DIFF
--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -92,7 +92,7 @@ func httpAvailabilityRequest(source *m.Source, app *m.Application, uri *url.URL)
 	defer resp.Body.Close()
 
 	// anything greater than 299 is bad, right??? right????
-	if resp.StatusCode%100 > 2 {
+	if resp.StatusCode/100 > 2 {
 		l.Log.Warnf("Bad response from client: %v", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
Saw this while testing - we were getting a warn for 204 and I realized I used `%` instead of `/`. This will eliminate the warn message since anything 2xx is not a problem. 