### PR TITLE
Skip marshaling OpenAPI JSON when reading from disk/embed

### DIFF
--- a/openapi_handlers.go
+++ b/openapi_handlers.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"embed"
-	"encoding/json"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -12,25 +11,14 @@ import (
 var publicDocs embed.FS
 
 func PublicOpenApiv31(c echo.Context) error {
-	out, err := readOpenApiJson("public/openapi-3-v3.1.json")
+	bytes, err := readOpenApiJson("public/openapi-3-v3.1.json")
 	if err != nil {
 		return err
 	}
 
-	return c.JSON(http.StatusOK, out)
+	return c.JSONBlob(http.StatusOK, bytes)
 }
 
-func readOpenApiJson(filename string) (map[string]interface{}, error) {
-	bytes, err := publicDocs.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-
-	out := make(map[string]interface{})
-	err = json.Unmarshal(bytes, &out)
-	if err != nil {
-		return nil, err
-	}
-
-	return out, nil
+func readOpenApiJson(filename string) ([]byte, error) {
+	return publicDocs.ReadFile(filename)
 }


### PR DESCRIPTION
Found out as in #176 we can use `c.JSONBlob(...)` instead of re-marshaling the JSON when we are reading from disk or a response etc. 

Basically we use this function only when we know the bytes are already JSON. 