### PR TITLE
[RHCLOUD-18651] EAN to OrgId migration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type SourcesApiConfig struct {
 	MigrationsSetup           bool
 	MigrationsReset           bool
 	SecretStore               string
+	TenantTranslatorUrl       string
 }
 
 // Get - returns the config parsed from runtime vars
@@ -121,6 +122,7 @@ func Get() *SourcesApiConfig {
 		secretStore = "database"
 	}
 	options.SetDefault("SecretStore", secretStore)
+	options.SetDefault("TenantTranslatorUrl", os.Getenv("TENANT_TRANSLATOR_URL"))
 
 	// Parse any Flags (using our own flag set to not conflict with the global flag)
 	fs := flag.NewFlagSet("runtime", flag.ContinueOnError)
@@ -184,6 +186,7 @@ func Get() *SourcesApiConfig {
 		MigrationsSetup:           options.GetBool("MigrationsSetup"),
 		MigrationsReset:           options.GetBool("MigrationsReset"),
 		SecretStore:               options.GetString("SecretStore"),
+		TenantTranslatorUrl:       options.GetString("TenantTranslatorUrl"),
 	}
 
 	return parsedConfig

--- a/db/migrations/20220330120000_add_org_id_tenants.go
+++ b/db/migrations/20220330120000_add_org_id_tenants.go
@@ -1,24 +1,15 @@
 package migrations
 
 import (
-	"context"
 	_ "embed"
 
-	"github.com/RedHatInsights/sources-api-go/config"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
-	"github.com/RedHatInsights/tenant-utils/pkg/tenantid"
 	"github.com/go-gormigrate/gormigrate/v2"
 	"gorm.io/gorm"
 )
 
