### PR TITLE
[RHCLOUD-18512] fix: external tenant not being included in availability status requests

### DIFF
--- a/source_handlers.go
+++ b/source_handlers.go
@@ -305,6 +305,7 @@ func SourceCheckAvailability(c echo.Context) error {
 		"Applications",
 		"Applications.ApplicationType",
 		"Endpoints",
+		"Endpoints.Tenant",
 		"Tenant",
 	)
 	if err != nil {


### PR DESCRIPTION
The availability status requester we've got is not appending the correct account number to the "update the availability status for this endpoint" requests.

1. The handler preloads a source with some of its relations on `source_hanlders.go#SourceCheckAvailability`. More specifically, it preloads `source types`, `applications`, `applications.applicationtypes`, `endpoints`, `tenant`.

https://github.com/RedHatInsights/sources-api-go/blob/6116014febaa7e16ee81e2284303c4c70441890a/source_handlers.go#L303-L309

2. On the `service/availability_check.go#publishSatelliteMessage` though, the `source.endpoint.tenant` relation is accessed, which hasn't been preloaded.

https://github.com/RedHatInsights/sources-api-go/blob/6116014febaa7e16ee81e2284303c4c70441890a/service/availability_check.go#L146-L149

This causes the header not to have the `r-xh-identity` or `x-rh-sources-account-number` filled with the correct account number.


## Links

[[RHCLOUD-18512]](https://issues.redhat.com/browse/RHCLOUD-18512)