### PR TITLE
fix: don't try to create fixtures when cleaning up the test database

### DIFF
--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -91,12 +91,6 @@ func CreateFixtures(schema string) {
 // the database in the previous schema.
 func DoneWithFixtures(schema string) {
 	DropSchema(schema)
-
-	DB.Create(&fixtures.TestApplicationTypeData)
-
-	DB.Create(&fixtures.TestSourceData)
-	DB.Create(&fixtures.TestApplicationData)
-
 	ConnectToTestDB("dao")
 }
 


### PR DESCRIPTION
Apparently this code was forgotten here, which causes some errors when cleaning up the database after the tests have run.