### PR TITLE
Change BulkCreate ApplicationAuthentication logic to work with DB-backed DAO

### DIFF
--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
@@ -67,8 +68,8 @@ func TestApplicationAuthenticationList(t *testing.T) {
 		t.Error("ghosts infected the return")
 	}
 
-	authID := fixtures.TestAuthenticationData[0].ID
-	if appAuth["authentication_uid"] != authID {
+	authID := strconv.Itoa(int(fixtures.TestAuthenticationData[0].DbID))
+	if appAuth["authentication_id"].(string) != authID {
 		t.Error("ghosts infected the return")
 	}
 
@@ -128,8 +129,8 @@ func TestApplicationAuthenticationGet(t *testing.T) {
 	if err != nil {
 		t.Error("Failed unmarshaling output")
 	}
-	authID := fixtures.TestAuthenticationData[0].ID
-	if out.AuthenticationUID != authID {
+	authID := strconv.Itoa(int(fixtures.TestAuthenticationData[0].DbID))
+	if out.AuthenticationID != authID {
 		t.Error("ghosts infected the return")
 	}
 

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -43,15 +43,6 @@ func TestDeleteApplicationAuthentication(t *testing.T) {
 		}
 	}
 
-	{
-		want := applicationAuthentication.AuthenticationUID
-		got := deletedApplicationAuthentication.AuthenticationUID
-
-		if want != got {
-			t.Errorf(`incorrect applicationAuthentication deleted. Want "%s" in the authenticationUid field, got "%s"`, want, got)
-		}
-	}
-
 	DoneWithFixtures("delete")
 }
 

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -23,7 +23,7 @@ type ApplicationAuthentication struct {
 	ApplicationID int64 `json:"application_id"`
 	Application   Application
 	// TODO: fix correctly PR#40
-	AuthenticationID int64 `json:"authentication_id"`
+	AuthenticationID int64 `json:"-"`
 
 	AuthenticationUID string `json:"-" gorm:"-"`
 }

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
@@ -14,7 +15,7 @@ type ApplicationAuthentication struct {
 	UpdatedAt time.Time  `json:"updated_at"`
 	PausedAt  *time.Time `json:"paused_at"`
 
-	VaultPath string `json:"vault_path"`
+	VaultPath string `json:"vault_path" gorm:"-"`
 
 	TenantID int64
 	Tenant   Tenant
@@ -24,20 +25,19 @@ type ApplicationAuthentication struct {
 	// TODO: fix correctly PR#40
 	AuthenticationID int64 `json:"authentication_id"`
 
-	AuthenticationUID string `json:"-"`
+	AuthenticationUID string `json:"-" gorm:"-"`
 }
 
 func (aa *ApplicationAuthentication) ToEvent() interface{} {
 	aaEvent := &ApplicationAuthenticationEvent{
-		ID:                aa.ID,
-		PausedAt:          util.DateTimePointerToRecordFormat(aa.PausedAt),
-		CreatedAt:         util.DateTimeToRecordFormat(aa.CreatedAt),
-		UpdatedAt:         util.DateTimeToRecordFormat(aa.UpdatedAt),
-		ApplicationID:     aa.ApplicationID,
-		AuthenticationID:  aa.AuthenticationID,
-		AuthenticationUID: aa.AuthenticationUID,
-		Tenant:            &aa.Tenant.ExternalTenant,
-		VaultPath:         aa.VaultPath,
+		ID:               aa.ID,
+		PausedAt:         util.DateTimePointerToRecordFormat(aa.PausedAt),
+		CreatedAt:        util.DateTimeToRecordFormat(aa.CreatedAt),
+		UpdatedAt:        util.DateTimeToRecordFormat(aa.UpdatedAt),
+		ApplicationID:    aa.ApplicationID,
+		AuthenticationID: aa.AuthenticationID,
+		Tenant:           &aa.Tenant.ExternalTenant,
+		VaultPath:        aa.VaultPath,
 	}
 
 	return aaEvent
@@ -47,7 +47,7 @@ func (aa *ApplicationAuthentication) ToResponse() *ApplicationAuthenticationResp
 	id := strconv.FormatInt(aa.ID, 10)
 	appId := strconv.FormatInt(aa.ApplicationID, 10)
 	authId := ""
-	if aa.VaultPath != "" {
+	if aa.VaultPath != "" && config.IsVaultOn() {
 		parts := strings.Split(aa.VaultPath, "/")
 		authId = parts[len(parts)-1]
 	} else {
@@ -55,11 +55,10 @@ func (aa *ApplicationAuthentication) ToResponse() *ApplicationAuthenticationResp
 	}
 
 	return &ApplicationAuthenticationResponse{
-		ID:                id,
-		AuthenticationUID: aa.AuthenticationUID,
-		CreatedAt:         util.DateTimeToRFC3339(aa.CreatedAt),
-		UpdatedAt:         util.DateTimeToRFC3339(aa.UpdatedAt),
-		ApplicationID:     appId,
-		AuthenticationID:  authId,
+		ID:               id,
+		CreatedAt:        util.DateTimeToRFC3339(aa.CreatedAt),
+		UpdatedAt:        util.DateTimeToRFC3339(aa.UpdatedAt),
+		ApplicationID:    appId,
+		AuthenticationID: authId,
 	}
 }

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -15,7 +15,7 @@ import (
 type Authentication struct {
 	DbID      int64     `gorm:"primaryKey; column:id" json:"-"`
 	ID        string    `json:"id"`
-	CreatedAt time.Time `json:"created_at"`
+	CreatedAt time.Time `json:"created_at" gorm:"-"`
 
 	Name     string                 `json:"name,omitempty"`
 	AuthType string                 `gorm:"column:authtype" json:"authtype"`
@@ -23,7 +23,7 @@ type Authentication struct {
 	Password string                 `json:"password"`
 	Extra    map[string]interface{} `gorm:"-" json:"extra,omitempty"`
 	ExtraDb  datatypes.JSON         `gorm:"column:extra"`
-	Version  string                 `json:"version"`
+	Version  string                 `json:"version" gorm:"-"`
 
 	AvailabilityStatus      string     `json:"availability_status,omitempty"`
 	LastCheckedAt           *time.Time `json:"last_checked_at,omitempty"`
@@ -176,9 +176,11 @@ func mapIdExtraFields(auth *Authentication) (string, map[string]interface{}) {
 	} else {
 		id = strconv.FormatInt(auth.DbID, 10)
 
-		err := json.Unmarshal(auth.ExtraDb, &extra)
-		if err != nil {
-			logger.Log.Errorf(`could not unmarshal "extra" field from authentication with ID "%s"`, id)
+		if auth.ExtraDb != nil {
+			err := json.Unmarshal(auth.ExtraDb, &extra)
+			if err != nil {
+				logger.Log.Errorf(`could not unmarshal "extra" field from authentication with ID "%s"`, id)
+			}
 		}
 	}
 

--- a/model/event_models.go
+++ b/model/event_models.go
@@ -49,12 +49,14 @@ type ApplicationAuthenticationEvent struct {
 	UpdatedAt *string `json:"updated_at"`
 	PausedAt  *string `json:"paused_at"`
 
-	ApplicationID     int64  `json:"application_id"`
-	AuthenticationID  int64  `json:"authentication_id"`
-	AuthenticationUID string `json:"authentication_uid"`
+	ApplicationID    int64 `json:"application_id"`
+	AuthenticationID int64 `json:"authentication_id"`
+	// TODO: maybe add back in if we get vault
+	AuthenticationUID string `json:"-"`
 
-	Tenant    *string `json:"tenant"`
-	VaultPath string  `json:"vault_path"`
+	Tenant *string `json:"tenant"`
+	// TODO: add back in if we get vault
+	VaultPath string `json:"-"`
 }
 
 type EndpointEvent struct {

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -77,13 +77,13 @@ func BulkAssembly(req m.BulkCreateRequest, tenantID *int64) (*m.BulkCreateOutput
 				return err
 			}
 
-			if strings.ToLower(output.Authentications[i].ResourceType) == "Application" {
+			if strings.ToLower(output.Authentications[i].ResourceType) == "application" {
 				output.ApplicationAuthentications = append(output.ApplicationAuthentications, m.ApplicationAuthentication{
 					// TODO: After vault migration.
 					// VaultPath:         output.Authentications[i].Path(),
-					ApplicationID:     output.Authentications[i].ResourceID,
-					AuthenticationUID: output.Authentications[i].ID,
-					TenantID:          *tenantID,
+					ApplicationID:    output.Authentications[i].ResourceID,
+					AuthenticationID: output.Authentications[i].DbID,
+					TenantID:         *tenantID,
 				})
 			}
 		}

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -3,13 +3,11 @@
     {
       "application_id": 1,
       "authentication_id": 1,
-      "authentication_uid": "611a8a38-f434-4e62-bda0-78cd45ffae5b",
       "created_at": "2022-01-19 11:57:23 CET",
       "id": 1,
       "paused_at": null,
       "tenant": "12345",
-      "updated_at": "2022-01-19 11:57:23 CET",
-      "vault_path": "Application_1_611a8a38-f434-4e62-bda0-78cd45ffae5b"
+      "updated_at": "2022-01-19 11:57:23 CET"
     }
   ],
   "applications": [

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -3,13 +3,11 @@
     {
       "application_id": 1,
       "authentication_id": 1,
-      "authentication_uid": "611a8a38-f434-4e62-bda0-78cd45ffae5b",
       "created_at": "2022-01-19 11:57:23 CET",
       "id": 1,
       "paused_at": null,
       "tenant": "12345",
-      "updated_at": "2022-01-19 11:57:23 CET",
-      "vault_path": "Application_1_611a8a38-f434-4e62-bda0-78cd45ffae5b"
+      "updated_at": "2022-01-19 11:57:23 CET"
     }
   ],
   "applications": [


### PR DESCRIPTION
BulkCreate wasn't working for applicationAuthentications before mostly because of our DB schema being not-correct for the vault backend. 

In the future we're going to need to relax the constraints and change that table's layout a bit to fit both options. But today is not that day since we do not have a vault. 