### PR TITLE
[RHCLOUD-18724] feature: "password_hash" column in the initial migration

### DIFF
--- a/db/migrations/sql/1_initial_schema.sql
+++ b/db/migrations/sql/1_initial_schema.sql
@@ -194,7 +194,8 @@ BEGIN
             "last_checked_at" TIMESTAMP WITHOUT TIME ZONE,
             "last_available_at" TIMESTAMP WITHOUT TIME ZONE,
             "source_id" BIGINT,
-            "paused_at" TIMESTAMP WITHOUT TIME ZONE
+            "paused_at" TIMESTAMP WITHOUT TIME ZONE,
+            "password_hash" CHARACTER VARYING
         );
 
         CREATE SEQUENCE public."authentications_id_seq"


### PR DESCRIPTION
Since the column has been added in the Rails application, this should be included in the initial schema migration as well.

Reference: https://github.com/RedHatInsights/sources-api/pull/496

## Links

[[RHCLOUD-18724]](https://issues.redhat.com/browse/RHCLOUD-18724)