-// AddOrgIdToTenants creates a new "org_id" column with an index in the "tenants" table and attempts to translate the
-// current EBS account numbers to "org_id"s.
-//
-// If the translation is not possible, it doesn't fail the migration: it simply logs an error. This is due to the
-// transition stage we are in. Since we are proactively taking steps towards the full "OrgId" support, not having a
-// translation for an EBS account number is acceptable.
-//
-// It also adds a comment to the "external_tenant" column, clarifying that it refers to "EBS account numbers".
+// AddOrgIdToTenants creates a new "org_id" column with an index in the "tenants" table. It also adds a comment to the
+// "external_tenant" column, clarifying that it refers to "EBS account numbers".
 func AddOrgIdToTenants() *gormigrate.Migration {
 	type Tenant struct {
 		OrgId string `gorm:"index; comment:Tenant identifier"`
@@ -27,8 +18,8 @@ func AddOrgIdToTenants() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "20220330120000",
 		Migrate: func(db *gorm.DB) error {
-			logging.Log.Info(`Migration "external tenants to org ids" started`)
-			defer logging.Log.Info(`Migration "external tenants to org ids" ended`)
+			logging.Log.Info(`Migration "add orgIds to tenants" started`)
+			defer logging.Log.Info(`Migration "add orgIds to tenants" ended`)
 
 			// Perform the table migration.
 			err := db.Transaction(func(tx *gorm.DB) error {
@@ -54,54 +45,7 @@ func AddOrgIdToTenants() *gormigrate.Migration {
 				return nil
 			})
 
-			if err != nil {
-				return err
-			}
-
-			// Get all the EBS account numbers from the database.
-			var ebsAccountNumbers []string
-			err = db.
-				Debug().
-				Model(&Tenant{}).
-				Where("external_tenant IS NOT NULL").
-				Pluck("external_tenant", &ebsAccountNumbers).
-				Error
-
-			if err != nil {
-				return err
-			}
-
-			// Attempt to translate the EANs.
-			translator := tenantid.NewTranslator(config.Get().TenantTranslatorUrl)
-			results, err := translator.EANsToOrgIDs(context.Background(), ebsAccountNumbers)
-			if err != nil {
-				return err
-			}
-
-			for _, result := range results {
-				if result.Err != nil {
-					logging.Log.Errorf(`[external_tenant: %s] could not translate to "org_id": %s`, *result.EAN, err)
-					continue
-				}
-
-				dbResult := db.
-					Debug().
-					Model(&Tenant{}).
-					Where("external_tenant = ?", result.EAN).
-					Updates(map[string]interface{}{
-						"org_id": result.OrgID,
-					})
-
-				if dbResult.RowsAffected == 0 {
-					logging.Log.Errorf(`[external_tenant: %s] could not translate to "org_id", external tenant not found`, *result.EAN)
-				}
-
-				if err != nil {
-					logging.Log.Errorf(`[external_tenant: %s][org_id: %s] could no translate to "org_id": %s`, *result.EAN, result.OrgID, err)
-				}
-			}
-
-			return nil
+			return err
 		},
 		Rollback: func(db *gorm.DB) error {
 			// Remove the "org_id" column and remove the comment from the "external_tenant" column.

--- a/db/migrations/20220330120000_add_org_id_tenants.go
+++ b/db/migrations/20220330120000_add_org_id_tenants.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// OrgIdSupport creates a new "org_id" column with an index in the "tenants" table and attempts to translate the
+// AddOrgIdToTenants creates a new "org_id" column with an index in the "tenants" table and attempts to translate the
 // current EBS account numbers to "org_id"s.
 //
 // If the translation is not possible, it doesn't fail the migration: it simply logs an error. This is due to the
@@ -19,7 +19,7 @@ import (
 // translation for an EBS account number is acceptable.
 //
 // It also adds a comment to the "external_tenant" column, clarifying that it refers to "EBS account numbers".
-func OrgIdSupport() *gormigrate.Migration {
+func AddOrgIdToTenants() *gormigrate.Migration {
 	type Tenant struct {
 		OrgId string `gorm:"index; comment:Tenant identifier"`
 	}

--- a/db/migrations/20220330120000_org_id_support.go
+++ b/db/migrations/20220330120000_org_id_support.go
@@ -89,8 +89,7 @@ func OrgIdSupport() *gormigrate.Migration {
 					Model(&Tenant{}).
 					Where("external_tenant = ?", result.EAN).
 					Updates(map[string]interface{}{
-						"external_tenant": *result.EAN,
-						"org_id":          result.OrgID,
+						"org_id": result.OrgID,
 					})
 
 				if dbResult.RowsAffected == 0 {

--- a/db/migrations/20220330120000_org_id_support.go
+++ b/db/migrations/20220330120000_org_id_support.go
@@ -81,6 +81,7 @@ func OrgIdSupport() *gormigrate.Migration {
 			for _, result := range results {
 				if result.Err != nil {
 					logging.Log.Errorf(`[external_tenant: %s] could not translate to "org_id": %s`, *result.EAN, err)
+					continue
 				}
 
 				dbResult := db.

--- a/db/migrations/20220330120000_org_id_support.go
+++ b/db/migrations/20220330120000_org_id_support.go
@@ -1,0 +1,175 @@
+package migrations
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/RedHatInsights/sources-api-go/config"
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/tenant-utils/pkg/tenantid"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// OrgIdSupport creates a new "org_id" column with an index in the "tenants" table and attempts to translate the
+// current EBS account numbers to "org_id"s.
+//
+// If the translation is not possible, it doesn't fail the migration: it simply logs an error. This is due to the
+// transition stage we are in. Since we are proactively taking steps towards the full "OrgId" support, not having a
+// translation for an EBS account number is acceptable.
+//
+// It also adds a comment to the "external_tenant" column, clarifying that it refers to "EBS account numbers".
+func OrgIdSupport() *gormigrate.Migration {
+	type Tenant struct {
+		OrgId string `gorm:"index; comment:Tenant identifier"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220330120000",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "20220330120000" started`)
+			defer logging.Log.Info(`Migration "20220330120000" ended`)
+
+			// Perform the table migration.
+			err := db.Transaction(func(tx *gorm.DB) error {
+				// Add the comment to the "external_tenant" column manually, since doing it in the struct with a "gorm"
+				// tag makes "gormigrate" try to create the already existing column.
+				err := tx.
+					Debug().
+					Exec(`COMMENT ON COLUMN "tenants"."external_tenant" IS 'EBS account number'`).
+					Error
+
+				if err != nil {
+					return err
+				}
+
+				err = tx.
+					Debug().
+					AutoMigrate(&Tenant{})
+
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+
+			if err != nil {
+				return err
+			}
+
+			// Get all the EBS account numbers from the database.
+			var ebsAccountNumbers []string
+			err = db.
+				Debug().
+				Model(&Tenant{}).
+				Where("external_tenant IS NOT NULL").
+				Pluck("external_tenant", &ebsAccountNumbers).
+				Error
+
+			if err != nil {
+				return err
+			}
+
+			// Attempt to translate the EANs.
+			translator := tenantid.NewTranslator(config.Get().TenantTranslatorUrl)
+			results, err := translator.EANsToOrgIDs(context.Background(), ebsAccountNumbers)
+			if err != nil {
+				return err
+			}
+
+			for _, result := range results {
+				if result.Err != nil {
+					logging.Log.Errorf(`[external_tenant: %s] could not translate to "org_id": %s`, *result.EAN, err)
+				}
+
+				dbResult := db.
+					Debug().
+					Model(&Tenant{}).
+					Where("external_tenant = ?", result.EAN).
+					Updates(map[string]interface{}{
+						"external_tenant": nil,
+						"org_id":          result.OrgID,
+					})
+
+				if dbResult.RowsAffected == 0 {
+					logging.Log.Errorf(`[external_tenant: %s] could not translate to "org_id", external tenant not found`, *result.EAN)
+				}
+
+				if err != nil {
+					logging.Log.Errorf(`[external_tenant: %s][org_id: %s] could no translate to "org_id": %s`, *result.EAN, result.OrgID, err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(db *gorm.DB) error {
+			// Get all the EBS account numbers from the database.
+			var orgIds []string
+			err := db.
+				Debug().
+				Model(&Tenant{}).
+				Where("org_id IS NOT NULL").
+				Pluck("org_id", &orgIds).
+				Error
+
+			if err != nil {
+				return err
+			}
+
+			// Revert all OrgIds to EANs.
+			translator := tenantid.NewTranslator(config.Get().TenantTranslatorUrl)
+			results, err := translator.OrgIDsToEANs(context.Background(), orgIds)
+			if err != nil {
+				return err
+			}
+
+			// Revert the "OrgId"s back to "EAN"s.
+			for _, result := range results {
+				if result.Err != nil {
+					logging.Log.Errorf(`[org_id: %s] could not translate to "EAN": %s`, result.OrgID, err)
+				}
+
+				dbResult := db.
+					Debug().
+					Model(&Tenant{}).
+					Where("org_id = ?", result.OrgID).
+					Updates(map[string]interface{}{
+						"external_tenant": *result.EAN,
+						"org_id":          nil,
+					})
+
+				if dbResult.RowsAffected == 0 {
+					logging.Log.Errorf(`[org_id: %s] could not translate to "EAN", org id not found`, result.OrgID)
+				}
+
+				if err != nil {
+					logging.Log.Errorf(`[org_id: %s][external_tenant: %s] could no translate to "EAN": %s`, result.OrgID, *result.EAN, err)
+				}
+			}
+
+			// Remove the "org_id" column and remove the comment from the "external_tenant" column.
+			err = db.Transaction(func(tx *gorm.DB) error {
+				err := tx.
+					Debug().
+					Migrator().
+					DropColumn(&Tenant{}, "org_id")
+
+				if err != nil {
+					return err
+				}
+
+				// Remove the comment from the "external_tenant" column manually, since doing it in the struct with a
+				// "gorm" tag makes "gormigrate" try to create the already existing column.
+				err = tx.
+					Debug().
+					Exec(`COMMENT ON COLUMN "tenants"."external_tenant" IS NULL`).
+					Error
+
+				return err
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/20220330120000_org_id_support.go
+++ b/db/migrations/20220330120000_org_id_support.go
@@ -89,7 +89,7 @@ func OrgIdSupport() *gormigrate.Migration {
 					Model(&Tenant{}).
 					Where("external_tenant = ?", result.EAN).
 					Updates(map[string]interface{}{
-						"external_tenant": nil,
+						"external_tenant": *result.EAN,
 						"org_id":          result.OrgID,
 					})
 

--- a/db/migrations/20220330120000_org_id_support.go
+++ b/db/migrations/20220330120000_org_id_support.go
@@ -27,8 +27,8 @@ func OrgIdSupport() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "20220330120000",
 		Migrate: func(db *gorm.DB) error {
-			logging.Log.Info(`Migration "20220330120000" started`)
-			defer logging.Log.Info(`Migration "20220330120000" ended`)
+			logging.Log.Info(`Migration "external tenants to org ids" started`)
+			defer logging.Log.Info(`Migration "external tenants to org ids" ended`)
 
 			// Perform the table migration.
 			err := db.Transaction(func(tx *gorm.DB) error {

--- a/db/migrations/20220404150000_translate_ebs_org_ids.go
+++ b/db/migrations/20220404150000_translate_ebs_org_ids.go
@@ -42,7 +42,11 @@ func TranslateEbsAccountNumbersToOrgIds() *gormigrate.Migration {
 				return err
 			}
 
-			// Attempt to translate the EANs.
+			// Attempt to translate the EANs, unless there is nothing to translate.
+			if len(ebsAccountNumbers) == 0 {
+				return nil
+			}
+
 			translator := tenantid.NewTranslator(config.Get().TenantTranslatorUrl)
 			results, err := translator.EANsToOrgIDs(context.Background(), ebsAccountNumbers)
 			if err != nil {

--- a/db/migrations/20220404150000_translate_ebs_org_ids.go
+++ b/db/migrations/20220404150000_translate_ebs_org_ids.go
@@ -1,0 +1,81 @@
+package migrations
+
+import (
+	"context"
+	_ "embed"
+
+	"github.com/RedHatInsights/sources-api-go/config"
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/tenant-utils/pkg/tenantid"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// TranslateEbsAccountNumbersToOrgIds attempts to translate the current EBS account numbers to "org_id"s.
+//
+// If the translation is not possible, it doesn't fail the migration: it simply logs an error. This is due to the
+// transition stage we are in. Since we are proactively taking steps towards the full "OrgId" support, not having a
+// translation for an EBS account number is acceptable.
+//
+// It also adds a comment to the "external_tenant" column, clarifying that it refers to "EBS account numbers".
+func TranslateEbsAccountNumbersToOrgIds() *gormigrate.Migration {
+	type Tenant struct {
+		OrgId string `gorm:"index; comment:Tenant identifier"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220404150000",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "translate EBS account numbers to orgIds" started`)
+			defer logging.Log.Info(`Migration "translate EBS account numbers to orgIds" ended`)
+
+			// Get all the EBS account numbers from the database.
+			var ebsAccountNumbers []string
+			err := db.
+				Debug().
+				Model(&Tenant{}).
+				Where("external_tenant IS NOT NULL").
+				Pluck("external_tenant", &ebsAccountNumbers).
+				Error
+
+			if err != nil {
+				return err
+			}
+
+			// Attempt to translate the EANs.
+			translator := tenantid.NewTranslator(config.Get().TenantTranslatorUrl)
+			results, err := translator.EANsToOrgIDs(context.Background(), ebsAccountNumbers)
+			if err != nil {
+				return err
+			}
+
+			for _, result := range results {
+				if result.Err != nil {
+					logging.Log.Errorf(`[external_tenant: %s] could not translate to "org_id": %s`, *result.EAN, err)
+					continue
+				}
+
+				dbResult := db.
+					Debug().
+					Model(&Tenant{}).
+					Where("external_tenant = ?", result.EAN).
+					Updates(map[string]interface{}{
+						"org_id": result.OrgID,
+					})
+
+				if dbResult.RowsAffected == 0 {
+					logging.Log.Errorf(`[external_tenant: %s] could not translate to "org_id", external tenant not found`, *result.EAN)
+				}
+
+				if err != nil {
+					logging.Log.Errorf(`[external_tenant: %s][org_id: %s] could no translate to "org_id": %s`, *result.EAN, result.OrgID, err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(db *gorm.DB) error {
+			return nil
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -13,6 +13,7 @@ import (
 
 var migrationsCollection = []*gormigrate.Migration{
 	InitialSchema(),
+	OrgIdSupport(),
 	SourceTypesAddCategoryColumn(),
 }
 

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -13,7 +13,7 @@ import (
 
 var migrationsCollection = []*gormigrate.Migration{
 	InitialSchema(),
-	OrgIdSupport(),
+	AddOrgIdToTenants(),
 	SourceTypesAddCategoryColumn(),
 }
 

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -14,6 +14,7 @@ import (
 var migrationsCollection = []*gormigrate.Migration{
 	InitialSchema(),
 	AddOrgIdToTenants(),
+	TranslateEbsAccountNumbersToOrgIds(),
 	SourceTypesAddCategoryColumn(),
 }
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -90,7 +90,7 @@ objects:
               name: sources-api-secrets
               key: encryption-key
         - name: TENANT_TRANSLATOR_URL
-          value: ${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
+          value: ${TENANT_TRANSLATOR_SCHEME}://${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
         readinessProbe:
           tcpSocket:
             port: 8000
@@ -238,10 +238,14 @@ parameters:
   name: SOURCES_ENV
   required: true
   value: stage
+- description: Scheme for the EAN to OrgId translator.
+  name: TENANT_TRANSLATOR_SCHEME
+  required: true
+  value: 'http'
 - description: Host for the EAN to OrgId translator.
   name: TENANT_TRANSLATOR_HOST
   required: true
-  value: 'http://apicast.3scale-dev.svc.cluster.local'
+  value: 'apicast.3scale-dev.svc.cluster.local'
 - description: Port for the EAN to OrgId translator.
   name: TENANT_TRANSLATOR_PORT
   required: true

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -89,6 +89,8 @@ objects:
             secretKeyRef:
               name: sources-api-secrets
               key: encryption-key
+        - name: TENANT_TRANSLATOR_URL
+          value: ${TENANT_TRANSLATOR_HOST}:${TENANT_TRANSLATOR_PORT}
         readinessProbe:
           tcpSocket:
             port: 8000
@@ -236,3 +238,11 @@ parameters:
   name: SOURCES_ENV
   required: true
   value: stage
+- description: Host for the EAN to OrgId translator.
+  name: TENANT_TRANSLATOR_HOST
+  required: true
+  value: 'http://apicast.3scale-dev.svc.cluster.local'
+- description: Port for the EAN to OrgId translator.
+  name: TENANT_TRANSLATOR_PORT
+  required: true
+  value: '8892'

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,14 @@ go 1.16
 require (
 	github.com/99designs/gqlgen v0.17.2
 	github.com/RedHatInsights/rbac-client-go v1.0.0
+	github.com/RedHatInsights/tenant-utils v0.0.0-20220322192943-150a1a665a5f
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/aws/aws-sdk-go v1.42.22
 	github.com/gertd/go-pluralize v0.1.7
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-migrate/migrate/v4 v4.15.1
-	github.com/google/go-cmp v0.5.6
+	github.com/google/go-cmp v0.5.7
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/vault/api v1.1.1
 	github.com/iancoleman/strcase v0.2.0
@@ -21,7 +22,7 @@ require (
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/labstack/gommon v0.3.1
 	github.com/neko-neko/echo-logrus/v2 v2.0.1
-	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_golang v1.12.1
 	github.com/redhatinsights/app-common-go v1.6.0
 	github.com/redhatinsights/platform-go-middlewares v0.10.0
 	github.com/redhatinsights/sources-superkey-worker v0.0.0-20220110114734-d076299a7d68

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/RedHatInsights/rbac-client-go v1.0.0 h1:vA6y4V/vj4T00H0+V6LxT8bKnYNjoVYiNpKAKURlUkE=
 github.com/RedHatInsights/rbac-client-go v1.0.0/go.mod h1:+7A7JULqhAnpSnWYXM4WsYol3tEoCR8AVeob0Qby3Zc=
 github.com/RedHatInsights/sources-api-go v0.0.0-20211213144039-456336cb8e5c/go.mod h1:4C3CdPsFr5ZhdVa5coel1TkUgwWKwsqXgKQKiwy18bg=
+github.com/RedHatInsights/tenant-utils v0.0.0-20220322192943-150a1a665a5f h1:bWjJDKfFRaCxcTtEMvogVnPpTMdSWPl78/ZPBhz3PsE=
+github.com/RedHatInsights/tenant-utils v0.0.0-20220322192943-150a1a665a5f/go.mod h1:wgdbAAraizlXVvWfFd01uoaU+4dC3yaSaFxPzvvffG8=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/sarama v1.30.0/go.mod h1:zujlQQx1kzHsh4jfV1USnptCQrHAEZ2Hk8fTKCulPVs=
@@ -612,8 +614,9 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-github/v35 v35.2.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -1062,6 +1065,8 @@ github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vv
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
+github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
+github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1156,8 +1161,9 @@ github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeD
 github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.10.0/go.mod h1:WJM3cc3yu7XKBKa/I8WeZm+V3eltZnBwfENSU7mdogU=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
+github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -1192,8 +1198,9 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
+github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rabbitmq/amqp091-go v1.1.0/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
@@ -1713,8 +1720,9 @@ golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -5,6 +5,7 @@ import "time"
 type Tenant struct {
 	Id             int64
 	ExternalTenant string
+	OrgId          string
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }


### PR DESCRIPTION
Modifies the tenancy table by adding the "org_id" column, and attempting a non-hard-failing translation from current EANs to OrgIds.

**NOTE:** https://github.com/RedHatInsights/sources-api-go/pull/175 needs to be merged first, and then, this PR needs to be rebased.

## Links

[[RHCLOUD-18651]](https://issues.redhat.com/browse/RHCLOUD-18651)