### PR TITLE
[RHCLOUD-15003] Remove old active record migrations table

### DIFF
--- a/db/migrations/20220705100000_remove_old_migrations_table.go
+++ b/db/migrations/20220705100000_remove_old_migrations_table.go
@@ -1,0 +1,54 @@
+package migrations
+
+import (
+	"time"
+
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// RemoveOldMigrationsTable removes the ActiveRecord migrations table.
+func RemoveOldMigrationsTable() *gormigrate.Migration {
+	type schemaMigrations struct {
+		Version string `gorm:"primaryKey;type:varchar"`
+	}
+
+	type arInternalMetadata struct {
+		Key       string    `gorm:"primaryKey;type:varchar;not null"`
+		Value     string    `gorm:"type:varchar"`
+		CreatedAt time.Time `gorm:"type:timestamp"`
+		UpdatedAt time.Time `gorm:"type:timestamp"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220705100000",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "remove old migrations table" started`)
+			defer logging.Log.Info(`Migration "remove old migrations table" ended`)
+
+			err := db.Transaction(func(tx *gorm.DB) error {
+				err := tx.Migrator().DropTable(&schemaMigrations{})
+				if err != nil {
+					return err
+				}
+
+				err = tx.Migrator().DropTable(&arInternalMetadata{})
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Transaction(func(tx *gorm.DB) error {
+				return tx.Migrator().AutoMigrate(&schemaMigrations{}, &arInternalMetadata{})
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -24,6 +24,7 @@ var MigrationsCollection = []*gormigrate.Migration{
 	AddUserIdColumnIntoTables(),
 	AddResourceOwnershipToApplicationTypes(),
 	AddApplicationConstraint(),
+	RemoveOldMigrationsTable(),
 }
 
 var ctx = context.Background()


### PR DESCRIPTION
This PR adds a migration to remove the old ActiveRecord migrations table from the database, since we are not going to use it anymore.

## Links

https://issues.redhat.com/browse/RHCLOUD-15003