### PR TITLE
renaming of return value from NewRelationObject() in SubCollectionList() dao methods

### DIFF
--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -32,12 +32,12 @@ type applicationDaoImpl struct {
 
 func (a *applicationDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
 	applications := make([]m.Application, 0, limit)
-	sourceType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
+	relationObject, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("source")
 	}
 
-	query := sourceType.HasMany(&m.Application{}, DB.Debug())
+	query := relationObject.HasMany(&m.Application{}, DB.Debug())
 
 	query, err = applyFilters(query, filters)
 	if err != nil {

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -32,12 +32,12 @@ func (a *applicationTypeDaoImpl) SubCollectionList(primaryCollection interface{}
 	// 0, size of limit (since we will not be returning more than that)
 	applicationTypes := make([]m.ApplicationType, 0, limit)
 
-	applicationType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
+	relationObject, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("source")
 	}
 
-	query := applicationType.HasMany(&m.ApplicationType{}, DB.Debug())
+	query := relationObject.HasMany(&m.ApplicationType{}, DB.Debug())
 
 	query, err = applyFilters(query, filters)
 	if err != nil {

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -31,12 +31,12 @@ type endpointDaoImpl struct {
 
 func (a *endpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
-	sourceType, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
+	relationObject, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("source")
 	}
 
-	query := sourceType.HasMany(&m.Endpoint{}, DB.Debug())
+	query := relationObject.HasMany(&m.Endpoint{}, DB.Debug())
 	query = query.Where("endpoints.tenant_id = ?", a.TenantID)
 
 	query, err = applyFilters(query, filters)

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -25,12 +25,12 @@ type metaDataDaoImpl struct{}
 
 func (md *metaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
 	metadatas := make([]m.MetaData, 0, limit)
-	collection, err := m.NewRelationObject(primaryCollection, -1, DB.Debug())
+	relationObject, err := m.NewRelationObject(primaryCollection, -1, DB.Debug())
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("application type")
 	}
 
-	query := collection.HasMany(&m.MetaData{}, DB.Debug())
+	query := relationObject.HasMany(&m.MetaData{}, DB.Debug())
 	query = query.Where("meta_data.type = ?", m.APP_META_DATA)
 
 	query, err = applyFilters(query, filters)

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -36,11 +36,11 @@ func (s *sourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 	// 0, size of limit (since we will not be returning more than that)
 	sources := make([]m.Source, 0, limit)
 
-	sourceType, err := m.NewRelationObject(primaryCollection, *s.TenantID, DB.Debug())
+	relationObject, err := m.NewRelationObject(primaryCollection, *s.TenantID, DB.Debug())
 	if err != nil {
-		return nil, 0, util.NewErrNotFound(sourceType.StringBaseObject())
+		return nil, 0, util.NewErrNotFound(relationObject.StringBaseObject())
 	}
-	query := sourceType.HasMany(&m.Source{}, DB.Debug())
+	query := relationObject.HasMany(&m.Source{}, DB.Debug())
 
 	query = query.Where("sources.tenant_id = ?", s.TenantID)
 


### PR DESCRIPTION
without JIRA ticket

I found out that in `source_dao.go` in `SubCollectionList()` method we used `sourceType` name for value returned from `NewRelationObject()`

`sourceType, err := m.NewRelationObject(primaryCollection, *s.TenantID, DB.Debug())`

but this method is used not only for endpoint `source_types/id/sources` but for `application_types/id/sources` too => in second case was in variable `sourceType` the application type object 

so because this name is a little bit confusing I changed it in all `SubCollectionList()` methods into `relatedObject`

