### PR TITLE
Set log level for GORM `Debug()` statements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -151,6 +151,8 @@ func Get() *SourcesApiConfig {
 		MetricsPort:               options.GetInt("MetricsPort"),
 		LogLevel:                  options.GetString("LogLevel"),
 		LogLevelForMiddlewareLogs: options.GetString("LogLevelForMiddlewareLogs"),
+		LogLevelForSqlLogs:        options.GetString("LogLevelForSqlLogs"),
+		SlowSQLThreshold:          options.GetInt("SlowSQLThreshold"),
 		LogHandler:                options.GetString("LogHandler"),
 		LogGroup:                  options.GetString("LogGroup"),
 		MarketplaceHost:           options.GetString("MarketplaceHost"),

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -36,7 +36,10 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplicati
 		applicationIDs = append(applicationIDs, value.ID)
 	}
 
-	err := DB.Preload("Tenant").Where("application_id IN ?", applicationIDs).Find(&applicationAuthentications).Error
+	err := DB.Debug().
+		Preload("Tenant").
+		Where("application_id IN ?", applicationIDs).
+		Find(&applicationAuthentications).Error
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +55,10 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByAuthentic
 		authenticationUIDs = append(authenticationUIDs, value.ID)
 	}
 
-	result := DB.Preload("Tenant").Where("authentication_uid IN ?", authenticationUIDs).Find(&applicationAuthentications)
+	result := DB.Debug().
+		Preload("Tenant").
+		Where("authentication_uid IN ?", authenticationUIDs).
+		Find(&applicationAuthentications)
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -70,7 +76,8 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByResource(
 
 func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
 	appAuths := make([]m.ApplicationAuthentication, 0, limit)
-	query := DB.Debug().Model(&m.ApplicationAuthentication{}).
+	query := DB.Debug().
+		Model(&m.ApplicationAuthentication{}).
 		Offset(offset).
 		Where("tenant_id = ?", a.TenantID)
 
@@ -91,7 +98,8 @@ func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 
 func (a *applicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAuthentication, error) {
 	appAuth := &m.ApplicationAuthentication{ID: *id}
-	result := DB.Where("tenant_id = ?", a.TenantID).First(&appAuth)
+	result := DB.Debug().
+		Where("tenant_id = ?", a.TenantID).First(&appAuth)
 	if result.Error != nil {
 		return nil, util.NewErrNotFound("application authentication")
 	}
@@ -100,7 +108,7 @@ func (a *applicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAut
 
 func (a *applicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthentication) error {
 	appAuth.TenantID = *a.TenantID
-	err := DB.Create(appAuth).Error
+	err := DB.Debug().Create(appAuth).Error
 	if err != nil {
 		return util.NewErrBadRequest("failed to create application_authentication: " + err.Error())
 	}
@@ -108,7 +116,7 @@ func (a *applicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthenti
 }
 
 func (a *applicationAuthenticationDaoImpl) Update(appAuth *m.ApplicationAuthentication) error {
-	result := DB.Updates(appAuth)
+	result := DB.Debug().Updates(appAuth)
 	return result.Error
 }
 

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -77,7 +77,7 @@ func (a *applicationDaoImpl) List(limit int, offset int, filters []util.Filter) 
 
 func (a *applicationDaoImpl) GetById(id *int64) (*m.Application, error) {
 	app := &m.Application{ID: *id}
-	result := DB.First(&app)
+	result := DB.Debug().First(&app)
 	if result.Error != nil {
 		return nil, util.NewErrNotFound("application")
 	}
@@ -100,13 +100,13 @@ func (a *applicationDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (
 
 func (a *applicationDaoImpl) Create(app *m.Application) error {
 	app.TenantID = *a.TenantID
-	result := DB.Create(app)
+	result := DB.Debug().Create(app)
 
 	return result.Error
 }
 
 func (a *applicationDaoImpl) Update(app *m.Application) error {
-	result := DB.Updates(app)
+	result := DB.Debug().Updates(app)
 	return result.Error
 }
 
@@ -154,7 +154,7 @@ func (a *applicationDaoImpl) IsSuperkey(id int64) bool {
 
 func (a *applicationDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
 	application := &m.Application{ID: resource.ResourceID}
-	result := DB.Preload("Source").Find(&application)
+	result := DB.Debug().Preload("Source").Find(&application)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -168,7 +168,7 @@ func (a *applicationDaoImpl) BulkMessage(resource util.Resource) (map[string]int
 }
 
 func (a *applicationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {
-	result := DB.Model(&m.Application{ID: resource.ResourceID}).Updates(updateAttributes)
+	result := DB.Debug().Model(&m.Application{ID: resource.ResourceID}).Updates(updateAttributes)
 	if result.RowsAffected == 0 {
 		return fmt.Errorf("application not found %v", resource)
 	}
@@ -178,7 +178,7 @@ func (a *applicationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttr
 
 func (a *applicationDaoImpl) FindWithTenant(id *int64) (*m.Application, error) {
 	app := &m.Application{ID: *id}
-	result := DB.Preload("Tenant").Find(&app)
+	result := DB.Debug().Preload("Tenant").Find(&app)
 
 	return app, result.Error
 }

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -61,7 +61,7 @@ func (a *applicationTypeDaoImpl) List(limit, offset int, filters []util.Filter) 
 	// allocating a slice of application types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	appTypes := make([]m.ApplicationType, 0, limit)
-	query := DB.Model(&m.ApplicationType{}).Debug()
+	query := DB.Debug().Model(&m.ApplicationType{})
 
 	query, err := applyFilters(query, filters)
 	if err != nil {
@@ -114,7 +114,7 @@ func (at *applicationTypeDaoImpl) ApplicationTypeCompatibleWithSource(typeId, so
 	// Looks up the source ID and then compare's the source-type's name with the
 	// application type's supported source types
 	source := m.Source{ID: sourceId}
-	result := DB.Preload("SourceType").Find(&source)
+	result := DB.Debug().Preload("SourceType").Find(&source)
 	if result.Error != nil {
 		return fmt.Errorf("source not found")
 	}

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -79,7 +79,7 @@ func (a *endpointDaoImpl) List(limit int, offset int, filters []util.Filter) ([]
 
 func (a *endpointDaoImpl) GetById(id *int64) (*m.Endpoint, error) {
 	app := &m.Endpoint{ID: *id}
-	result := DB.First(&app)
+	result := DB.Debug().First(&app)
 	if result.Error != nil {
 		return nil, util.NewErrNotFound("endpoint")
 	}
@@ -90,7 +90,7 @@ func (a *endpointDaoImpl) GetById(id *int64) (*m.Endpoint, error) {
 func (a *endpointDaoImpl) Create(app *m.Endpoint) error {
 	app.TenantID = *a.TenantID
 
-	result := DB.Create(app)
+	result := DB.Debug().Create(app)
 	return result.Error
 }
 
@@ -128,13 +128,13 @@ func (a *endpointDaoImpl) CanEndpointBeSetAsDefaultForSource(sourceId int64) boo
 	endpoint := &m.Endpoint{}
 
 	// add double quotes to the "default" column to avoid any clashes with postgres' "default" keyword
-	result := DB.Where(`"default" = true AND source_id = ?`, sourceId).First(&endpoint)
+	result := DB.Debug().Where(`"default" = true AND source_id = ?`, sourceId).First(&endpoint)
 	return result.Error != nil
 }
 
 func (a *endpointDaoImpl) IsRoleUniqueForSource(role string, sourceId int64) bool {
 	endpoint := &m.Endpoint{}
-	result := DB.Where("role = ? AND source_id = ?", role, sourceId).First(&endpoint)
+	result := DB.Debug().Where("role = ? AND source_id = ?", role, sourceId).First(&endpoint)
 
 	// If the record doesn't exist "result.Error" will have a "record not found" error
 	return result.Error != nil
@@ -143,14 +143,14 @@ func (a *endpointDaoImpl) IsRoleUniqueForSource(role string, sourceId int64) boo
 func (a *endpointDaoImpl) SourceHasEndpoints(sourceId int64) bool {
 	endpoint := &m.Endpoint{}
 
-	result := DB.Where("source_id = ?", sourceId).First(&endpoint)
+	result := DB.Debug().Where("source_id = ?", sourceId).First(&endpoint)
 
 	return result.Error == nil
 }
 
 func (a *endpointDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
 	endpoint := &m.Endpoint{ID: resource.ResourceID}
-	result := DB.Preload("Source").Find(&endpoint)
+	result := DB.Debug().Preload("Source").Find(&endpoint)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -161,7 +161,7 @@ func (a *endpointDaoImpl) BulkMessage(resource util.Resource) (map[string]interf
 }
 
 func (a *endpointDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {
-	result := DB.Model(&m.Endpoint{ID: resource.ResourceID}).Updates(updateAttributes)
+	result := DB.Debug().Model(&m.Endpoint{ID: resource.ResourceID}).Updates(updateAttributes)
 	if result.RowsAffected == 0 {
 		return fmt.Errorf("endpoint not found %v", resource)
 	}
@@ -171,7 +171,7 @@ func (a *endpointDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttribu
 
 func (a *endpointDaoImpl) FindWithTenant(id *int64) (*m.Endpoint, error) {
 	endpoint := &m.Endpoint{ID: *id}
-	result := DB.Preload("Tenant").Find(&endpoint)
+	result := DB.Debug().Preload("Tenant").Find(&endpoint)
 
 	return endpoint, result.Error
 }

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -69,7 +69,7 @@ func (md *metaDataDaoImpl) List(limit int, offset int, filters []util.Filter) ([
 
 func (md *metaDataDaoImpl) GetById(id *int64) (*m.MetaData, error) {
 	metaData := &m.MetaData{ID: *id}
-	result := DB.First(&metaData)
+	result := DB.Debug().First(&metaData)
 	if result.Error != nil {
 		return nil, util.NewErrNotFound("metadata")
 	}

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -112,7 +112,7 @@ func (s *sourceDaoImpl) ListInternal(limit, offset int, filters []util.Filter) (
 
 func (s *sourceDaoImpl) GetById(id *int64) (*m.Source, error) {
 	src := &m.Source{ID: *id}
-	result := DB.First(src)
+	result := DB.Debug().First(src)
 	if result.Error != nil {
 		return nil, util.NewErrNotFound("source")
 	}
@@ -123,7 +123,7 @@ func (s *sourceDaoImpl) GetById(id *int64) (*m.Source, error) {
 // Function that searches for a source and preloads any specified relations
 func (s *sourceDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error) {
 	src := &m.Source{ID: *id}
-	q := DB.Where("tenant_id = ?", s.TenantID)
+	q := DB.Debug().Where("tenant_id = ?", s.TenantID)
 
 	for _, preload := range preloads {
 		q = q.Preload(preload)
@@ -138,12 +138,12 @@ func (s *sourceDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.So
 
 func (s *sourceDaoImpl) Create(src *m.Source) error {
 	src.TenantID = *s.TenantID // the TenantID gets injected in the middleware
-	result := DB.Create(src)
+	result := DB.Debug().Create(src)
 	return result.Error
 }
 
 func (s *sourceDaoImpl) Update(src *m.Source) error {
-	result := DB.Updates(src)
+	result := DB.Debug().Updates(src)
 	return result.Error
 }
 
@@ -174,7 +174,7 @@ func (s *sourceDaoImpl) Tenant() *int64 {
 
 func (s *sourceDaoImpl) NameExistsInCurrentTenant(name string) bool {
 	src := &m.Source{Name: name}
-	result := DB.Where("name = ? AND tenant_id = ?", name, s.TenantID).First(src)
+	result := DB.Debug().Where("name = ? AND tenant_id = ?", name, s.TenantID).First(src)
 
 	// If the name is found, GORM returns one row and no errors.
 	return result.Error == nil
@@ -197,7 +197,7 @@ func (s *sourceDaoImpl) IsSuperkey(id int64) bool {
 
 func (s *sourceDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
 	src := m.Source{ID: resource.ResourceID}
-	result := DB.Find(&src)
+	result := DB.Debug().Find(&src)
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -207,7 +207,7 @@ func (s *sourceDaoImpl) BulkMessage(resource util.Resource) (map[string]interfac
 }
 
 func (s *sourceDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error {
-	result := DB.Model(&m.Source{ID: resource.ResourceID}).Updates(updateAttributes)
+	result := DB.Debug().Model(&m.Source{ID: resource.ResourceID}).Updates(updateAttributes)
 	if result.RowsAffected == 0 {
 		return fmt.Errorf("source not found %v", resource)
 	}
@@ -217,7 +217,7 @@ func (s *sourceDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttribute
 
 func (s *sourceDaoImpl) FindWithTenant(id *int64) (*m.Source, error) {
 	src := &m.Source{ID: *id}
-	result := DB.Preload("Tenant").Find(&src)
+	result := DB.Debug().Preload("Tenant").Find(&src)
 
 	return src, result.Error
 }

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -24,7 +24,7 @@ func (t *tenantDaoImpl) GetOrCreateTenantID(accountNumber string) (*int64, error
 	tenant := m.Tenant{ExternalTenant: accountNumber}
 
 	// Find the tenant, scanning into the struct above
-	result := DB.
+	result := DB.Debug().
 		Where("external_tenant = ?", accountNumber).
 		First(&tenant)
 
@@ -39,7 +39,7 @@ func (t *tenantDaoImpl) GetOrCreateTenantID(accountNumber string) (*int64, error
 func (t *tenantDaoImpl) TenantByAccountNumber(accountNumber string) (*m.Tenant, error) {
 	tenant := m.Tenant{ExternalTenant: accountNumber}
 
-	result := DB.
+	result := DB.Debug().
 		Where("external_tenant = ?", accountNumber).
 		First(&tenant)
 


### PR DESCRIPTION
This pr is probably best viewed by commits - the first commit shows the "real" change, the second is just adding `.Debug()` everywhere.

---

Was wondering why we were logging every SQL query even when log level is set to info, turns out we didn't pass along the config settings in the config struct. Now we are only logging all of the sql queries when something in this list happens:
1. The `LOG_LEVEL` is set to debug
2. The query takes longer than the configured time (2 seconds by default)

This way we lower the log level on stage a bunch. 

---

I also went through and made sure we're tacking debug on every query. There were a few places that were missed. 