### PR TITLE
Remove SourceID and non-raw ID fields from AuthenticationCreateRequest

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -168,7 +168,6 @@ func TestAuthenticationCreate(t *testing.T) {
 		Password:      "123456",
 		ResourceType:  "Application",
 		ResourceIDRaw: 1,
-		SourceID:      1,
 	}
 
 	body, err := json.Marshal(requestBody)
@@ -223,7 +222,6 @@ func TestAuthenticationCreateBadRequest(t *testing.T) {
 		Password:     "123456",
 		ResourceType: "InvalidType",
 		ResourceID:   1,
-		SourceID:     1,
 	}
 
 	body, err := json.Marshal(requestBody)

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -50,8 +50,7 @@ type AuthenticationCreateRequest struct {
 
 	ResourceType  string      `json:"resource_type"`
 	ResourceIDRaw interface{} `json:"resource_id"`
-	ResourceID    int64
-	SourceID      int64 `json:"source_id"`
+	ResourceID    int64       `json:"-"`
 }
 
 type AuthenticationEditRequest struct {


### PR DESCRIPTION
Noticing this over on the superkey side - the `source_id` field is coming through when it shouldn't be able to. I should have caught this when I wrote this but apparently didn't. 