### PR TITLE
sources test update

### DIFF
--- a/internal/testutils/fixtures/source.go
+++ b/internal/testutils/fixtures/source.go
@@ -8,6 +8,7 @@ var (
 	uid1 = "5eebe172-7baa-4280-823f-19e597d091e9"
 	uid2 = "31b5338b-685d-4056-ba39-d00b4d7f19cc"
 	uid3 = "36be1c27-ef96-42b0-9a13-72240b18cf83"
+	uid4 = "1c8b6c9a-af40-11ec-b909-0242ac120002"
 )
 
 var TestSourceData = []m.Source{
@@ -34,5 +35,13 @@ var TestSourceData = []m.Source{
 		TenantID:           1,
 		AvailabilityStatus: m.AvailabilityStatus{AvailabilityStatus: "available"},
 		Uid:                &uid3,
+	},
+	{
+		ID:                 4,
+		Name:               "Source4",
+		SourceTypeID:       2,
+		TenantID:           1,
+		AvailabilityStatus: m.AvailabilityStatus{AvailabilityStatus: "available"},
+		Uid:                &uid4,
 	},
 }

--- a/internal/testutils/fixtures/source_type.go
+++ b/internal/testutils/fixtures/source_type.go
@@ -7,4 +7,12 @@ var TestSourceTypeData = []m.SourceType{
 		Id:   1,
 		Name: "amazon",
 	},
+	{
+		Id:   2,
+		Name: "google",
+	},
+	{
+		Id:   100,
+		Name: "source type without sources in fixtures",
+	},
 }

--- a/source_type_handlers_test.go
+++ b/source_type_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -48,7 +49,7 @@ func TestSourceTypeList(t *testing.T) {
 		t.Error("offset not set correctly")
 	}
 
-	if len(out.Data) != 1 {
+	if len(out.Data) != len(fixtures.TestSourceTypeData) {
 		t.Error("not enough objects passed back from DB")
 	}
 
@@ -57,8 +58,7 @@ func TestSourceTypeList(t *testing.T) {
 		if !ok {
 			t.Error("model did not deserialize as a application type response")
 		}
-
-		if s["name"] != "amazon" {
+		if s["id"] == 1 && s["name"] != "amazon" {
 			t.Error("ghosts infected the return")
 		}
 	}


### PR DESCRIPTION
without JIRA ticket

added test for subcollection (`api/sources/v3.1/source_types/1/sources`) when source type exists and we don't have any source with this source type ... then expected is status OK and empty list of sources in response
+
small update - now adding new fixtures with different source type will not affect the changed tests
