### PR TITLE
[RHCLOUD-18651][RHCLOUD-19093] Support orgIds in the incoming headers

### DIFF
--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -38,7 +38,12 @@ func BulkCreate(c echo.Context) error {
 		return err
 	}
 
-	service.SendBulkMessages(output, service.ForwadableHeaders(c), xrhid)
+	forwardableHeaders, err := service.ForwadableHeaders(c)
+	if err != nil {
+		return err
+	}
+
+	service.SendBulkMessages(output, forwardableHeaders, xrhid)
 
 	return c.JSON(http.StatusCreated, output.ToResponse())
 }

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -166,5 +166,7 @@ type TenantDao interface {
 	// GetOrCreateTenantID returns the ID of the tenant associated with the provided identity. It tries to fetch the
 	// tenant by its OrgId, and if it is not present, by its EBS account number.
 	GetOrCreateTenantID(identity *identity.Identity) (int64, error)
-	TenantByAccountNumber(accountNumber string) (*m.Tenant, error)
+	// TenantByIdentity returns the tenant associated to the given identity. It tries to fetch the tenant by its OrgId,
+	// and if it is not preset, by its EBS account number.
+	TenantByIdentity(identity *identity.Identity) (*m.Tenant, error)
 }

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -4,6 +4,7 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/hashicorp/vault/api"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 type SourceDao interface {
@@ -162,6 +163,8 @@ type RhcConnectionDao interface {
 }
 
 type TenantDao interface {
-	GetOrCreateTenantID(accountNumber string) (*int64, error)
+	// GetOrCreateTenantID returns the ID of the tenant associated with the provided identity. It tries to fetch the
+	// tenant by its OrgId, and if it is not present, by its EBS account number.
+	GetOrCreateTenantID(identity *identity.Identity) (int64, error)
 	TenantByAccountNumber(accountNumber string) (*m.Tenant, error)
 }

