### PR TITLE
add new line to standard error output

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,7 +112,7 @@ func Get() *SourcesApiConfig {
 
 	err := fs.Parse(os.Args[1:])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error parsing flags: %v", err)
+		fmt.Fprintf(os.Stderr, "error parsing flags: %v\n", err)
 	}
 
 	options.SetDefault("StatusListener", *availabilityListener)


### PR DESCRIPTION
without JIRA ticket

I had interesting troubles in Golang with tests results. My test results tab didn't contain all tests.
e.g. here I ran 4 tests, but only 3 are visible:
![image](https://user-images.githubusercontent.com/89980168/158993028-7a1a9a97-9157-4ae6-89c1-3582b56058cc.png)

and console output:
```
flag provided but not defined: -test.v
Usage of runtime:
  -listener
    	run availability status listener
error parsing flags: flag provided but not defined: -test.v=== RUN   TestInternalAuthenticationGet
    internal_handlers_test.go:36: Did not return 200
    internal_handlers_test.go:46: ghosts infected the return
=== RUN   TestInternalAuthenticationGetNotFound
--- PASS: TestInternalAuthenticationGetNotFound (0.00s)
```

focus on `-test.v=== RUN`
it seems that because here is not line indent, the Golang incorrectly shows the test results

same test after change:
![image](https://user-images.githubusercontent.com/89980168/158993625-34023fb8-dc50-4231-8b31-50ab8777fc8e.png)
