### PR TITLE
[RHCLOUD-17965] Add Oracle Cloud Infraestructure as a new source

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -35,6 +35,7 @@
   - amazon
   - azure
   - google
+  - oracle-cloud-infraestructure
   - openshift
   - ibm
   supported_authentication_types:
@@ -46,6 +47,8 @@
     - project_id_service_account_json
     openshift:
     - token
+    oracle-cloud-infraestructure:
+    - ocid
     ibm:
     - api_token_account_id
 "/insights/platform/cloud-meter":

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -293,7 +293,27 @@ gitlab:
           - component: text-field
             name: authentication.password
             label: Personal Acces Token for the GitLab account
-
+oracle-cloud-infrastructure:
+  product_name: Oracle Cloud Infrastructure
+  vendor: Oracle
+  schema:
+    authentication:
+      - type: ocid
+        name: Oracle Cloud ID (OCID)
+        fields:
+          - component: text-field
+            hideField: true
+            initializeOnMount: true
+            initialValue: ocid
+            name: authentication.authtype
+          - component: text-field
+            isRequired: true
+            label: Oracle Cloud ID (OCID)
+            name: authentication.username
+            validate:
+              - type: required
+              - type: pattern
+                pattern: "^ocid1\\..*"
 openshift:
   product_name: Red Hat OpenShift Container Platform
   schema:


### PR DESCRIPTION
Adds Oracle Cloud Infraestructure as a source, by supporting the [Oracle Cloud IDs (OCIDs)](https://docs.oracle.com/en-us/iaas/Content/General/Concepts/identifiers.htm)

## Links

[[RHCLOUD-17965]](https://issues.redhat.com/browse/RHCLOUD-17965)