### PR TITLE
[RHCLOUD-17965] Refactor delete returning

### DIFF
--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -1,0 +1,74 @@
+package dao
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// TestDeleteApplicationAuthentication tests that an applicationAuthentication gets correctly deleted, and its data returned.
+func TestDeleteApplicationAuthentication(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("delete")
+
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestSourceData[0].TenantID)
+
+	applicationAuthentication := fixtures.TestApplicationAuthenticationData[0]
+	// Set the ID to 0 to let GORM know it should insert a new applicationAuthentication and not update an existing one.
+	applicationAuthentication.ID = 0
+	// Set some data to compare the returned applicationAuthentication.
+	applicationAuthentication.AuthenticationUID = "complex uuid"
+
+	// Create the test applicationAuthentication.
+	err := applicationAuthenticationDao.Create(&applicationAuthentication)
+	if err != nil {
+		t.Errorf("error creating applicationAuthentication: %s", err)
+	}
+
+	deletedApplicationAuthentication, err := applicationAuthenticationDao.Delete(&applicationAuthentication.ID)
+	if err != nil {
+		t.Errorf("error deleting an applicationAuthentication: %s", err)
+	}
+
+	{
+		want := applicationAuthentication.ID
+		got := deletedApplicationAuthentication.ID
+
+		if want != got {
+			t.Errorf(`incorrect applicationAuthentication deleted. Want id "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := applicationAuthentication.AuthenticationUID
+		got := deletedApplicationAuthentication.AuthenticationUID
+
+		if want != got {
+			t.Errorf(`incorrect applicationAuthentication deleted. Want "%s" in the authenticationUid field, got "%s"`, want, got)
+		}
+	}
+
+	DoneWithFixtures("delete")
+}
+
+// TestDeleteApplicationAuthenticationNotExists tests that when an applicationAuthentication that doesn't exist is tried to be deleted, an error is
+// returned.
+func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("delete")
+
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestSourceData[0].TenantID)
+
+	nonExistentId := int64(12345)
+	_, err := applicationAuthenticationDao.Delete(&nonExistentId)
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("delete")
+}

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -1,11 +1,15 @@
 package dao
 
 import (
+	"bytes"
+	"errors"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 // testApplication holds a test application in order to avoid having to write the "fixtures..." stuff every time.
@@ -60,4 +64,67 @@ func TestResumeApplication(t *testing.T) {
 	}
 
 	DoneWithFixtures("pause_unpause")
+}
+
+// TestDeleteApplication tests that an application gets correctly deleted, and its data returned.
+func TestDeleteApplication(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("delete")
+
+	applicationDao := GetApplicationDao(&fixtures.TestSourceData[0].TenantID)
+
+	application := fixtures.TestApplicationData[0]
+	// Set the ID to 0 to let GORM know it should insert a new application and not update an existing one.
+	application.ID = 0
+	// Set some data to compare the returned application.
+	application.Extra = []byte(`{"hello": "world"}`)
+
+	// Create the test application.
+	err := applicationDao.Create(&application)
+	if err != nil {
+		t.Errorf("error creating application: %s", err)
+	}
+
+	deletedApplication, err := applicationDao.Delete(&application.ID)
+	if err != nil {
+		t.Errorf("error deleting an application: %s", err)
+	}
+
+	{
+		want := application.ID
+		got := deletedApplication.ID
+
+		if want != got {
+			t.Errorf(`incorrect application deleted. Want id "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := application.Extra
+		got := deletedApplication.Extra
+
+		if !bytes.Equal(want, got) {
+			t.Errorf(`incorrect application deleted. Want "%s" in the extra field, got "%s"`, want, got)
+		}
+	}
+
+	DoneWithFixtures("delete")
+}
+
+// TestDeleteApplicationNotExists tests that when an application that doesn't exist is tried to be deleted, an error is
+// returned.
+func TestDeleteApplicationNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("delete")
+
+	applicationDao := GetApplicationDao(&fixtures.TestSourceData[0].TenantID)
+
+	nonExistentId := int64(12345)
+	_, err := applicationDao.Delete(&nonExistentId)
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("delete")
 }

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -1,0 +1,75 @@
+package dao
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// TestDeleteEndpoint tests that an endpoint gets correctly deleted, and its data returned.
+func TestDeleteEndpoint(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("delete")
+
+	endpointDao := GetEndpointDao(&fixtures.TestSourceData[0].TenantID)
+
+	endpoint := fixtures.TestEndpointData[0]
+	// Set the ID to 0 to let GORM know it should insert a new endpoint and not update an existing one.
+	endpoint.ID = 0
+	// Set some data to compare the returned endpoint.
+	host := "example.org"
+	endpoint.Host = &host
+
+	// Create the test endpoint.
+	err := endpointDao.Create(&endpoint)
+	if err != nil {
+		t.Errorf("error creating endpoint: %s", err)
+	}
+
+	deletedEndpoint, err := endpointDao.Delete(&endpoint.ID)
+	if err != nil {
+		t.Errorf("error deleting an endpoint: %s", err)
+	}
+
+	{
+		want := endpoint.ID
+		got := deletedEndpoint.ID
+
+		if want != got {
+			t.Errorf(`incorrect endpoint deleted. Want id "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := host
+		got := deletedEndpoint.Host
+
+		if want != *got {
+			t.Errorf(`incorrect endpoint deleted. Want "%s" in the host field, got "%s"`, want, *got)
+		}
+	}
+
+	DoneWithFixtures("delete")
+}
+
+// TestDeleteEndpointNotExists tests that when an endpoint that doesn't exist is tried to be deleted, an error is
+// returned.
+func TestDeleteEndpointNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("delete")
+
+	endpointDao := GetEndpointDao(&fixtures.TestSourceData[0].TenantID)
+
+	nonExistentId := int64(12345)
+	_, err := endpointDao.Delete(&nonExistentId)
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
+	}
+
+	DoneWithFixtures("delete")
+}

--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -77,12 +77,14 @@ func CreateFixtures(schema string) {
 	DB.Create(&fixtures.TestSourceTypeData)
 
 	DB.Create(&fixtures.TestSourceData)
+	DB.Create(&fixtures.TestEndpointData)
 
 	DB.Create(&fixtures.TestRhcConnectionData)
 	DB.Create(&fixtures.TestSourceRhcConnectionData)
 
 	DB.Create(&fixtures.TestApplicationTypeData)
 	DB.Create(&fixtures.TestApplicationData)
+	DB.Create(&fixtures.TestApplicationAuthenticationData)
 
 	UpdateTablesSequences(schema)
 }
@@ -111,9 +113,11 @@ func MigrateSchema() {
 		&m.MetaData{},
 
 		&m.Source{},
+		&m.Endpoint{},
 		&m.RhcConnection{},
 		&m.SourceRhcConnection{},
 		&m.Application{},
+		&m.ApplicationAuthentication{},
 	)
 
 	if err != nil {
@@ -158,6 +162,10 @@ func UpdateTablesSequences(schema string) {
 		"source_types",
 		"rhc_connections",
 		"tenants",
+		"applications",
+		"endpoints",
+		"rhc_connections",
+		"application_authentications",
 	}
 
 	for _, table := range tables {


### PR DESCRIPTION
This PR replaces the `Delete` methods from the DAOs so that they use SQL's `RETURNING` statement. That way we can spare the "does this resource exist?" query to the database.

**Note:** requires https://github.com/RedHatInsights/sources-api-go/pull/167 to be merged first.

## Links

[[RHCLOUD-17965]](https://issues.redhat.com/browse/RHCLOUD-17965)