--- a/dao/tenant_dao_test.go
+++ b/dao/tenant_dao_test.go
@@ -170,7 +170,7 @@ func TestGetOrCreateTenantIDOrgIdFind(t *testing.T) {
 // TestTenantByIdentity tests that the function is able to fetch by either EBS account number or OrgId.
 func TestTenantByIdentity(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("tenant_tests")
+	SwitchSchema("tenant_tests")
 
 	tenantDao := GetTenantDao()
 
@@ -208,13 +208,13 @@ func TestTenantByIdentity(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("tenant_tests")
+	DropSchema("tenant_tests")
 }
 
 // TestTenantByIdentityNotFound tests that a "not found" error is returned when the tenant is not found.
 func TestTenantByIdentityNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("tenant_tests")
+	SwitchSchema("tenant_tests")
 
 	tenantDao := GetTenantDao()
 
@@ -236,5 +236,5 @@ func TestTenantByIdentityNotFound(t *testing.T) {
 		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("tenant_tests")
+	DropSchema("tenant_tests")
 }

--- a/dao/tenant_dao_test.go
+++ b/dao/tenant_dao_test.go
@@ -1,0 +1,165 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+// TestGetOrCreateTenantIDEbsNumberCreate tests that when the EBS account number is not found, a new tenant is created.
+func TestGetOrCreateTenantIDEbsNumberCreate(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("tenant_tests")
+
+	accountNumber := "98765"
+	identityStruct := identity.Identity{
+		AccountNumber: accountNumber,
+	}
+
+	tenantDao := GetTenantDao()
+
+	id, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	if err != nil {
+		t.Errorf(`Error getting or creating the tenant. Want nil error, got "%s"`, err)
+	}
+
+	var tenant model.Tenant
+	err = DB.
+		Debug().
+		Model(&model.Tenant{}).
+		Where(`id = ?`, id).
+		First(&tenant).
+		Error
+
+	if err != nil {
+		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
+	}
+
+	want := accountNumber
+	got := tenant.ExternalTenant
+
+	if want != got {
+		t.Errorf(`unexpected tenant fetched. Want EBS number "%s", got "%s"`, want, got)
+	}
+
+	DropSchema("tenant_tests")
+}
+
+// TestGetOrCreateTenantIDEbsNumberFind tests that when the EBS account number is found, the associated tenant id is
+// returned.
+func TestGetOrCreateTenantIDEbsNumberFind(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("tenant_tests")
+
+	identityStruct := identity.Identity{
+		AccountNumber: fixtures.TestTenantData[0].ExternalTenant,
+	}
+
+	tenantDao := GetTenantDao()
+
+	id, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	if err != nil {
+		t.Errorf(`Error getting or creating the tenant. Want nil error, got "%s"`, err)
+	}
+
+	var tenant model.Tenant
+	err = DB.
+		Debug().
+		Model(&model.Tenant{}).
+		Where(`id = ?`, id).
+		First(&tenant).
+		Error
+
+	if err != nil {
+		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
+	}
+
+	want := fixtures.TestTenantData[0].ExternalTenant
+	got := tenant.ExternalTenant
+
+	if want != got {
+		t.Errorf(`unexpected tenant fetched. Want EBS number "%s", got "%s"`, want, got)
+	}
+
+	DropSchema("tenant_tests")
+}
+
+// TestGetOrCreateTenantIDOrgIdCreate tests that when the OrgId is not found, a new tenant is created.
+func TestGetOrCreateTenantIDOrgIdCreate(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("tenant_tests")
+
+	orgId := "1239875"
+	identityStruct := identity.Identity{
+		OrgID: orgId,
+	}
+
+	tenantDao := GetTenantDao()
+
+	id, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	if err != nil {
+		t.Errorf(`Error getting or creating the tenant. Want nil error, got "%s"`, err)
+	}
+
+	var tenant model.Tenant
+	err = DB.
+		Debug().
+		Model(&model.Tenant{}).
+		Where(`id = ?`, id).
+		First(&tenant).
+		Error
+
+	if err != nil {
+		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
+	}
+
+	want := orgId
+	got := tenant.OrgID
+
+	if want != got {
+		t.Errorf(`unexpected tenant fetched. Want EBS number "%s", got "%s"`, want, got)
+	}
+
+	DropSchema("tenant_tests")
+}
+
+// TestGetOrCreateTenantIDOrgIdFind tests that when the OrgId is found, the associated tenant id is returned.
+func TestGetOrCreateTenantIDOrgIdFind(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("tenant_tests")
+
+	identityStruct := identity.Identity{
+		OrgID: fixtures.TestTenantData[0].OrgID,
+	}
+
+	tenantDao := GetTenantDao()
+
+	id, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	if err != nil {
+		t.Errorf(`Error getting or creating the tenant. Want nil error, got "%s"`, err)
+	}
+
+	var tenant model.Tenant
+	err = DB.
+		Debug().
+		Model(&model.Tenant{}).
+		Where(`id = ?`, id).
+		First(&tenant).
+		Error
+
+	if err != nil {
+		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
+	}
+
+	want := fixtures.TestTenantData[0].OrgID
+	got := tenant.OrgID
+
+	if want != got {
+		t.Errorf(`unexpected tenant fetched. Want EBS number "%s", got "%s"`, want, got)
+	}
+
+	DropSchema("tenant_tests")
+}

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -238,8 +238,11 @@ func EndpointDelete(c echo.Context) error {
 	c.Logger().Infof("Deleting Endpoint Id %v", id)
 
 	// Cascade delete the endpoint.
-	headers := service.ForwadableHeaders(c)
-	err = service.DeleteCascade(endpointDao.Tenant(), "Endpoint", id, headers)
+	forwardableHeaders, err := service.ForwadableHeaders(c)
+	if err != nil {
+		return err
+	}
+	err = service.DeleteCascade(endpointDao.Tenant(), "Endpoint", id, forwardableHeaders)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/neko-neko/echo-logrus/v2 v2.0.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/redhatinsights/app-common-go v1.6.0
-	github.com/redhatinsights/platform-go-middlewares v0.10.0
+	github.com/redhatinsights/platform-go-middlewares v0.12.0
 	github.com/redhatinsights/sources-superkey-worker v0.0.0-20220110114734-d076299a7d68
 	github.com/segmentio/kafka-go v0.4.25
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1211,6 +1211,8 @@ github.com/redhatinsights/app-common-go v1.6.0/go.mod h1:SqgG5JkX/RNlk2d+sXamIFx
 github.com/redhatinsights/platform-go-middlewares v0.8.1/go.mod h1:koDaxx4Ht3ZgXqAhfkKFhBy9586kZ3aDm9IAlEs0Oo4=
 github.com/redhatinsights/platform-go-middlewares v0.10.0 h1:VVuWvPL7xHYnmVMz6jK9lUqyPc1vOEWdpo6eVu7e9iQ=
 github.com/redhatinsights/platform-go-middlewares v0.10.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
+github.com/redhatinsights/platform-go-middlewares v0.12.0 h1:gLFgsqupumRqAKDuYtvrYVNQr53iqfhQYc98VJ/cRUs=
+github.com/redhatinsights/platform-go-middlewares v0.12.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/redhatinsights/sources-superkey-worker v0.0.0-20220110114734-d076299a7d68 h1:YOKTWdW6poVAoL0ds7oB5yJSXNQOUIveCjqQRthzJ30=
 github.com/redhatinsights/sources-superkey-worker v0.0.0-20220110114734-d076299a7d68/go.mod h1:D74VLRhmYd+tGF1eid7+HLUKytgsm9L2dS9CoR+lxXM=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/graphql_handlers.go
+++ b/graphql_handlers.go
@@ -112,7 +112,12 @@ func ProxyGraphqlToLegacySources(c echo.Context) error {
 	}
 
 	// fetch the headers to forward along
-	for _, h := range service.ForwadableHeaders(c) {
+	forwardableHeaders, err := service.ForwadableHeaders(c)
+	if err != nil {
+		return err
+	}
+
+	for _, h := range forwardableHeaders {
 		req.Header.Add(h.Key, string(h.Value))
 	}
 

--- a/internal/testutils/fixtures/tenant.go
+++ b/internal/testutils/fixtures/tenant.go
@@ -6,6 +6,7 @@ var TestTenantData = []m.Tenant{
 	{
 		Id:             1,
 		ExternalTenant: "12345",
+		OrgID:          "9876543210",
 	},
 	{
 		Id:             2,

--- a/middleware/event_stream.go
+++ b/middleware/event_stream.go
@@ -52,7 +52,10 @@ func RaiseEvent(next echo.HandlerFunc) echo.HandlerFunc {
 
 		l.Log.Infof("Raising Event %v", eventType)
 
-		headers := service.ForwadableHeaders(c)
+		headers, err := service.ForwadableHeaders(c)
+		if err != nil {
+			return err
+		}
 
 		// async!
 		go func() {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -33,6 +33,10 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set("psk-account", c.Request().Header.Get("x-rh-sources-account-number"))
 		}
 
+		if c.Request().Header.Get("x-rh-sources-org-id") != "" {
+			c.Set("psk-org-id", c.Request().Header.Get("x-rh-sources-org-id"))
+		}
+
 		// parsing the base64-encoded identity header if present
 		if c.Request().Header.Get("x-rh-identity") != "" {
 			// store it raw first.

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -25,6 +25,7 @@ func TestParseAll(t *testing.T) {
 
 	c.Request().Header.Set("x-rh-identity", xrhid)
 	c.Request().Header.Set("x-rh-sources-psk", "1234")
+	c.Request().Header.Set("x-rh-sources-org-id", "abcde")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -42,6 +43,10 @@ func TestParseAll(t *testing.T) {
 	// Gets set from the xrhid's account number.
 	if c.Get("psk-account").(string) != "12345" {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get("psk-account").(string), "9876")
+	}
+
+	if c.Get("psk-org-id").(string) != "abcde" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get("x-rh-sources-org-id").(string))
 	}
 
 	id, ok := c.Get("identity").(*identity.XRHID)

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -44,7 +44,7 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get("psk-account").(string), "9876")
 	}
 
-	id, ok := c.Get("identity").(identity.XRHID)
+	id, ok := c.Get("identity").(*identity.XRHID)
 	if !ok {
 		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
 	}

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -39,8 +39,13 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}
 
+			forwardableHeaders, err := service.ForwadableHeaders(c)
+			if err != nil {
+				return err
+			}
+
 			jobs.Enqueue(&jobs.SuperkeyDestroyJob{
-				Headers:  service.ForwadableHeaders(c),
+				Headers:  forwardableHeaders,
 				Tenant:   tenantId,
 				Identity: xrhid,
 				Model:    "source",
@@ -74,8 +79,13 @@ func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}
 
+			forwardableHeaders, err := service.ForwadableHeaders(c)
+			if err != nil {
+				return err
+			}
+
 			jobs.Enqueue(&jobs.SuperkeyDestroyJob{
-				Headers:  service.ForwadableHeaders(c),
+				Headers:  forwardableHeaders,
 				Tenant:   tenantId,
 				Identity: xrhid,
 				Model:    "application",

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -5,7 +5,7 @@ import "time"
 type Tenant struct {
 	Id             int64
 	ExternalTenant string
-	OrgId          string
+	OrgID          string
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }

--- a/service/events.go
+++ b/service/events.go
@@ -33,6 +33,7 @@ func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) 
 // ForwadableHeaders fetches the required identity headers from the request that are needed to forward along:
 // 	1. x-rh-identity -- a generated one if it wasn't passed along (e.g. psk)
 //	2. x-rh-sources-psk -- always passed if present, and used for generation.
+//	3. x-rh-sources-org-id -- always passed if present, and used for generation.
 func ForwadableHeaders(c echo.Context) []kafka.Header {
 	headers := make([]kafka.Header, 0)
 
@@ -57,6 +58,13 @@ func ForwadableHeaders(c echo.Context) []kafka.Header {
 				Key:   "x-rh-identity",
 				Value: []byte(util.XRhIdentityWithAccountNumber(psk)),
 			})
+		}
+	}
+
+	if c.Get("x-rh-sources-org-id") != nil {
+		orgId, ok := c.Get("x-rh-sources-org-id").(string)
+		if ok {
+			headers = append(headers, kafka.Header{Key: "x-rh-sources-org-id", Value: []byte(orgId)})
 		}
 	}
 

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -1,0 +1,326 @@
+package service
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+// TestForwadableHeadersPsk tests that when the "psk-account" context value is present, two headers are returned from
+// the function under test: "x-rh-sources-account-number" and "x-rh-identity".
+func TestForwadableHeadersPsk(t *testing.T) {
+	testPskAccountValue := "abcde"
+
+	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
+	context.Set("psk-account", testPskAccountValue)
+
+	// Call the function under test.
+	headers, err := ForwadableHeaders(context)
+	if err != nil {
+		t.Errorf(`unexpected error when building the forwardable headers: %s`, err)
+	}
+
+	{
+		want := 2
+		got := len(headers)
+
+		if want != got {
+			t.Errorf(`incorrect number of Kafka headers generated. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		pskHeader := headers[0]
+
+		{
+			want := "x-rh-sources-account-number"
+			got := pskHeader.Key
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			want := []byte(testPskAccountValue)
+			got := pskHeader.Value
+
+			if !bytes.Equal(want, got) {
+				t.Errorf(`incorrect Kafka header value generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+	}
+	{
+		xRhIdHeader := headers[1]
+		{
+			want := "x-rh-identity"
+			got := xRhIdHeader.Key
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			id, err := util.IdentityFromKafkaHeaders([]kafka.Header{xRhIdHeader})
+			if err != nil {
+				t.Errorf(`unexpected error when extracting the identity from the Kafka header: %s`, err)
+			}
+
+			want := testPskAccountValue
+			got := id.AccountNumber
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header value generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+	}
+}
+
+// TestForwadableHeadersOrgId tests that when the "x-rh-sources-org-id" context value is present, two headers are
+// returned from the function under test: "x-rh-sources-org-id" and "x-rh-identity".
+func TestForwadableHeadersOrgId(t *testing.T) {
+	testOrgIdValue := "abcde"
+
+	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
+	context.Set("x-rh-sources-org-id", testOrgIdValue)
+
+	// Call the function under test.
+	headers, err := ForwadableHeaders(context)
+	if err != nil {
+		t.Errorf(`unexpected error when building the forwardable headers: %s`, err)
+	}
+
+	{
+		want := 2
+		got := len(headers)
+
+		if want != got {
+			t.Errorf(`incorrect number of Kafka headers generated. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		orgIdHeader := headers[0]
+
+		{
+			want := "x-rh-sources-org-id"
+			got := orgIdHeader.Key
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			want := []byte(testOrgIdValue)
+			got := orgIdHeader.Value
+
+			if !bytes.Equal(want, got) {
+				t.Errorf(`incorrect Kafka header value generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+	}
+	{
+		xRhIdHeader := headers[1]
+		{
+			want := "x-rh-identity"
+			got := xRhIdHeader.Key
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			id, err := util.IdentityFromKafkaHeaders([]kafka.Header{xRhIdHeader})
+			if err != nil {
+				t.Errorf(`unexpected error when extracting the identity from the Kafka header: %s`, err)
+			}
+
+			want := testOrgIdValue
+			got := id.OrgID
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header value generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+	}
+}
+
+// TestForwadableHeadersXrhId tests that when the "x-rh-identity" context value is present, only one header is returned
+// from the function under test: "x-rh-identity".
+func TestForwadableHeadersXrhId(t *testing.T) {
+	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
+
+	// Generate the XRHID to set it in the context.
+	var xRhId identity.XRHID
+
+	testAccountNumber := "abcde"
+	testOrgId := "12345"
+
+	xRhId.Identity.AccountNumber = testAccountNumber
+	xRhId.Identity.OrgID = testOrgId
+
+	result, err := json.Marshal(xRhId)
+	if err != nil {
+		t.Errorf(`unexpected error when marshalling the XRHID: %s`, err)
+	}
+
+	context.Set("x-rh-identity", base64.StdEncoding.EncodeToString(result))
+
+	// Call the function under test.
+	headers, err := ForwadableHeaders(context)
+	if err != nil {
+		t.Errorf(`unexpected error when building the forwardable headers: %s`, err)
+	}
+
+	{
+		want := 1
+		got := len(headers)
+
+		if want != got {
+			t.Errorf(`incorrect number of Kafka headers generated. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		xRhIdentityHeader := headers[0]
+
+		{
+			want := "x-rh-identity"
+			got := xRhIdentityHeader.Key
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			xRhId, err := util.ParseXRHIDHeader(string(xRhIdentityHeader.Value))
+			if err != nil {
+				t.Errorf(`unexpected error when parsing the xRhIdentity base64 string: %s`, err)
+			}
+			{
+				want := testAccountNumber
+				got := xRhId.Identity.AccountNumber
+
+				if want != got {
+					t.Errorf(`incorrect account number on xRhId struct. Want "%s", got "%s"`, want, got)
+				}
+			}
+			{
+				want := testOrgId
+				got := xRhId.Identity.OrgID
+
+				if want != got {
+					t.Errorf(`incorrect orgId on xRhId struct. Want "%s", got "%s"`, want, got)
+				}
+			}
+		}
+	}
+}
+
+// TestForwadableHeadersOrgId tests that when the "psk-account" and "x-rh-sources-org-id" context values are present,
+// three headers are returned from the function under test: "x-rh-sources-account-number", "x-rh-sources-org-id" and
+// "x-rh-identity"
+func TestForwadableHeadersPskOrgId(t *testing.T) {
+	testPskAccountValue := "abcde"
+	testOrgIdValue := "12345"
+
+	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
+	context.Set("psk-account", testPskAccountValue)
+	context.Set("x-rh-sources-org-id", testOrgIdValue)
+
+	// Call the function under test.
+	headers, err := ForwadableHeaders(context)
+	if err != nil {
+		t.Errorf(`unexpected error when building the forwardable headers: %s`, err)
+	}
+
+	{
+		want := 3
+		got := len(headers)
+
+		if want != got {
+			t.Errorf(`incorrect number of Kafka headers generated. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		pskHeader := headers[0]
+
+		{
+			want := "x-rh-sources-account-number"
+			got := pskHeader.Key
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			want := []byte(testPskAccountValue)
+			got := pskHeader.Value
+
+			if !bytes.Equal(want, got) {
+				t.Errorf(`incorrect Kafka header value generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+	}
+
+	{
+		orgIdHeader := headers[1]
+
+		{
+			want := "x-rh-sources-org-id"
+			got := orgIdHeader.Key
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			want := []byte(testOrgIdValue)
+			got := orgIdHeader.Value
+
+			if !bytes.Equal(want, got) {
+				t.Errorf(`incorrect Kafka header value generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+	}
+
+	{
+		xRhIdentityHeader := headers[2]
+
+		{
+			want := "x-rh-identity"
+			got := xRhIdentityHeader.Key
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			xRhId, err := util.ParseXRHIDHeader(string(xRhIdentityHeader.Value))
+			if err != nil {
+				t.Errorf(`unexpected error when parsing the xRhIdentity base64 string: %s`, err)
+			}
+			{
+				want := testPskAccountValue
+				got := xRhId.Identity.AccountNumber
+
+				if want != got {
+					t.Errorf(`incorrect account number on xRhId struct. Want "%s", got "%s"`, want, got)
+				}
+			}
+			{
+				want := testOrgIdValue
+				got := xRhId.Identity.OrgID
+
+				if want != got {
+					t.Errorf(`incorrect orgId on xRhId struct. Want "%s", got "%s"`, want, got)
+				}
+			}
+		}
+	}
+
+}

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -199,8 +199,12 @@ func SourceDelete(c echo.Context) (err error) {
 	c.Logger().Infof("Deleting Source Id %v", id)
 
 	// Cascade delete the source.
-	headers := service.ForwadableHeaders(c)
-	err = service.DeleteCascade(sourcesDB.Tenant(), "Source", id, headers)
+	forwardableHeaders, err := service.ForwadableHeaders(c)
+	if err != nil {
+		return err
+	}
+
+	err = service.DeleteCascade(sourcesDB.Tenant(), "Source", id, forwardableHeaders)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}
@@ -418,17 +422,20 @@ func SourcePause(c echo.Context) error {
 	}
 
 	// Get the Kafka headers we will need to be forwarding.
-	kafkaHeaders := service.ForwadableHeaders(c)
+	forwardableHeaders, err := service.ForwadableHeaders(c)
+	if err != nil {
+		return err
+	}
 
 	// Raise the pause event for the source.
-	err = service.RaiseEvent("Source.pause", source, kafkaHeaders)
+	err = service.RaiseEvent("Source.pause", source, forwardableHeaders)
 	if err != nil {
 		return err
 	}
 
 	// Raise the pause event for its applications
 	for _, app := range source.Applications {
-		err := service.RaiseEvent("Application.pause", &app, kafkaHeaders)
+		err := service.RaiseEvent("Application.pause", &app, forwardableHeaders)
 		if err != nil {
 			return err
 		}
@@ -461,17 +468,20 @@ func SourceUnpause(c echo.Context) error {
 	}
 
 	// Get the Kafka headers we will need to be forwarding.
-	kafkaHeaders := service.ForwadableHeaders(c)
+	forwardableHeaders, err := service.ForwadableHeaders(c)
+	if err != nil {
+		return err
+	}
 
 	// Raise the unpause event for the source.
-	err = service.RaiseEvent("Source.unpause", source, kafkaHeaders)
+	err = service.RaiseEvent("Source.unpause", source, forwardableHeaders)
 	if err != nil {
 		return err
 	}
 
 	// Raise the unpause event for its applications
 	for _, app := range source.Applications {
-		err := service.RaiseEvent("Application.unpause", &app, kafkaHeaders)
+		err := service.RaiseEvent("Application.unpause", &app, forwardableHeaders)
 		if err != nil {
 			return err
 		}

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -139,7 +139,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		}
 
 		if emailInfo != nil {
-			err = service.EmitAvailabilityStatusNotification(accountNumber, emailInfo.ToEmail(previousStatus))
+			err = service.EmitAvailabilityStatusNotification(id.AccountNumber, emailInfo.ToEmail(previousStatus))
 			if err != nil {
 				l.Log.Errorf("unable to emit notification: %v", err)
 			}

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -104,14 +104,14 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		return
 	}
 
-	accountNumber, err := util.AccountNumberFromHeaders(headers)
+	id, err := util.IdentityFromKafkaHeaders(headers)
 	if err != nil {
 		l.Log.Error(err)
 		return
 	}
 
 	tenantDao := dao.GetTenantDao()
-	tenant, err := tenantDao.TenantByAccountNumber(accountNumber)
+	tenant, err := tenantDao.TenantByIdentity(id)
 	if err != nil {
 		l.Log.Error(err)
 		return

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -4,12 +4,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+	l "github.com/RedHatInsights/sources-api-go/logger"
 )
 
 func TestMain(t *testing.M) {
 	// we need this to parse arguments otherwise there are not recognized which lead to error
 	_ = parser.ParseFlags()
+
+	// Initialize the logger to avoid nil pointer dereferences.
+	l.InitLogger(config.Get())
 
 	os.Exit(t.Run())
 }

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"strings"
+	"testing"
+)
+
+// TestParseXRHIDHeader tests that the function parses the xRhIdentity header correctly.
+func TestParseXRHIDHeader(t *testing.T) {
+	// Set up the identity with some custom information.
+	accountNumber := "12345"
+	orgId := "abc-org-id"
+
+	xRhId := identity.XRHID{
+		Identity: identity.Identity{
+			AccountNumber: accountNumber,
+			OrgID:         orgId,
+		},
+	}
+
+	jsonIdentity, err := json.Marshal(xRhId)
+	if err != nil {
+		t.Errorf(`could not marshal test identity to JSON: %s`, err)
+	}
+
+	base64Identity := base64.StdEncoding.EncodeToString(jsonIdentity)
+
+	// Call the function under test.
+	result, err := ParseXRHIDHeader(base64Identity)
+	if err != nil {
+		t.Errorf(`unexpected error when parsing the identity: %s`, err)
+	}
+
+	{
+		want := orgId
+		got := result.Identity.OrgID
+
+		if want != got {
+			t.Errorf(`invalid OrgId returned. Want "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := accountNumber
+		got := result.Identity.AccountNumber
+
+		if want != got {
+			t.Errorf(`invalid account number returned. Want "%s", got "%s"`, want, got)
+		}
+	}
+
+}
+
+// TestParseXRHIDHeaderInvalidBase64String tests that an error is returned when the given string is not properly base64
+// encoded.
+func TestParseXRHIDHeaderInvalidBase64String(t *testing.T) {
+	invalidIdentity := "Hello, World!"
+
+	_, got := ParseXRHIDHeader(invalidIdentity)
+
+	want := "error decoding Identity"
+	if !strings.Contains(got.Error(), want) {
+		t.Errorf(`unexpected error received when decoding an invalid base64 string. Want "%s", got "%s"`, want, got)
+	}
+}
+
+// TestParseXRHIDHeaderInvalidBase64Json tests that an error is returned when the given string has an invalid base64
+// encoded JSON.
+func TestParseXRHIDHeaderInvalidBase64Json(t *testing.T) {
+	// {"hello": "world"
+	invalidJson := "eyJoZWxsbyI6ICJ3b3JsZCI="
+
+	_, got := ParseXRHIDHeader(invalidJson)
+
+	want := "x-rh-identity header does not contain"
+	if !strings.Contains(got.Error(), want) {
+		t.Errorf(`unexpected error received when decoding an invalid base64 string. Want "%s", got "%s"`, want, got)
+	}
+}

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -3,17 +3,21 @@ package util
 import (
 	"encoding/base64"
 	"encoding/json"
-	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"strings"
 	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-// TestParseXRHIDHeader tests that the function parses the xRhIdentity header correctly.
-func TestParseXRHIDHeader(t *testing.T) {
-	// Set up the identity with some custom information.
-	accountNumber := "12345"
-	orgId := "abc-org-id"
+// accountNumber to be used in the tests.
+const accountNumber = "12345"
 
+// orgId to be used in the tests.
+const orgId = "abc-org-id"
+
+// setUpValidIdentity returns a base64 encoded valid identity.
+func setUpValidIdentity(t *testing.T) string {
 	xRhId := identity.XRHID{
 		Identity: identity.Identity{
 			AccountNumber: accountNumber,
@@ -27,6 +31,13 @@ func TestParseXRHIDHeader(t *testing.T) {
 	}
 
 	base64Identity := base64.StdEncoding.EncodeToString(jsonIdentity)
+
+	return base64Identity
+}
+
+// TestParseXRHIDHeader tests that the function parses the xRhIdentity header correctly.
+func TestParseXRHIDHeader(t *testing.T) {
+	base64Identity := setUpValidIdentity(t)
 
 	// Call the function under test.
 	result, err := ParseXRHIDHeader(base64Identity)
@@ -79,4 +90,62 @@ func TestParseXRHIDHeaderInvalidBase64Json(t *testing.T) {
 	if !strings.Contains(got.Error(), want) {
 		t.Errorf(`unexpected error received when decoding an invalid base64 string. Want "%s", got "%s"`, want, got)
 	}
+}
+
+// TestIdentityFromKafkaHeaders tests that the function under test is able to extract the identity when the
+// "x-rh-identity" is given, and when the "x-rh-account-number" header is given.
+func TestIdentityFromKafkaHeaders(t *testing.T) {
+	// First test with the "x-rh-identity" header.
+	base64Identity := setUpValidIdentity(t)
+
+	headers := []kafka.Header{
+		{
+			Key:   xrhIdentityKey,
+			Value: []byte(base64Identity),
+		},
+	}
+
+	// Call the function under test.
+	id, err := IdentityFromKafkaHeaders(headers)
+	if err != nil {
+		t.Errorf(`unexpected error when recovering the identity: %s`, err)
+	}
+
+	{
+		want := accountNumber
+		got := id.AccountNumber
+		if want != got {
+			t.Errorf(`invalid account number extracted from identity. Want "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := orgId
+		got := id.OrgID
+		if want != got {
+			t.Errorf(`invalid orgId extracted from identity. Want "%s", got "%s"`, want, got)
+		}
+	}
+
+	// Lastly test with the "x-rh-account-number" header.
+	headers = []kafka.Header{
+		{
+			Key:   xrhAccountNumberKey,
+			Value: []byte(accountNumber),
+		},
+	}
+
+	id, err = IdentityFromKafkaHeaders(headers)
+	if err != nil {
+		t.Errorf(`unexpected error when recovering the identity: %s`, err)
+	}
+
+	{
+		want := accountNumber
+		got := id.AccountNumber
+		if want != got {
+			t.Errorf(`invalid account number extracted from identity. Want "%s", got "%s"`, want, got)
+		}
+	}
+
 }


### PR DESCRIPTION
This PR takes care of the incoming headers both by the REST API and the Kafka messages, by allowing the creation and fetching of the tenants by either the EBS account number or the orgId. It also adds a log message to watch for anemic tenants.

## Links

* [[RHCLOUD-18651]](https://issues.redhat.com/browse/RHCLOUD-18651)
* [[RHCLOUD-19093]](https://issues.redhat.com/browse/RHCLOUD-19093)