### PR TITLE
[RHCLOUD-18729] refactor: make integration tests use the real schema

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -724,12 +725,19 @@ func TestApplicationDelete(t *testing.T) {
 	tenantID := fixtures.TestTenantData[0].Id
 	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantID})
 
+	uid, err := uuid.NewUUID()
+	if err != nil {
+		t.Errorf(`could not create UUID fro the fixture source: %s`, err)
+	}
+
+	uidStr := uid.String()
 	src := m.Source{
 		Name:         "Source for TestApplicationDelete()",
 		SourceTypeID: 1,
+		Uid:          &uidStr,
 	}
 
-	err := sourceDao.Create(&src)
+	err = sourceDao.Create(&src)
 	if err != nil {
 		t.Errorf("source not created correctly: %s", err)
 	}

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -18,25 +18,13 @@ func TestDeleteApplicationAuthentication(t *testing.T) {
 
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestSourceData[0].TenantID)
 
-	applicationAuthentication := fixtures.TestApplicationAuthenticationData[0]
-	// Set the ID to 0 to let GORM know it should insert a new applicationAuthentication and not update an existing one.
-	applicationAuthentication.ID = 0
-	// Set some data to compare the returned applicationAuthentication.
-	applicationAuthentication.AuthenticationUID = "complex uuid"
-
-	// Create the test applicationAuthentication.
-	err := applicationAuthenticationDao.Create(&applicationAuthentication)
-	if err != nil {
-		t.Errorf("error creating applicationAuthentication: %s", err)
-	}
-
-	deletedApplicationAuthentication, err := applicationAuthenticationDao.Delete(&applicationAuthentication.ID)
+	deletedApplicationAuthentication, err := applicationAuthenticationDao.Delete(&fixtures.TestApplicationAuthenticationData[0].ID)
 	if err != nil {
 		t.Errorf("error deleting an applicationAuthentication: %s", err)
 	}
 
 	{
-		want := applicationAuthentication.ID
+		want := fixtures.TestApplicationAuthenticationData[0].ID
 		got := deletedApplicationAuthentication.ID
 
 		if want != got {
@@ -250,6 +238,7 @@ func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
 // and correct count of returned objects
 func TestApplicationAuthenticationListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("offset_limit")
 
 	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/google/uuid"
 )
 
 // TestAuthType is an authentication type used in the fixtures to perform checks.
@@ -267,10 +268,13 @@ func TestListForSource(t *testing.T) {
 
 	// Create a new source the new fixtures will be attached to.
 	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	uuidRaw, _ := uuid.NewUUID()
+	uuidStr := uuidRaw.String()
 	source := model.Source{
 		Name:         "new source in new tenant",
 		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
 		TenantID:     fixtures.TestTenantData[1].Id,
+		Uid:          &uuidStr,
 	}
 
 	err := sourceDao.Create(&source)
@@ -352,10 +356,13 @@ func TestListForApplication(t *testing.T) {
 
 	// Create a new source the new fixtures will be attached to.
 	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	uuidRaw, _ := uuid.NewUUID()
+	uuidStr := uuidRaw.String()
 	source := model.Source{
 		Name:         "new source in new tenant",
 		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
 		TenantID:     fixtures.TestTenantData[1].Id,
+		Uid:          &uuidStr,
 	}
 
 	err := sourceDao.Create(&source)
@@ -448,10 +455,13 @@ func TestListForApplicationAuthentication(t *testing.T) {
 
 	// Create a new source the new fixtures will be attached to.
 	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	uuidRaw, _ := uuid.NewUUID()
+	uuidStr := uuidRaw.String()
 	source := model.Source{
 		Name:         "new source in new tenant",
 		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
 		TenantID:     fixtures.TestTenantData[1].Id,
+		Uid:          &uuidStr,
 	}
 
 	err := sourceDao.Create(&source)
@@ -551,10 +561,13 @@ func TestListForEndpoint(t *testing.T) {
 
 	// Create a new source the new fixtures will be attached to.
 	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	uuidRaw, _ := uuid.NewUUID()
+	uuidStr := uuidRaw.String()
 	source := model.Source{
 		Name:         "new source in new tenant",
 		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
 		TenantID:     fixtures.TestTenantData[1].Id,
+		Uid:          &uuidStr,
 	}
 
 	err := sourceDao.Create(&source)

--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/db/migrations"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/mocks"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
-	m "github.com/RedHatInsights/sources-api-go/model"
-	"gorm.io/datatypes"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/sirupsen/logrus"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
@@ -26,6 +27,9 @@ var defaultSchema = "dao"
 
 func TestMain(t *testing.M) {
 	flags = parser.ParseFlags()
+
+	logging.Log = logrus.New()
+
 	if flags.Integration {
 		Vault = &mocks.MockVault{}
 		ConnectAndMigrateDB("dao")
@@ -125,9 +129,9 @@ func CreateFixtures(schema string) {
 
 	DB.Create(&fixtures.TestApplicationTypeData)
 	DB.Create(&fixtures.TestApplicationData)
-	DB.Create(&fixtures.TestApplicationAuthenticationData)
 
 	DB.Create(&fixtures.TestAuthenticationData)
+	DB.Create(&fixtures.TestApplicationAuthenticationData)
 
 	DB.Create(&fixtures.TestMetaDataData)
 
@@ -148,45 +152,12 @@ func DropSchema(dbSchema string) {
 
 // MigrateSchema migrates all the models for the current schema.
 func MigrateSchema() {
-	// Use a custom "authentication" table to avoid Gorm creating FKs when the real databases don't have them.
-	type authentication struct {
-		Id                      int64          `gorm:"primaryKey"`
-		Name                    string         `gorm:"column:name"`
-		AuthType                string         `gorm:"column:authtype"`
-		Username                string         `gorm:"column:username"`
-		MiqPassword             string         `gorm:"column:password"`
-		Password                string         `gorm:"column:password_hash"`
-		Extra                   datatypes.JSON `gorm:"column:extra"`
-		Version                 string         `gorm:"column:version"`
-		AvailabilityStatus      string         `gorm:"column:availability_status"`
-		AvailabilityStatusError string         `gorm:"column:availability_status_error"`
-		LastCheckedAt           time.Time      `gorm:"column:last_checked_at"`
-		LastAvailableAt         time.Time      `gorm:"column:last_available_at"`
-		SourceId                int64          `gorm:"column:source_id"`
-		TenantId                int64          `gorm:"column:tenant_id"`
-		UserID                  *int64         `gorm:"column:user_id"`
-		ResourceType            string         `gorm:"column:resource_type"`
-		ResourceId              int64          `gorm:"column:resource_id"`
-		CreatedAt               time.Time      `gorm:"column:created_at"`
-		UpdatedAt               time.Time      `gorm:"column:updated_at"`
-	}
-
-	err := DB.AutoMigrate(
-		&m.SourceType{},
-		&m.ApplicationType{},
-		&m.MetaData{},
-
-		&m.Source{},
-		&m.Endpoint{},
-		&m.RhcConnection{},
-		&m.SourceRhcConnection{},
-		&m.Application{},
-		&authentication{},
-		&m.ApplicationAuthentication{},
-	)
+	// Perform the migrations and store the error for a proper return.
+	migrateTool := gormigrate.New(DB, gormigrate.DefaultOptions, migrations.MigrationsCollection)
+	err := migrateTool.Migrate()
 
 	if err != nil {
-		log.Fatalf("Error automigrating the schema: %s", err)
+		log.Fatalf(`error migrating the schema: %s`, err)
 	}
 }
 

--- a/dao/rhc_connection_dao.go
+++ b/dao/rhc_connection_dao.go
@@ -207,7 +207,11 @@ func (s *rhcConnectionDaoImpl) Create(rhcConnection *m.RhcConnection) (*m.RhcCon
 }
 
 func (s *rhcConnectionDaoImpl) Update(rhcConnection *m.RhcConnection) error {
-	err := DB.Debug().
+	err := DB.
+		Debug().
+		// We need to use the "Omit" clause since otherwise Gorm tries to create the associate source for the
+		// connection as well.
+		Omit(clause.Associations).
 		Updates(rhcConnection).
 		Error
 	return err

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -135,6 +135,8 @@ func TestDeleteSource(t *testing.T) {
 	source.ID = 0
 	// Set some data to compare the returned source.
 	source.Name = "cool source"
+	sourceUid := "abcde-fghij"
+	source.Uid = &sourceUid
 
 	// Create the test source.
 	err := sourceDao.Create(&source)

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm"
 )
 
-var migrationsCollection = []*gormigrate.Migration{
+var MigrationsCollection = []*gormigrate.Migration{
 	InitialSchema(),
 	AddOrgIdToTenants(),
 	TranslateEbsAccountNumbersToOrgIds(),
@@ -72,7 +72,7 @@ func Migrate(db *gorm.DB) {
 	}
 
 	// Perform the migrations and store the error for a proper return.
-	migrateTool := gormigrate.New(db, gormigrate.DefaultOptions, migrationsCollection)
+	migrateTool := gormigrate.New(db, gormigrate.DefaultOptions, MigrationsCollection)
 	err = migrateTool.Migrate()
 	if err != nil {
 		logging.Log.Fatalf(`error when performing the database migrations: %s. The Redis lock is going to try to be released...`, err)

--- a/db/migrations/sql/1_initial_schema.sql
+++ b/db/migrations/sql/1_initial_schema.sql
@@ -11,13 +11,13 @@ AS $fk_exists$
 BEGIN
     RETURN EXISTS (
         SELECT 1 FROM "information_schema"."table_constraints"
-        WHERE "table_schema" = 'public' AND "table_name" = tn AND "constraint_name" = cn
+        WHERE "table_schema" = "current_schema"() AND "table_name" = tn AND "constraint_name" = cn
     );
 END
 $fk_exists$ LANGUAGE plpgsql;
 
 -- table_exists(string) takes a table name as an argument and
--- checks if it exists in the "public" schema.
+-- checks if it exists in the current schema.
 --
 -- Returns true if it exists.
 CREATE OR REPLACE FUNCTION "table_exists"(tn TEXT) RETURNS BOOLEAN
@@ -25,7 +25,7 @@ AS $table_exists$
 BEGIN
 	RETURN EXISTS (
 		SELECT 1 FROM "information_schema"."tables"
-		WHERE "table_schema" = 'public' AND "table_name" = tn
+		WHERE "table_schema" = "current_schema"() AND "table_name" = tn
 	);
 END
 $table_exists$ LANGUAGE plpgsql;
@@ -48,7 +48,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('application_authentications') THEN
-        CREATE TABLE public."application_authentications" (
+        CREATE TABLE "application_authentications" (
             "id" BIGINT NOT NULL,
             "tenant_id" BIGINT NOT NULL,
             "application_id" BIGINT NOT NULL,
@@ -58,25 +58,25 @@ BEGIN
             "paused_at" TIMESTAMP WITHOUT TIME ZONE
         );
 
-        CREATE SEQUENCE public."application_authentications_id_seq"
+        CREATE SEQUENCE "application_authentications_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."application_authentications_id_seq" OWNED BY public."application_authentications"."id";
+        ALTER SEQUENCE "application_authentications_id_seq" OWNED BY "application_authentications"."id";
 
-        ALTER TABLE ONLY public."application_authentications" ALTER COLUMN "id" SET DEFAULT nextval('public.application_authentications_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "application_authentications" ALTER COLUMN "id" SET DEFAULT nextval('application_authentications_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."application_authentications"
+        ALTER TABLE ONLY "application_authentications"
             ADD CONSTRAINT "application_authentications_pkey" PRIMARY KEY ("id");
 
-        CREATE INDEX "index_application_authentications_on_application_id" ON public."application_authentications" USING btree ("application_id");
-        CREATE INDEX "index_application_authentications_on_authentication_id" ON public."application_authentications" USING btree ("authentication_id");
-        CREATE INDEX "index_application_authentications_on_paused_at" ON public."application_authentications" USING btree ("paused_at");
-        CREATE INDEX "index_application_authentications_on_tenant_id" ON public."application_authentications" USING btree ("tenant_id");
-        CREATE UNIQUE INDEX "index_on_tenant_application_authentication" ON public."application_authentications" USING btree ("tenant_id", "application_id", "authentication_id");
+        CREATE INDEX "index_application_authentications_on_application_id" ON "application_authentications" USING btree ("application_id");
+        CREATE INDEX "index_application_authentications_on_authentication_id" ON "application_authentications" USING btree ("authentication_id");
+        CREATE INDEX "index_application_authentications_on_paused_at" ON "application_authentications" USING btree ("paused_at");
+        CREATE INDEX "index_application_authentications_on_tenant_id" ON "application_authentications" USING btree ("tenant_id");
+        CREATE UNIQUE INDEX "index_on_tenant_application_authentication" ON "application_authentications" USING btree ("tenant_id", "application_id", "authentication_id");
 
         RAISE NOTICE '"application_authentications": table, sequences and indexes created.';
     END IF;
@@ -91,7 +91,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('application_types') THEN
-        CREATE TABLE public."application_types" (
+        CREATE TABLE "application_types" (
             "id" BIGINT NOT NULL,
             "name" CHARACTER VARYING NOT NULL,
             "created_at" TIMESTAMP WITHOUT TIME ZONE NOT NULL,
@@ -102,21 +102,21 @@ BEGIN
             "supported_authentication_types" JSONB
         );
 
-        CREATE SEQUENCE public."application_types_id_seq"
+        CREATE SEQUENCE "application_types_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."application_types_id_seq" OWNED BY public."application_types"."id";
+        ALTER SEQUENCE "application_types_id_seq" OWNED BY "application_types"."id";
 
-        ALTER TABLE ONLY public."application_types" ALTER COLUMN "id" SET DEFAULT nextval('public.application_types_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "application_types" ALTER COLUMN "id" SET DEFAULT nextval('application_types_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."application_types"
+        ALTER TABLE ONLY "application_types"
             ADD CONSTRAINT "application_types_pkey" PRIMARY KEY ("id");
 
-        CREATE UNIQUE INDEX "index_application_types_on_name" ON public."application_types" USING btree ("name");
+        CREATE UNIQUE INDEX "index_application_types_on_name" ON "application_types" USING btree ("name");
 
         RAISE NOTICE '"application_types": table, sequences and indexes created.';
     END IF;
@@ -131,7 +131,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('applications') THEN
-        CREATE TABLE public."applications" (
+        CREATE TABLE "applications" (
             "id" BIGINT NOT NULL,
             "tenant_id" BIGINT NOT NULL,
             "source_id" BIGINT NOT NULL,
@@ -147,24 +147,24 @@ BEGIN
             "paused_at" TIMESTAMP WITHOUT TIME ZONE
         );
 
-        CREATE SEQUENCE public."applications_id_seq"
+        CREATE SEQUENCE "applications_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."applications_id_seq" OWNED BY public."applications"."id";
+        ALTER SEQUENCE "applications_id_seq" OWNED BY "applications"."id";
 
-        ALTER TABLE ONLY public."applications" ALTER COLUMN "id" SET DEFAULT nextval('public.applications_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "applications" ALTER COLUMN "id" SET DEFAULT nextval('applications_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."applications"
+        ALTER TABLE ONLY "applications"
             ADD CONSTRAINT "applications_pkey" PRIMARY KEY ("id");
 
-        CREATE INDEX "index_applications_on_application_type_id" ON public."applications" USING btree ("application_type_id");
-        CREATE INDEX "index_applications_on_paused_at" ON public."applications" USING btree ("paused_at");
-        CREATE INDEX "index_applications_on_source_id" ON public."applications" USING btree ("source_id");
-        CREATE INDEX "index_applications_on_tenant_id" ON public."applications" USING btree ("tenant_id");
+        CREATE INDEX "index_applications_on_application_type_id" ON "applications" USING btree ("application_type_id");
+        CREATE INDEX "index_applications_on_paused_at" ON "applications" USING btree ("paused_at");
+        CREATE INDEX "index_applications_on_source_id" ON "applications" USING btree ("source_id");
+        CREATE INDEX "index_applications_on_tenant_id" ON "applications" USING btree ("tenant_id");
 
         RAISE NOTICE '"applications": table, sequences and indexes created.';
     END IF;
@@ -179,7 +179,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('authentications') THEN
-        CREATE TABLE public."authentications" (
+        CREATE TABLE "authentications" (
             "id" BIGINT NOT NULL,
             "resource_type" CHARACTER VARYING,
             "resource_id" integer,
@@ -198,23 +198,23 @@ BEGIN
             "password_hash" CHARACTER VARYING
         );
 
-        CREATE SEQUENCE public."authentications_id_seq"
+        CREATE SEQUENCE "authentications_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."authentications_id_seq" OWNED BY public."authentications"."id";
+        ALTER SEQUENCE "authentications_id_seq" OWNED BY "authentications"."id";
 
-        ALTER TABLE ONLY public."authentications" ALTER COLUMN "id" SET DEFAULT nextval('public.authentications_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "authentications" ALTER COLUMN "id" SET DEFAULT nextval('authentications_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."authentications"
+        ALTER TABLE ONLY "authentications"
             ADD CONSTRAINT "authentications_pkey" PRIMARY KEY ("id");
 
-        CREATE INDEX "index_authentications_on_paused_at" ON public."authentications" USING btree ("paused_at");
-        CREATE INDEX "index_authentications_on_resource_type_and_resource_id" ON public."authentications" USING btree ("resource_type", "resource_id");
-        CREATE INDEX "index_authentications_on_tenant_id" ON public."authentications" USING btree ("tenant_id");
+        CREATE INDEX "index_authentications_on_paused_at" ON "authentications" USING btree ("paused_at");
+        CREATE INDEX "index_authentications_on_resource_type_and_resource_id" ON "authentications" USING btree ("resource_type", "resource_id");
+        CREATE INDEX "index_authentications_on_tenant_id" ON "authentications" USING btree ("tenant_id");
 
         RAISE NOTICE '"authentications": table, sequences and indexes created.';
     END IF;
@@ -229,7 +229,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('endpoints') THEN
-        CREATE TABLE public."endpoints" (
+        CREATE TABLE "endpoints" (
             "id" BIGINT NOT NULL,
             "role" CHARACTER VARYING,
             "port" integer,
@@ -251,23 +251,23 @@ BEGIN
             "paused_at" TIMESTAMP WITHOUT TIME ZONE
         );
 
-        CREATE SEQUENCE public."endpoints_id_seq"
+        CREATE SEQUENCE "endpoints_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."endpoints_id_seq" OWNED BY public."endpoints"."id";
+        ALTER SEQUENCE "endpoints_id_seq" OWNED BY "endpoints"."id";
 
-        ALTER TABLE ONLY public."endpoints" ALTER COLUMN "id" SET DEFAULT nextval('public.endpoints_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "endpoints" ALTER COLUMN "id" SET DEFAULT nextval('endpoints_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."endpoints"
+        ALTER TABLE ONLY "endpoints"
             ADD CONSTRAINT "endpoints_pkey" PRIMARY KEY ("id");
 
-        CREATE INDEX "index_endpoints_on_paused_at" ON public."endpoints" USING btree ("paused_at");
-        CREATE INDEX "index_endpoints_on_source_id" ON public."endpoints" USING btree ("source_id");
-        CREATE INDEX "index_endpoints_on_tenant_id" ON public."endpoints" USING btree ("tenant_id");
+        CREATE INDEX "index_endpoints_on_paused_at" ON "endpoints" USING btree ("paused_at");
+        CREATE INDEX "index_endpoints_on_source_id" ON "endpoints" USING btree ("source_id");
+        CREATE INDEX "index_endpoints_on_tenant_id" ON "endpoints" USING btree ("tenant_id");
 
         RAISE NOTICE '"endpoints": table, sequences and indexes created.';
     END IF;
@@ -282,7 +282,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('meta_data') THEN
-        CREATE TABLE public."meta_data" (
+        CREATE TABLE "meta_data" (
             "id" BIGINT NOT NULL,
             "application_type_id" integer,
             "step" integer,
@@ -294,18 +294,18 @@ BEGIN
             "type" CHARACTER VARYING
         );
 
-        CREATE SEQUENCE public."meta_data_id_seq"
+        CREATE SEQUENCE "meta_data_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."meta_data_id_seq" OWNED BY public."meta_data"."id";
+        ALTER SEQUENCE "meta_data_id_seq" OWNED BY "meta_data"."id";
 
-        ALTER TABLE ONLY public."meta_data" ALTER COLUMN "id" SET DEFAULT nextval('public.meta_data_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "meta_data" ALTER COLUMN "id" SET DEFAULT nextval('meta_data_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."meta_data"
+        ALTER TABLE ONLY "meta_data"
             ADD CONSTRAINT "meta_data_pkey" PRIMARY KEY ("id");
 
         RAISE NOTICE '"meta_data": table, sequences and indexes created.';
@@ -321,7 +321,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('rhc_connections') THEN
-        CREATE TABLE public."rhc_connections" (
+        CREATE TABLE "rhc_connections" (
             "id" BIGINT NOT NULL,
             "rhc_id" CHARACTER VARYING,
             "extra" JSONB DEFAULT '{}'::JSONB,
@@ -333,21 +333,21 @@ BEGIN
             "updated_at" TIMESTAMP WITHOUT TIME ZONE NOT NULL
         );
 
-        CREATE SEQUENCE public."rhc_connections_id_seq"
+        CREATE SEQUENCE "rhc_connections_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."rhc_connections_id_seq" OWNED BY public."rhc_connections"."id";
+        ALTER SEQUENCE "rhc_connections_id_seq" OWNED BY "rhc_connections"."id";
 
-        ALTER TABLE ONLY public."rhc_connections" ALTER COLUMN "id" SET DEFAULT nextval('public.rhc_connections_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "rhc_connections" ALTER COLUMN "id" SET DEFAULT nextval('rhc_connections_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."rhc_connections"
+        ALTER TABLE ONLY "rhc_connections"
             ADD CONSTRAINT "rhc_connections_pkey" PRIMARY KEY ("id");
 
-        CREATE UNIQUE INDEX "index_rhc_connections_on_rhc_id" ON public."rhc_connections" USING btree ("rhc_id");
+        CREATE UNIQUE INDEX "index_rhc_connections_on_rhc_id" ON "rhc_connections" USING btree ("rhc_id");
 
         RAISE NOTICE '"rhc_connections": table, sequences and indexes created.';
     END IF;
@@ -362,13 +362,13 @@ DO
 $$
     BEGIN
         IF NOT "table_exists"('source_rhc_connections') THEN
-            CREATE TABLE public."source_rhc_connections" (
+            CREATE TABLE "source_rhc_connections" (
                 "source_id" INTEGER,
                 "rhc_connection_id" INTEGER,
                 "tenant_id" BIGINT
             );
 
-            CREATE UNIQUE INDEX "index_source_rhc_connections_on_source_id_and_rhc_connection_id" ON public."source_rhc_connections" USING btree ("source_id", "rhc_connection_id");
+            CREATE UNIQUE INDEX "index_source_rhc_connections_on_source_id_and_rhc_connection_id" ON "source_rhc_connections" USING btree ("source_id", "rhc_connection_id");
 
             RAISE NOTICE '"source_rhc_connections": table and index created.';
         END IF;
@@ -383,7 +383,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('source_types') THEN
-        CREATE TABLE public."source_types" (
+        CREATE TABLE "source_types" (
             "id" BIGINT NOT NULL,
             "name" CHARACTER VARYING NOT NULL,
             "product_name" CHARACTER VARYING NOT NULL,
@@ -394,21 +394,21 @@ BEGIN
             "icon_url" CHARACTER VARYING
         );
 
-        CREATE SEQUENCE public."source_types_id_seq"
+        CREATE SEQUENCE "source_types_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."source_types_id_seq" OWNED BY public."source_types"."id";
+        ALTER SEQUENCE "source_types_id_seq" OWNED BY "source_types"."id";
 
-        ALTER TABLE ONLY public."source_types" ALTER COLUMN "id" SET DEFAULT nextval('public.source_types_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "source_types" ALTER COLUMN "id" SET DEFAULT nextval('source_types_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."source_types"
+        ALTER TABLE ONLY "source_types"
             ADD CONSTRAINT "source_types_pkey" PRIMARY KEY ("id");
 
-        CREATE UNIQUE INDEX "index_source_types_on_name" ON public."source_types" USING btree ("name");
+        CREATE UNIQUE INDEX "index_source_types_on_name" ON "source_types" USING btree ("name");
 
         RAISE NOTICE '"source_types": table, sequences and indexes created.';
     END IF;
@@ -423,7 +423,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('sources') THEN
-        CREATE TABLE public."sources" (
+        CREATE TABLE "sources" (
             "id" BIGINT NOT NULL,
             "name" CHARACTER VARYING NOT NULL,
             "uid" CHARACTER VARYING NOT NULL,
@@ -441,24 +441,24 @@ BEGIN
             "paused_at" TIMESTAMP WITHOUT TIME ZONE
         );
 
-        CREATE SEQUENCE public."sources_id_seq"
+        CREATE SEQUENCE "sources_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."sources_id_seq" OWNED BY public."sources"."id";
+        ALTER SEQUENCE "sources_id_seq" OWNED BY "sources"."id";
 
-        ALTER TABLE ONLY public."sources" ALTER COLUMN "id" SET DEFAULT nextval('public.sources_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "sources" ALTER COLUMN "id" SET DEFAULT nextval('sources_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."sources"
+        ALTER TABLE ONLY "sources"
             ADD CONSTRAINT "sources_pkey" PRIMARY KEY ("id");
 
-        CREATE INDEX "index_sources_on_paused_at" ON public."sources" USING btree ("paused_at");
-        CREATE INDEX index_sources_on_source_type_id ON public."sources" USING btree ("source_type_id");
-        CREATE INDEX index_sources_on_tenant_id ON public."sources" USING btree ("tenant_id");
-        CREATE UNIQUE INDEX index_sources_on_uid ON public."sources" USING btree ("uid");
+        CREATE INDEX "index_sources_on_paused_at" ON "sources" USING btree ("paused_at");
+        CREATE INDEX index_sources_on_source_type_id ON "sources" USING btree ("source_type_id");
+        CREATE INDEX index_sources_on_tenant_id ON "sources" USING btree ("tenant_id");
+        CREATE UNIQUE INDEX index_sources_on_uid ON "sources" USING btree ("uid");
 
         RAISE NOTICE '"sources": table, sequences and indexes created.';
     END IF;
@@ -473,7 +473,7 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('tenants') THEN
-        CREATE TABLE public."tenants" (
+        CREATE TABLE "tenants" (
             "id" BIGINT NOT NULL,
             "name" CHARACTER VARYING,
             "description" TEXT,
@@ -482,18 +482,18 @@ BEGIN
             "updated_at" TIMESTAMP WITHOUT TIME ZONE NOT NULL
         );
 
-        CREATE SEQUENCE public."tenants_id_seq"
+        CREATE SEQUENCE "tenants_id_seq"
             START WITH 1
             INCREMENT BY 1
             NO MINVALUE
             NO MAXVALUE
             CACHE 1;
 
-        ALTER SEQUENCE public."tenants_id_seq" OWNED BY public."tenants"."id";
+        ALTER SEQUENCE "tenants_id_seq" OWNED BY "tenants"."id";
 
-        ALTER TABLE ONLY public."tenants" ALTER COLUMN "id" SET DEFAULT nextval('public.tenants_id_seq'::REGCLASS);
+        ALTER TABLE ONLY "tenants" ALTER COLUMN "id" SET DEFAULT nextval('tenants_id_seq'::REGCLASS);
 
-        ALTER TABLE ONLY public."tenants"
+        ALTER TABLE ONLY "tenants"
             ADD CONSTRAINT "tenants_pkey" PRIMARY KEY ("id");
 
         RAISE NOTICE '"tenants": table, sequences and indexes created.';
@@ -516,14 +516,14 @@ DO
 $$
 BEGIN
     IF NOT "fk_exists"('fk_rails_85a04922b1', 'application_authentications') THEN
-        ALTER TABLE ONLY public."application_authentications"
-            ADD CONSTRAINT "fk_rails_85a04922b1" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "application_authentications"
+            ADD CONSTRAINT "fk_rails_85a04922b1" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE;
 
-        ALTER TABLE ONLY public."application_authentications"
-            ADD CONSTRAINT "fk_rails_d709bbbff3" FOREIGN KEY ("authentication_id") REFERENCES public."authentications"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "application_authentications"
+            ADD CONSTRAINT "fk_rails_d709bbbff3" FOREIGN KEY ("authentication_id") REFERENCES "authentications"("id") ON DELETE CASCADE;
 
-        ALTER TABLE ONLY public."application_authentications"
-            ADD CONSTRAINT "fk_rails_a051188e10" FOREIGN KEY ("application_id") REFERENCES public."applications"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "application_authentications"
+            ADD CONSTRAINT "fk_rails_a051188e10" FOREIGN KEY ("application_id") REFERENCES "applications"("id") ON DELETE CASCADE;
 
         RAISE NOTICE '"application_authentications": foreign keys created.';
     END IF;
@@ -538,14 +538,14 @@ DO
 $$
 BEGIN
     IF NOT "fk_exists"('fk_rails_ad5ea13d24', 'applications') THEN
-        ALTER TABLE ONLY public."applications"
-            ADD CONSTRAINT "fk_rails_ad5ea13d24" FOREIGN KEY ("application_type_id") REFERENCES public."application_types"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "applications"
+            ADD CONSTRAINT "fk_rails_ad5ea13d24" FOREIGN KEY ("application_type_id") REFERENCES "application_types"("id") ON DELETE CASCADE;
 
-        ALTER TABLE ONLY public."applications"
-            ADD CONSTRAINT "fk_rails_cbcddd5826" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "applications"
+            ADD CONSTRAINT "fk_rails_cbcddd5826" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE;
 
-        ALTER TABLE ONLY public.applications
-            ADD CONSTRAINT "fk_rails_064e03ae58" FOREIGN KEY ("source_id") REFERENCES public."sources"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY applications
+            ADD CONSTRAINT "fk_rails_064e03ae58" FOREIGN KEY ("source_id") REFERENCES "sources"("id") ON DELETE CASCADE;
 
         RAISE NOTICE '"applications": foreign keys created.';
     END IF;
@@ -560,8 +560,8 @@ DO
 $$
 BEGIN
     IF NOT "fk_exists"('fk_rails_28143f952b', 'authentications') THEN
-        ALTER TABLE ONLY public.authentications
-            ADD CONSTRAINT "fk_rails_28143f952b" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY authentications
+            ADD CONSTRAINT "fk_rails_28143f952b" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE;
 
         RAISE NOTICE '"authentications": foreign keys created.';
     END IF;
@@ -576,11 +576,11 @@ DO
 $$
 BEGIN
     IF NOT "fk_exists"('fk_rails_430e742d27', 'endpoints') THEN
-        ALTER TABLE ONLY public."endpoints"
-            ADD CONSTRAINT "fk_rails_430e742d27" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "endpoints"
+            ADD CONSTRAINT "fk_rails_430e742d27" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE;
 
-        ALTER TABLE ONLY public."endpoints"
-            ADD CONSTRAINT "fk_rails_67ee0f0d63" FOREIGN KEY ("source_id") REFERENCES public."sources"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "endpoints"
+            ADD CONSTRAINT "fk_rails_67ee0f0d63" FOREIGN KEY ("source_id") REFERENCES "sources"("id") ON DELETE CASCADE;
 
         RAISE NOTICE '"endpoints": foreign keys created.';
     END IF;
@@ -595,14 +595,14 @@ DO
 $$
 BEGIN
     IF NOT "fk_exists"('fk_rhc_connection_id', 'source_rhc_connections') THEN
-        ALTER TABLE ONLY public."source_rhc_connections"
-            ADD CONSTRAINT "fk_rhc_connection_id" FOREIGN KEY ("rhc_connection_id") REFERENCES public."rhc_connections"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "source_rhc_connections"
+            ADD CONSTRAINT "fk_rhc_connection_id" FOREIGN KEY ("rhc_connection_id") REFERENCES "rhc_connections"("id") ON DELETE CASCADE;
 
-        ALTER TABLE ONLY public."source_rhc_connections"
-            ADD CONSTRAINT "fk_source_id" FOREIGN KEY ("source_id") REFERENCES public."sources"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "source_rhc_connections"
+            ADD CONSTRAINT "fk_source_id" FOREIGN KEY ("source_id") REFERENCES "sources"("id") ON DELETE CASCADE;
 
-        ALTER TABLE ONLY public."source_rhc_connections"
-            ADD CONSTRAINT "fk_tenant_id" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id");
+        ALTER TABLE ONLY "source_rhc_connections"
+            ADD CONSTRAINT "fk_tenant_id" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id");
     END IF;
 END
 $$;
@@ -615,12 +615,12 @@ DO
 $$
 BEGIN
     IF NOT "fk_exists"('fk_rails_e7365b4f5b', 'sources') THEN
-        ALTER TABLE ONLY public."sources"
-            ADD CONSTRAINT "fk_rails_e7365b4f5b" FOREIGN KEY ("source_type_id") REFERENCES public."source_types"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "sources"
+            ADD CONSTRAINT "fk_rails_e7365b4f5b" FOREIGN KEY ("source_type_id") REFERENCES "source_types"("id") ON DELETE CASCADE;
 
 
-        ALTER TABLE ONLY public."sources"
-            ADD CONSTRAINT "fk_rails_f830a376e4" FOREIGN KEY ("tenant_id") REFERENCES public."tenants"("id") ON DELETE CASCADE;
+        ALTER TABLE ONLY "sources"
+            ADD CONSTRAINT "fk_rails_f830a376e4" FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id") ON DELETE CASCADE;
 
         RAISE NOTICE '"sources": foreign keys created.';
     END IF;
@@ -635,14 +635,14 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('ar_internal_metadata') THEN
-        CREATE TABLE public."ar_internal_metadata" (
+        CREATE TABLE "ar_internal_metadata" (
             "key" CHARACTER VARYING NOT NULL,
             "value" CHARACTER VARYING,
             "created_at" TIMESTAMP WITHOUT TIME ZONE NOT NULL,
             "updated_at" TIMESTAMP WITHOUT TIME ZONE NOT NULL
         );
 
-        ALTER TABLE ONLY public."ar_internal_metadata"
+        ALTER TABLE ONLY "ar_internal_metadata"
             ADD CONSTRAINT "ar_internal_metadata_pkey" PRIMARY KEY ("key");
     END IF;
 END
@@ -653,11 +653,11 @@ DO
 $$
 BEGIN
     IF NOT "table_exists"('ar_internal_metadata') THEN
-        CREATE TABLE public."schema_migrations" (
+        CREATE TABLE "schema_migrations" (
             "version" CHARACTER VARYING NOT NULL
         );
 
-        ALTER TABLE ONLY public."schema_migrations"
+        ALTER TABLE ONLY "schema_migrations"
             ADD CONSTRAINT "schema_migrations_pkey" PRIMARY KEY ("version");
     END IF;
 END

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -578,12 +579,19 @@ func TestEndpointDelete(t *testing.T) {
 	tenantID := fixtures.TestTenantData[0].Id
 	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantID})
 
+	uid, err := uuid.NewUUID()
+	if err != nil {
+		t.Errorf(`could not create UUID fro the fixture source: %s`, err)
+	}
+
+	uidStr := uid.String()
 	src := m.Source{
 		Name:         "Source for TestApplicationDelete()",
 		SourceTypeID: 1,
+		Uid:          &uidStr,
 	}
 
-	err := sourceDao.Create(&src)
+	err = sourceDao.Create(&src)
 	if err != nil {
 		t.Errorf("source not created correctly: %s", err)
 	}

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -581,7 +581,7 @@ func TestEndpointDelete(t *testing.T) {
 
 	uid, err := uuid.NewUUID()
 	if err != nil {
-		t.Errorf(`could not create UUID fro the fixture source: %s`, err)
+		t.Errorf(`could not create UUID from the fixture source: %s`, err)
 	}
 
 	uidStr := uid.String()

--- a/main_test.go
+++ b/main_test.go
@@ -53,7 +53,8 @@ func TestMain(t *testing.M) {
 
 		service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &mocks.MockSender{}} }
 
-		database.CreateFixtures()
+		database.CreateFixtures("public")
+
 		err := dao.PopulateStaticTypeCache()
 		if err != nil {
 			panic("failed to populate static type cache")

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -29,7 +29,7 @@ func TestMain(t *testing.M) {
 
 		endpointDao = dao.GetEndpointDao(&fixtures.TestTenantData[0].Id)
 		sourceDao = dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
-		database.CreateFixtures()
+		database.CreateFixtures("service")
 	} else {
 		endpointDao = &dao.MockEndpointDao{}
 		sourceDao = &dao.MockSourceDao{}

--- a/service/source_validation_test.go
+++ b/service/source_validation_test.go
@@ -68,13 +68,21 @@ func TestInvalidDuplicatedNameInTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	sourceName := "Source350"
-	newSource := model.Source{ID: 350, Name: sourceName, SourceTypeID: 1, TenantID: 1}
-	dao.DB.Create(&newSource)
+	sourceUid := "abcde-fghijk"
+	newSource := model.Source{ID: 350, Name: sourceName, SourceTypeID: 1, TenantID: 1, Uid: &sourceUid}
+	err := dao.DB.
+		Debug().
+		Create(&newSource).
+		Error
+
+	if err != nil {
+		t.Errorf(`could not create the source fixture for the test: %s`, err)
+	}
 
 	request := setUp()
 	request.Name = &sourceName
 
-	err := ValidateSourceCreationRequest(sourceDao, &request)
+	err = ValidateSourceCreationRequest(sourceDao, &request)
 
 	if err == nil {
 		t.Errorf("Error expected, got none")

--- a/statuslistener/main_test.go
+++ b/statuslistener/main_test.go
@@ -6,12 +6,14 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+	l "github.com/RedHatInsights/sources-api-go/logger"
 )
 
 // runningIntegration is used to skip integration tests if we're just running unit tests.
 var runningIntegration = false
 
 func TestMain(t *testing.M) {
+	l.InitLogger(config)
 	flags := parser.ParseFlags()
 
 	if flags.CreateDb {
@@ -19,7 +21,7 @@ func TestMain(t *testing.M) {
 	} else if flags.Integration {
 		runningIntegration = true
 		database.ConnectAndMigrateDB("status_listener")
-		database.CreateFixtures()
+		database.CreateFixtures("status_listener")
 	}
 
 	code := t.Run()


### PR DESCRIPTION
This accomplishes two things:

1. We test the migrations since they get applied all the time.
2. We actually test again the database structure we use in development,
staging and production environments.

## Links

[[RHCLOUD-18729]](https://issues.redhat.com/browse/RHCLOUD-18729)