### PR TITLE
Clean up authentications when the subresource is deleted

### DIFF
--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	l "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"gorm.io/gorm/clause"
@@ -126,6 +127,11 @@ func (a *applicationDaoImpl) Delete(id *int64) (*m.Application, error) {
 
 	if result.RowsAffected == 0 {
 		return nil, util.NewErrNotFound("application")
+	}
+
+	err := GetAuthenticationDao(a.TenantID).Cleanup("Application", *id)
+	if err != nil {
+		l.Log.Warnf("error cleaning up authentications: %v", err)
 	}
 
 	return &application, nil

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	l "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"gorm.io/gorm/clause"
@@ -115,6 +116,11 @@ func (a *endpointDaoImpl) Delete(id *int64) (*m.Endpoint, error) {
 
 	if result.RowsAffected == 0 {
 		return nil, util.NewErrNotFound("endpoint")
+	}
+
+	err := GetAuthenticationDao(a.TenantID).Cleanup("Endpoint", *id)
+	if err != nil {
+		l.Log.Warnf("error cleaning up authentications: %v", err)
 	}
 
 	return &endpoint, nil

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -66,6 +66,7 @@ type AuthenticationDao interface {
 	BulkMessage(resource util.Resource) (map[string]interface{}, error)
 	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error
 	ToEventJSON(resource util.Resource) ([]byte, error)
+	Cleanup(string, int64) error
 }
 
 type ApplicationAuthenticationDao interface {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -692,6 +692,10 @@ func (m MockAuthenticationDao) Delete(id string) (*m.Authentication, error) {
 	return nil, util.NewErrNotFound("authentication")
 }
 
+func (m MockAuthenticationDao) Cleanup(rt string, rid int64) error {
+	panic("implement me")
+}
+
 func (m MockAuthenticationDao) Tenant() *int64 {
 	panic("implement me")
 }

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	l "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"gorm.io/gorm"
@@ -163,6 +164,11 @@ func (s *sourceDaoImpl) Delete(id *int64) (*m.Source, error) {
 
 	if result.RowsAffected == 0 {
 		return nil, util.NewErrNotFound("source")
+	}
+
+	err := GetAuthenticationDao(s.TenantID).Cleanup("Source", *id)
+	if err != nil {
+		l.Log.Warnf("error cleaning up authentications: %v", err)
 	}
 
 	return &source, nil

--- a/internal/testutils/mocks/mock_vault.go
+++ b/internal/testutils/mocks/mock_vault.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -17,7 +18,7 @@ var VaultPath = []string{fmt.Sprintf("Application_%d_%v", fixtures.TestTenantDat
 
 func (m *MockVault) Read(path string) (*api.Secret, error) {
 	if path != fmt.Sprintf("secret/data/%d/%v", fixtures.TestTenantData[0].Id, VaultPath[0]) {
-		return nil, nil
+		return nil, errors.New("boom")
 	}
 
 	secret := &api.Secret{}

--- a/main_test.go
+++ b/main_test.go
@@ -49,8 +49,6 @@ func TestMain(t *testing.M) {
 		getApplicationAuthenticationDao = getApplicationAuthenticationDaoWithTenant
 		getAuthenticationDao = getAuthenticationDaoWithTenant
 
-		dao.Vault = &mocks.MockVault{}
-
 		// Set up marketplace's token management functions
 		dao.GetMarketplaceTokenCacher = dao.GetMarketplaceTokenCacherWithTenantId
 
@@ -83,6 +81,8 @@ func TestMain(t *testing.M) {
 		getAuthenticationDao = func(c echo.Context) (dao.AuthenticationDao, error) { return mockAuthenticationDao, nil }
 
 	}
+
+	dao.Vault = &mocks.MockVault{}
 
 	code := t.Run()
 


### PR DESCRIPTION
Now that we've sharded our data - we need to clean up the vault db whenever something is deleted. 

I did this in the dao layer that way it's mostly transparent from the handlers. 

---

NOTE: ~this is only necessary for the vault store. The foreign keys should handle it for authentications~ I'm wrong.  