### PR TITLE
Add support for subresource filtering operations

### DIFF
--- a/dao/filtering.go
+++ b/dao/filtering.go
@@ -15,46 +15,59 @@ func applyFilters(query *gorm.DB, filters []util.Filter) (*gorm.DB, error) {
 			return nil, fmt.Errorf("failed to parse statement: %v", err)
 		}
 	}
+
 	var filterName string
 	for _, filter := range filters {
-		if query.Statement.Table != "" {
+		// subresource filtering!
+		if filter.Subresource != "" {
+			switch filter.Subresource {
+			case "source_type":
+				query = query.Joins("SourceType")
+				filterName = fmt.Sprintf("%v.%v", `"SourceType"`, filter.Name)
+			case "application_type":
+				query = query.Joins("ApplicationType")
+				filterName = fmt.Sprintf("%v.%v", `"ApplicationType"`, filter.Name)
+			default:
+				return nil, fmt.Errorf("invalid subresource type [%v]", filter.Subresource)
+			}
+		} else if query.Statement.Table != "" {
 			filterName = fmt.Sprintf("%v.%v", query.Statement.Table, filter.Name)
 		} else {
 			filterName = filter.Name
 		}
 
 		switch filter.Operation {
-		case "", "[eq]":
+		case "", "eq":
 			query = query.Where(fmt.Sprintf("%v = ?", filterName), filter.Value[0])
-		case "[not_eq]":
+		case "not_eq":
 			query = query.Where(fmt.Sprintf("%v != ?", filterName), filter.Value[0])
-		case "[gt]":
+		case "gt":
 			query = query.Where(fmt.Sprintf("%v > ?", filterName), filter.Value[0])
-		case "[gte]":
+		case "gte":
 			query = query.Where(fmt.Sprintf("%v >= ?", filterName), filter.Value[0])
-		case "[lt]":
+		case "lt":
 			query = query.Where(fmt.Sprintf("%v < ?", filterName), filter.Value[0])
-		case "[lte]":
+		case "lte":
 			query = query.Where(fmt.Sprintf("%v <= ?", filterName), filter.Value[0])
-		case "[nil]":
+		case "nil":
 			query = query.Where(fmt.Sprintf("%v IS NULL", filterName))
-		case "[not_nil]":
+		case "not_nil":
 			query = query.Where(fmt.Sprintf("%v IS NOT NULL", filterName))
-		case "[contains]":
+		case "contains":
 			query = query.Where(fmt.Sprintf("%v LIKE ?", filterName), fmt.Sprintf("%%%s%%", filter.Value[0]))
-		case "[starts_with]":
+		case "starts_with":
 			query = query.Where(fmt.Sprintf("%v LIKE ?", filterName), fmt.Sprintf("%s%%", filter.Value[0]))
-		case "[ends_with]":
+		case "ends_with":
 			query = query.Where(fmt.Sprintf("%v LIKE ?", filterName), fmt.Sprintf("%%%s", filter.Value[0]))
-		case "[eq_i]":
+		case "eq_i":
 			query = query.Where(fmt.Sprintf("LOWER(%v) = ?", filterName), strings.ToLower(filter.Value[0]))
-		case "[not_eq_i]":
+		case "not_eq_i":
 			query = query.Where(fmt.Sprintf("LOWER(%v) != ?", filterName), strings.ToLower(filter.Value[0]))
-		case "[contains_i]":
+		case "contains_i":
 			query = query.Where(fmt.Sprintf("%v ILIKE ?", filterName), fmt.Sprintf("%%%s%%", filter.Value[0]))
-		case "[starts_with_i]":
+		case "starts_with_i":
 			query = query.Where(fmt.Sprintf("%v ILIKE ?", filterName), fmt.Sprintf("%s%%", filter.Value[0]))
-		case "[ends_with_i]":
+		case "ends_with_i":
 			query = query.Where(fmt.Sprintf("%v ILIKE ?", filterName), fmt.Sprintf("%%%s", filter.Value[0]))
 		case "sort_by":
 			query = query.Order(filter.Value[0])

--- a/dao/filtering.go
+++ b/dao/filtering.go
@@ -22,9 +22,17 @@ func applyFilters(query *gorm.DB, filters []util.Filter) (*gorm.DB, error) {
 		if filter.Subresource != "" {
 			switch filter.Subresource {
 			case "source_type":
+				if query.Statement.Table != "sources" {
+					return nil, fmt.Errorf("cannot filter based on source_type subresource for table %q", query.Statement.Table)
+				}
+
 				query = query.Joins("SourceType")
 				filterName = fmt.Sprintf("%v.%v", `"SourceType"`, filter.Name)
 			case "application_type":
+				if query.Statement.Table != "applications" {
+					return nil, fmt.Errorf("cannot filter based on application_type subresource for table %q", query.Statement.Table)
+				}
+
 				query = query.Joins("ApplicationType")
 				filterName = fmt.Sprintf("%v.%v", `"ApplicationType"`, filter.Name)
 			default:

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -13,7 +13,7 @@ var e *echo.Echo
 var conf = config.Get()
 
 func TestParseFilterWithOperation(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?filter[name][eq]=test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[name][eq]=test", nil)
 	c := e.NewContext(req, nil)
 
 	filters := parseFilter(c)
@@ -28,7 +28,7 @@ func TestParseFilterWithOperation(t *testing.T) {
 		t.Error("did not parse field name correctly")
 	}
 
-	if f.Operation != "[eq]" {
+	if f.Operation != "eq" {
 		t.Error("did not parse operation correctly")
 	}
 

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -107,3 +107,61 @@ func TestParseSortingMultiple(t *testing.T) {
 		t.Error("sort[1] value did not get parsed correctly")
 	}
 }
+
+func TestParseSubresourceFilterWithOperation(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[source_type][name][eq]=test", nil)
+	c := e.NewContext(req, nil)
+
+	filters := parseFilter(c)
+
+	if len(filters) != 1 {
+		t.Error("wrong number of filters")
+	}
+
+	f := filters[0]
+
+	if f.Subresource != "source_type" {
+		t.Error("did not parse subresource correctly")
+	}
+
+	if f.Name != "name" {
+		t.Error("did not parse field name correctly")
+	}
+
+	if f.Operation != "eq" {
+		t.Error("did not parse operation correctly")
+	}
+
+	if f.Value[0] != "test" {
+		t.Error("did not parse value correctly")
+	}
+}
+
+func TestParseSubresourceFilterWithoutOperation(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?filter[source_type][name]=test", nil)
+	c := e.NewContext(req, nil)
+
+	filters := parseFilter(c)
+
+	if len(filters) != 1 {
+		t.Error("wrong number of filters")
+	}
+
+	f := filters[0]
+
+	if f.Subresource != "source_type" {
+		t.Error("did not parse subresource correctly")
+	}
+
+	if f.Name != "name" {
+		t.Error("did not parse field name correctly")
+	}
+
+	if f.Operation != "" {
+		t.Error("did not parse operation correctly")
+	}
+
+	if f.Value[0] != "test" {
+		t.Error("did not parse value correctly")
+	}
+}

--- a/util/filtering.go
+++ b/util/filtering.go
@@ -2,10 +2,23 @@ package util
 
 import "regexp"
 
-var FilterRegex = regexp.MustCompile(`^filter\[(\w+)](\[\w*]|$)`)
+// Simple regex - which matches only the characters.
+// the filters would come in like this:
+//
+// filter[name][eq]
+// or
+// filter[source_type][name][eq]
+//
+// and get matched as:
+//
+// ["filter", "name", "eq"]
+// or
+// ["filter", "source_type", "name", "eq"]
+var FilterRegex = regexp.MustCompile(`\w+`)
 
 type Filter struct {
-	Name      string
-	Operation string
-	Value     []string
+	Subresource string
+	Name        string
+	Operation   string
+	Value       []string
 }


### PR DESCRIPTION
This adds support for filtering sources or applications based on their types. This is used by GraphQL as well as some random requests that come from consoledot. 

example syntax:

```
GET /api/sources/v3.1/sources?filter[source_type][name]=amazon
```
would list the sources that have the amazon source type.

---

The biggest change was in the parsing - rather than using a fancy regex to try and parse whats between the brackets we just match the whitespace to ignore them and build out the struct appropriately. Comments explain what the input/output looks like.