### PR TITLE
[RHCLOUD-18600] feature: categorize source types in different categories

### DIFF
--- a/dao/seeding.go
+++ b/dao/seeding.go
@@ -88,6 +88,7 @@ func seedSourceTypes() error {
 		}
 
 		// mark the fields as updated
+		st.Category = values.Category
 		st.ProductName = values.ProductName
 		st.IconUrl = values.IconURL
 		st.Schema = schema

--- a/dao/seeding_types.go
+++ b/dao/seeding_types.go
@@ -9,6 +9,7 @@ type (
 )
 
 type sourceTypeSeed struct {
+	Category    string      `json:"category"`
 	ProductName string      `json:"product_name"`
 	Schema      interface{} `json:"schema"`
 	Vendor      string      `json:"vendor"`

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -1,6 +1,7 @@
 ---
 amazon:
   product_name: Amazon Web Services
+  category: Cloud
   schema:
     authentication:
     - type: access_key_secret_key
@@ -77,6 +78,7 @@ amazon:
   icon_url: "/apps/frontend-assets/partners-icons/aws-long.svg"
 ansible-tower:
   product_name: Red Hat Ansible Automation Platform
+  category: Red Hat
   vendor: Red Hat
   icon_url: "/apps/frontend-assets/platform-logos/ansible-automation-platform.svg"
   schema:
@@ -126,6 +128,7 @@ ansible-tower:
           is: true
 google:
   product_name: Google Cloud
+  category: Cloud
   vendor: Google
   icon_url: "/apps/frontend-assets/partners-icons/google-cloud.svg"
   schema:
@@ -161,6 +164,7 @@ google:
         initialValue: google
 azure:
   product_name: Microsoft Azure
+  category: Cloud
   vendor: Azure
   icon_url: "/apps/chrome/assets/images/partners-icons/microsoft-azure.svg"
   schema:
@@ -219,6 +223,7 @@ azure:
         initialValue: azure
 bitbucket:
   product_name: Bitbucket
+  category: Developer sources
   vendor: Atlassian
   schema:
     authentication:
@@ -238,6 +243,7 @@ bitbucket:
             label: App password for the Bitbucket account
 dockerhub:
   product_name: Docker Hub
+  category: Developer sources
   vendor: Docker
   schema:
     authentication:
@@ -257,6 +263,7 @@ dockerhub:
             label: Acces Token for the Docker Hub account
 github:
   product_name: GitHub
+  category: Developer sources
   vendor: Microsoft
   schema:
     authentication:
@@ -276,6 +283,7 @@ github:
             label: Personal Acces Token (PAT) for the GitHub account
 gitlab:
   product_name: GitLab
+  category: Developer sources
   vendor: GitLab
   schema:
     authentication:
@@ -294,6 +302,7 @@ gitlab:
             name: authentication.password
             label: Personal Acces Token for the GitLab account
 oracle-cloud-infrastructure:
+  category: Cloud
   product_name: Oracle Cloud Infrastructure
   vendor: Oracle
   schema:
@@ -316,6 +325,7 @@ oracle-cloud-infrastructure:
                 pattern: "^ocid1\\..*"
 openshift:
   product_name: Red Hat OpenShift Container Platform
+  category: Red Hat
   schema:
     authentication:
     - type: token
@@ -363,6 +373,7 @@ openshift:
   icon_url: "/apps/frontend-assets/platform-logos/openshift-container-platform.svg"
 quay:
   product_name: Quay
+  category: Developer sources
   vendor: Red Hat
   schema:
     authentication:
@@ -382,6 +393,7 @@ quay:
             label: Quay account's encrypted password
 rh-marketplace:
   product_name: Red Hat Marketplace
+  category: Red Hat
   vendor: Red Hat
   schema:
     authentication:
@@ -401,6 +413,7 @@ rh-marketplace:
         - type: required
 satellite:
   product_name: Red Hat Satellite
+  category: Red Hat
   vendor: Red Hat
   schema:
     authentication:
@@ -432,6 +445,7 @@ satellite:
   icon_url: "/apps/frontend-assets/platform-logos/satellite.svg"
 ibm:
   product_name: IBM Cloud
+  category: Cloud
   vendor: IBM
   icon_url: "/apps/frontend-assets/partners-icons/ibm-cloud.svg"
   schema:

--- a/db/migrations/20220413120000_sources_add_category_column.go
+++ b/db/migrations/20220413120000_sources_add_category_column.go
@@ -1,0 +1,107 @@
+package migrations
+
+import (
+	_ "embed"
+
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// SourceTypesAddCategoryColumn adds a "category" column to the "source_types" table. The column will have a "not null"
+// constraint, so for that the migration performs three steps inside the transaction:
+//
+// 1. Creates the column with the not null constraint and defaults it to "Cloud".
+// 2. Loops through all the source types and updates them with their corresponding category name.
+// 3. Removes the default value for the column.
+func SourceTypesAddCategoryColumn() *gormigrate.Migration {
+	type SourceType struct {
+		Category string `gorm:"column:category;comment:Category of the source;default:Cloud;not null;"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220413120000",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "source types: add category column" started`)
+			defer logging.Log.Info(`Migration "source types: add category column" ended`)
+
+			err := db.Debug().Transaction(func(tx *gorm.DB) error {
+				// Create the new column.
+				err := tx.AutoMigrate(&SourceType{})
+				if err != nil {
+					return err
+				}
+
+				// Find all the source types to be updated.
+				var dbSourceTypes []model.SourceType
+				err = tx.
+					Model(&SourceType{}).
+					Find(&dbSourceTypes).
+					Error
+
+				if err != nil {
+					return err
+				}
+
+				// Update the category column for each source type.
+				for _, sourceType := range dbSourceTypes {
+					switch sourceType.Name {
+					case "amazon":
+						sourceType.Category = model.CategoryCloud
+					case "ansible-tower":
+						sourceType.Category = model.CategoryRedhat
+					case "azure":
+						sourceType.Category = model.CategoryCloud
+					case "bitbucket":
+						sourceType.Category = model.CategoryDeveloperSources
+					case "dockerhub":
+						sourceType.Category = model.CategoryDeveloperSources
+					case "github":
+						sourceType.Category = model.CategoryDeveloperSources
+					case "gitlab":
+						sourceType.Category = model.CategoryDeveloperSources
+					case "google":
+						sourceType.Category = model.CategoryCloud
+					case "ibm":
+						sourceType.Category = model.CategoryCloud
+					case "openshift":
+						sourceType.Category = model.CategoryRedhat
+					case "oracle-cloud-infrastructure":
+						sourceType.Category = model.CategoryCloud
+					case "quay":
+						sourceType.Category = model.CategoryDeveloperSources
+					case "rh-marketplace":
+						sourceType.Category = model.CategoryRedhat
+					case "satellite":
+						sourceType.Category = model.CategoryRedhat
+					}
+
+					err = tx.
+						Updates(sourceType).
+						Error
+
+					if err != nil {
+						return err
+					}
+				}
+
+				// Remove the default value for the column.
+				err = tx.
+					Exec(`ALTER TABLE "source_types" ALTER COLUMN "category" DROP DEFAULT`).
+					Error
+
+				return err
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Transaction(func(tx *gorm.DB) error {
+				return tx.Migrator().DropColumn(&SourceType{}, "category")
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -12,6 +12,7 @@ import (
 
 var migrationsCollection = []*gormigrate.Migration{
 	InitialSchema(),
+	SourceTypesAddCategoryColumn(),
 }
 
 // redisLockKey is the key which will be used for the Redis lock when performing the migrations.

--- a/model/source_type.go
+++ b/model/source_type.go
@@ -10,12 +10,17 @@ import (
 	"gorm.io/datatypes"
 )
 
+const CategoryCloud = "Cloud"
+const CategoryDeveloperSources = "Developer sources"
+const CategoryRedhat = "Red Hat"
+
 type SourceType struct {
 	//fields for gorm
 	Id        int64     `gorm:"primarykey" json:"id"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 
+	Category     string            `json:"category"`
 	Name         string            `json:"name"`
 	ProductName  string            `json:"product_name"`
 	Vendor       string            `json:"vendor"`
@@ -34,6 +39,7 @@ func (st *SourceType) ToResponse() *SourceTypeResponse {
 		Id:          id,
 		CreatedAt:   util.DateTimeToRFC3339(st.CreatedAt),
 		UpdatedAt:   util.DateTimeToRFC3339(st.UpdatedAt),
+		Category:    st.Category,
 		Name:        st.Name,
 		ProductName: st.ProductName,
 		Vendor:      st.Vendor,

--- a/model/source_type_http.go
+++ b/model/source_type_http.go
@@ -10,6 +10,7 @@ type SourceTypeResponse struct {
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
 
+	Category    string         `json:"category"`
 	Name        string         `json:"name"`
 	ProductName string         `json:"product_name"`
 	Vendor      string         `json:"vendor"`


### PR DESCRIPTION
Due to the considerable number of source types we currently support, the UI is getting a little bit confusing. The aim of adding a new "category" field is to make it easier for the UI team to better organize how the source types are displayed.

## Links

[[RHCLOUD-18600]](https://issues.redhat.com/browse/RHCLOUD-18600)