### PR TITLE
[RHCLOUD-18704] Include the "rhc_connections" and "sources_rhc_connections" tables to the initial migration

### DIFF
--- a/db/migrations/20220222111000_initial_schema.go
+++ b/db/migrations/20220222111000_initial_schema.go
@@ -17,8 +17,8 @@ func InitialSchema() *gormigrate.Migration {
 	return &gormigrate.Migration{
 		ID: "20220222110000",
 		Migrate: func(db *gorm.DB) error {
-			logging.Log.Info(`Migration "20220222110000" started`)
-			defer logging.Log.Info(`Migration "20220222110000" ended`)
+			logging.Log.Info(`Migration "migrate initial schema" started`)
+			defer logging.Log.Info(`Migration "migrate initial schema" ended`)
 
 			err := db.Transaction(func(tx *gorm.DB) error {
 				err := tx.Exec(schemaContents).Error


### PR DESCRIPTION
Since the initial migration "will be skipped" on the staging and production environments, we can make an exception with this one and include the two missing tables in the initial migration.

## Links

[[RHCLOUD-18704]](https://issues.redhat.com/browse/RHCLOUD-18704)