### PR TITLE
Add created_at to Authentication Model storage

### DIFF
--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -264,6 +264,7 @@ func (a *authenticationDaoImpl) Create(auth *m.Authentication) error {
 	}
 
 	auth.ID = uuid.New().String()
+	auth.CreatedAt = time.Now()
 	path := fmt.Sprintf("secret/data/%d/%s_%v_%s", *a.TenantID, auth.ResourceType, auth.ResourceID, auth.ID)
 
 	data, err := auth.ToVaultMap()
@@ -290,6 +291,7 @@ func (a *authenticationDaoImpl) Create(auth *m.Authentication) error {
 // source ID is set beforehand.
 func (a *authenticationDaoImpl) BulkCreate(auth *m.Authentication) error {
 	auth.ID = uuid.New().String()
+	auth.CreatedAt = time.Now()
 	path := fmt.Sprintf("secret/data/%d/%s_%v_%s", *a.TenantID, auth.ResourceType, auth.ResourceID, auth.ID)
 
 	data, err := auth.ToVaultMap()

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -100,6 +100,7 @@ func (auth *Authentication) ToVaultMap() (map[string]interface{}, error) {
 		"resource_type":             auth.ResourceType,
 		"resource_id":               strconv.FormatInt(auth.ResourceID, 10),
 		"source_id":                 strconv.FormatInt(auth.SourceID, 10),
+		"created_at":                auth.CreatedAt,
 	}
 
 	// Vault requires the hash to be wrapped in a "data" object in order to be accepted.


### PR DESCRIPTION
1. ~Returning the actual error if the relationship object fails to be created - rather than it bubbling up to not found~ this broke tests, don't feel like refactoring it. 
2. Setting created_at everywhere in the authDAO
3. ~Added support for pointers in the relationship object since it was bubbling up errors like the first point and was very confusing that pointers didn't work.~ 