### PR TITLE
fix: typo in "product name"

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -237,7 +237,7 @@ bitbucket:
             name: authentication.password
             label: App password for the Bitbucket account
 dockerhub:
-  prodcut_name: Docker Hub
+  product_name: Docker Hub
   vendor: Docker
   schema:
     authentication:


### PR DESCRIPTION
I wrote `prodcut_name` instead of `product_name` :facepalm: 