### PR TITLE
[RHCLOUD-18700] fix: segmentation violation on status listener tests

### DIFF
--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -95,13 +95,21 @@ func PopulateDateFieldsFrom(resource interface{}) DateFields {
 		dateFields.UpdatedAt = typedResource.UpdatedAt
 	case *m.Application:
 		dateFields.CreatedAt = typedResource.CreatedAt
-		dateFields.LastAvailableAt = *typedResource.LastAvailableAt
-		dateFields.LastCheckedAt = *typedResource.LastCheckedAt
+		if typedResource.LastAvailableAt != nil {
+			dateFields.LastAvailableAt = *typedResource.LastAvailableAt
+		}
+		if typedResource.LastCheckedAt != nil {
+			dateFields.LastCheckedAt = *typedResource.LastCheckedAt
+		}
 		dateFields.UpdatedAt = typedResource.UpdatedAt
 	case *m.Endpoint:
 		dateFields.CreatedAt = typedResource.CreatedAt
-		dateFields.LastAvailableAt = *typedResource.LastAvailableAt
-		dateFields.LastCheckedAt = *typedResource.LastCheckedAt
+		if typedResource.LastAvailableAt != nil {
+			dateFields.LastAvailableAt = *typedResource.LastAvailableAt
+		}
+		if typedResource.LastCheckedAt != nil {
+			dateFields.LastCheckedAt = *typedResource.LastCheckedAt
+		}
 		dateFields.UpdatedAt = typedResource.UpdatedAt
 	case *m.ApplicationAuthentication:
 		dateFields.CreatedAt = typedResource.CreatedAt


### PR DESCRIPTION
Due to the change introduced in bfa0816, the "lastAvailableAt" and "lastCheckedAt" attributes from the models can be nil. The status listener was counting on them always having a value, and that was causing the issue.

## Links

* https://github.com/RedHatInsights/sources-api-go/pull/168
* [[RHCLOUD-18700]](https://issues.redhat.com/browse/RHCLOUD-18700)