### PR TITLE
Add Proxy of /graphql over to rails application

### DIFF
--- a/graphql_handlers.go
+++ b/graphql_handlers.go
@@ -4,23 +4,47 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"os"
 	"time"
 
+	l "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/labstack/echo/v4"
 )
 
+// this is the uri to hit "old" sources api, initialized in the init() function
+var legacyUri string
+
+// set the default host/port to what we'll see in k8s environments. Override
+// this by setting these values locally
+func init() {
+	legacyHost := os.Getenv("RAILS_HOST")
+	if legacyHost == "" {
+		legacyHost = "sources-api-svc"
+	}
+
+	legacyPort := os.Getenv("RAILS_PORT")
+	if legacyPort == "" {
+		legacyPort = "8000"
+	}
+
+	legacyUri = "http://" + legacyHost + ":" + legacyPort + "/api/sources/v3.1/graphql"
+}
+
+// this handler proxies the graphql request body + headers included over to the
+// legacy rails side.
+//
+// it will probably sit here for quite a while - basically until we decide to
+// implement graphql on the golang side which is a very low priority.
 func ProxyGraphqlToLegacySources(c echo.Context) error {
+	l.Log.Debugf("Proxying /graphql to [%v]", legacyUri)
+
 	// set up a context with the parent as the request - limiting execution time to 10 seconds
 	ctx, cancel := context.WithTimeout(c.Request().Context(), 10*time.Second)
 	defer cancel()
 
-	// create a request - using the body as the post body
-	req, err := http.NewRequestWithContext(ctx,
-		http.MethodPost,
-		"http://localhost:3002/api/sources/v3.1/graphql",
-		c.Request().Body,
-	)
+	// create a request - passing the body right along
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, legacyUri, c.Request().Body)
 	if err != nil {
 		return err
 	}
@@ -29,6 +53,9 @@ func ProxyGraphqlToLegacySources(c echo.Context) error {
 	for _, h := range service.ForwadableHeaders(c) {
 		req.Header.Add(h.Key, string(h.Value))
 	}
+
+	// add the content-type header, rails won't pick up the body otherwise
+	req.Header.Add("Content-Type", "application/json")
 
 	// run the request!
 	resp, err := http.DefaultClient.Do(req)

--- a/graphql_handlers.go
+++ b/graphql_handlers.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/RedHatInsights/sources-api-go/service"
+	"github.com/labstack/echo/v4"
+)
+
+func ProxyGraphqlToLegacySources(c echo.Context) error {
+	// set up a context with the parent as the request - limiting execution time to 10 seconds
+	ctx, cancel := context.WithTimeout(c.Request().Context(), 10*time.Second)
+	defer cancel()
+
+	// create a request - using the body as the post body
+	req, err := http.NewRequestWithContext(ctx,
+		http.MethodPost,
+		"http://localhost:3002/api/sources/v3.1/graphql",
+		c.Request().Body,
+	)
+	if err != nil {
+		return err
+	}
+
+	// fetch the headers to forward along
+	for _, h := range service.ForwadableHeaders(c) {
+		req.Header.Add(h.Key, string(h.Value))
+	}
+
+	// run the request!
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return c.JSONBlob(resp.StatusCode, bytes)
+}

--- a/routes.go
+++ b/routes.go
@@ -94,6 +94,9 @@ func setupRoutes(e *echo.Echo) {
 	v3.DELETE("/rhc_connections/:id", RhcConnectionDelete, permissionMiddleware...)
 	v3.GET("/rhc_connections/:id/sources", RhcConnectionSourcesList, permissionWithListMiddleware...)
 
+	// GraphQL
+	v3.POST("/graphql", ProxyGraphqlToLegacySources)
+
 	/**            **\
 	 * Internal API *
 	\**            **/


### PR DESCRIPTION
Pretty simple, just proxying a `POST /graphql` request over to the rails side.

\# TODO:
- [x] initial proxying
- [x] store rails URL in ENV