### PR TITLE
Add GraphQL Proxy back in, hidden behind an ENV var

### DIFF
--- a/graphql_handlers.go
+++ b/graphql_handlers.go
@@ -2,14 +2,19 @@ package main
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/RedHatInsights/sources-api-go/graph"
 	"github.com/RedHatInsights/sources-api-go/graph/generated"
+	l "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/labstack/echo/v4"
 )
 
@@ -18,6 +23,9 @@ var (
 	srv *handler.Server
 	// the wrapped handler function for graphql
 	h echo.HandlerFunc
+
+	// this is the uri to hit "old" sources api, initialized in the init() function
+	legacyUri string
 )
 
 func init() {
@@ -31,6 +39,20 @@ func init() {
 	}
 
 	h = echo.WrapHandler(srv)
+
+	// set the default host/port to what we'll see in k8s environments. Override
+	// this by setting these values locally
+	legacyHost := os.Getenv("RAILS_HOST")
+	if legacyHost == "" {
+		legacyHost = "sources-api-svc"
+	}
+
+	legacyPort := os.Getenv("RAILS_PORT")
+	if legacyPort == "" {
+		legacyPort = "8000"
+	}
+
+	legacyUri = "http://" + legacyHost + ":" + legacyPort + "/api/sources/v3.1/graphql"
 }
 
 func GraphQLQuery(c echo.Context) error {
@@ -63,4 +85,45 @@ func GraphQLQuery(c echo.Context) error {
 	)
 
 	return h(c)
+}
+
+// this handler proxies the graphql request body + headers included over to the
+// legacy rails side.
+//
+// it will probably sit here for quite a while - basically until we decide to
+// implement graphql on the golang side which is a very low priority.
+func ProxyGraphqlToLegacySources(c echo.Context) error {
+	l.Log.Debugf("Proxying /graphql to [%v]", legacyUri)
+
+	// set up a context with the parent as the request - limiting execution time to 10 seconds
+	ctx, cancel := context.WithTimeout(c.Request().Context(), 10*time.Second)
+	defer cancel()
+
+	// create a request - passing the body right along
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, legacyUri, c.Request().Body)
+	if err != nil {
+		return err
+	}
+
+	// fetch the headers to forward along
+	for _, h := range service.ForwadableHeaders(c) {
+		req.Header.Add(h.Key, string(h.Value))
+	}
+
+	// add the content-type header, rails won't pick up the body otherwise
+	req.Header.Add("Content-Type", "application/json")
+
+	// run the request!
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return c.JSONBlob(resp.StatusCode, bytes)
 }

--- a/routes.go
+++ b/routes.go
@@ -103,12 +103,17 @@ func setupRoutes(e *echo.Echo) {
 		r.GET("/rhc_connections/:id/sources", RhcConnectionSourcesList, permissionWithListMiddleware...)
 
 		// GraphQL
-		r.POST("/graphql", GraphQLQuery, middleware.Tenancy)
+		// TODO: remove this once we get the crazy filtering going on the gqlgen graphql
+		if os.Getenv("PROXY_GRAPHQL") == "true" {
+			r.POST("/graphql", ProxyGraphqlToLegacySources, middleware.Tenancy)
+		} else {
+			r.POST("/graphql", GraphQLQuery, middleware.Tenancy)
 
-		// run the graphQL playground if running locally or in ephemeral. really handy for development!
-		// https://github.com/graphql/graphiql
-		if os.Getenv("SOURCES_ENV") != "stage" && os.Getenv("SOURCES_ENV") != "prod" {
-			r.GET("/graphql_playground", echo.WrapHandler(playground.Handler("Sources API GraphQL Playground", "/api/sources/v3.1/graphql")))
+			// run the graphQL playground if running locally or in ephemeral. really handy for development!
+			// https://github.com/graphql/graphiql
+			if os.Getenv("SOURCES_ENV") != "stage" && os.Getenv("SOURCES_ENV") != "prod" {
+				r.GET("/graphql_playground", echo.WrapHandler(playground.Handler("Sources API GraphQL Playground", "/api/sources/v3.1/graphql")))
+			}
 		}
 	}
 


### PR DESCRIPTION
Since the filtering is just a bit crazier than initially anticipated (filtering on `sources.applications.application_type.<field> == "thing"`, oh my!) we're going to add the proxy back in and add the ability to turn it on/off via an ENV var. 