### PR TITLE
[RHCLOUD-18723] Cascade delete resources

### DIFF
--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -13,7 +13,7 @@ import (
 // TestDeleteApplicationAuthentication tests that an applicationAuthentication gets correctly deleted, and its data returned.
 func TestDeleteApplicationAuthentication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -43,14 +43,14 @@ func TestDeleteApplicationAuthentication(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 // TestDeleteApplicationAuthenticationNotExists tests that when an applicationAuthentication that doesn't exist is tried to be deleted, an error is
 // returned.
 func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -61,5 +61,5 @@ func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -3,12 +3,14 @@ package dao
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
@@ -127,4 +129,175 @@ func TestDeleteApplicationNotExists(t *testing.T) {
 	}
 
 	DoneWithFixtures("delete")
+}
+
+func TestApplicationDeleteCascade(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("delete")
+
+	// Create a new application on the database to cleanly test the function under test.
+	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	fixtureApp := model.Application{
+		ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
+		SourceID:          fixtures.TestSourceData[0].ID,
+		TenantID:          fixtures.TestTenantData[0].Id,
+	}
+
+	err := applicationDao.Create(&fixtureApp)
+	if err != nil {
+		t.Errorf(`could not create the fixture application: %s`, err)
+	}
+
+	// Create the authentications and the application authentications. The former are needed to avoid the foreign key
+	// constraints.
+	authenticationDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+
+	// Set the maximum amount of authentications we will create.
+	maxAuthenticationsCreated := 5
+
+	// Store the application authentications to perform checks later.
+	var createdAppAuths []model.ApplicationAuthentication
+	for i := 0; i < maxAuthenticationsCreated; i++ {
+		// Create the authentication.
+		authentication := setUpValidAuthentication()
+		authentication.ResourceType = "Application"
+		authentication.ResourceID = fixtureApp.ID
+
+		err := authenticationDao.Create(authentication)
+		if err != nil {
+			t.Errorf(`could not create the fixture authentication: %s`, err)
+		}
+
+		// Create the association between the application and its authentication.
+		appAuth := model.ApplicationAuthentication{
+			TenantID:          fixtures.TestTenantData[0].Id,
+			ApplicationID:     fixtureApp.ID,
+			AuthenticationID:  authentication.DbID,
+			AuthenticationUID: fmt.Sprintf("%d", i),
+		}
+
+		err = applicationAuthenticationDao.Create(&appAuth)
+		if err != nil {
+			t.Errorf(`could not create the fixture application authentication: %s`, err)
+		}
+
+		createdAppAuths = append(createdAppAuths, appAuth)
+	}
+
+	deletedApplicationAuthentications, deletedApplication, err := applicationDao.DeleteCascade(fixtureApp.ID)
+	if err != nil {
+		t.Errorf(`could not delete cascade the application: %s`, err)
+	}
+
+	// Count the application authentications from the given application, to check that they were deleted.
+	var appAuthCount int64
+	err = DB.
+		Debug().
+		Model(model.ApplicationAuthentication{}).
+		Where("application_id = ?", fixtureApp.ID).
+		Where("tenant_id = ?", fixtures.TestTenantData[0].Id).
+		Count(&appAuthCount).
+		Error
+
+	if err != nil {
+		t.Errorf(`error counting the application authentications related to the application: %s`, err)
+	}
+
+	// Check if the application authentications were deleted or not.
+	{
+		want := int64(0)
+		got := appAuthCount
+		if want != got {
+			t.Errorf(`the application authentications were not deleted. Want a count of "%d", got "%d"`, want, got)
+		}
+	}
+
+	// Check that we deleted the correct number of application authentications, and no more.
+	{
+		want := len(createdAppAuths)
+		got := len(deletedApplicationAuthentications)
+
+		if want != got {
+			t.Errorf(`unexpected number of application authentications deleted. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	// Check that we deleted the application authentications we expected to delete.
+	for i := 0; i < maxAuthenticationsCreated; i++ {
+		{
+			want := createdAppAuths[i].ID
+			got := deletedApplicationAuthentications[i].ID
+
+			if want != got {
+				t.Errorf(`unexpected application authentication deleted. Want application authentication with ID "%d", got ID "%d"`, want, got)
+			}
+		}
+	}
+
+	// Try to fetch the deleted application.
+	var deletedApplicationCheck *model.Application
+	err = DB.
+		Debug().
+		Model(model.Application{}).
+		Where(`id = ?`, fixtureApp.ID).
+		Where(`tenant_id = ?`, fixtures.TestTenantData[0].Id).
+		Find(&deletedApplicationCheck).
+		Error
+
+	if err != nil {
+		t.Errorf(`unexpected error: %s`, err)
+	}
+
+	// Check that the expected application was deleted.
+	if deletedApplicationCheck.ID != 0 {
+		t.Errorf(`unexpected application fetched. It should be deleted, but this application was fetched: %v`, deletedApplicationCheck)
+	}
+
+	{
+		want := fixtureApp.ID
+		got := deletedApplication.ID
+
+		if want != got {
+			t.Errorf(`unexpected application deleted. Want application with id "%d", got "%d"`, want, got)
+		}
+	}
+
+	DoneWithFixtures("delete")
+}
+
+// TestApplicationExists tests whether the function exists returns true when the given application exists.
+func TestApplicationExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("exists")
+	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+
+	got, err := applicationDao.Exists(fixtures.TestApplicationData[0].ID)
+	if err != nil {
+		t.Errorf(`unexpected error when checking that the application exists: %s`, err)
+	}
+
+	if !got {
+		t.Errorf(`the application does exist but the "Exist" function returns otherwise. Want "true", got "%t"`, got)
+	}
+
+	DoneWithFixtures("exists")
+}
+
+// TestApplicationNotExists tests whether the function exists returns false when the given application does not exist.
+func TestApplicationNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("exists")
+	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+
+	got, err := applicationDao.Exists(12345)
+	if err != nil {
+		t.Errorf(`unexpected error when checking that the application exists: %s`, err)
+	}
+
+	if got {
+		t.Errorf(`the application doesn't exist but the "Exist" function returns otherwise. Want "false", got "%t"`, got)
+	}
+
+	DoneWithFixtures("exists")
 }

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -20,8 +20,7 @@ var testApplication = fixtures.TestApplicationData[0]
 // TestPausingApplication tests that an application gets correctly paused when using the method from the DAO.
 func TestPausingApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-
-	CreateFixtures("pause_unpause")
+	SwitchSchema("pause_unpause")
 
 	applicationDao := GetApplicationDao(&fixtures.TestSourceData[0].TenantID)
 	err := applicationDao.Pause(testApplication.ID)
@@ -39,14 +38,13 @@ func TestPausingApplication(t *testing.T) {
 		t.Errorf(`want now, got "%s"`, application.PausedAt)
 	}
 
-	DoneWithFixtures("pause_unpause")
+	DropSchema("pause_unpause")
 }
 
 // TestResumeApplication tests that the application is properly resumed when using the method from the DAO.
 func TestResumeApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-
-	CreateFixtures("pause_unpause")
+	SwitchSchema("pause_unpause")
 
 	applicationDao := GetApplicationDao(&testApplication.TenantID)
 	err := applicationDao.Unpause(testApplication.ID)
@@ -65,13 +63,13 @@ func TestResumeApplication(t *testing.T) {
 		t.Errorf(`want "%s", got "%s"`, want, application.PausedAt)
 	}
 
-	DoneWithFixtures("pause_unpause")
+	DropSchema("pause_unpause")
 }
 
 // TestDeleteApplication tests that an application gets correctly deleted, and its data returned.
 func TestDeleteApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	applicationDao := GetApplicationDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -110,14 +108,14 @@ func TestDeleteApplication(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 // TestDeleteApplicationNotExists tests that when an application that doesn't exist is tried to be deleted, an error is
 // returned.
 func TestDeleteApplicationNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	applicationDao := GetApplicationDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -128,12 +126,12 @@ func TestDeleteApplicationNotExists(t *testing.T) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 func TestApplicationDeleteCascade(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	// Create a new application on the database to cleanly test the function under test.
 	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
@@ -263,13 +261,14 @@ func TestApplicationDeleteCascade(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 // TestApplicationExists tests whether the function exists returns true when the given application exists.
 func TestApplicationExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("exists")
+	SwitchSchema("exists")
+
 	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
 
 	got, err := applicationDao.Exists(fixtures.TestApplicationData[0].ID)
@@ -281,13 +280,14 @@ func TestApplicationExists(t *testing.T) {
 		t.Errorf(`the application does exist but the "Exist" function returns otherwise. Want "true", got "%t"`, got)
 	}
 
-	DoneWithFixtures("exists")
+	DropSchema("exists")
 }
 
 // TestApplicationNotExists tests whether the function exists returns false when the given application does not exist.
 func TestApplicationNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("exists")
+	SwitchSchema("exists")
+
 	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
 
 	got, err := applicationDao.Exists(12345)
@@ -299,5 +299,5 @@ func TestApplicationNotExists(t *testing.T) {
 		t.Errorf(`the application doesn't exist but the "Exist" function returns otherwise. Want "false", got "%t"`, got)
 	}
 
-	DoneWithFixtures("exists")
+	DropSchema("exists")
 }

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -261,6 +261,24 @@ func TestApplicationDeleteCascade(t *testing.T) {
 		}
 	}
 
+	// Check that the deleted resources come with the related tenant. This is necessary since otherwise the events will
+	// not have the "tenant" key populated.
+	for _, applicationAuthentication := range deletedApplicationAuthentications {
+		want := fixtures.TestTenantData[0].ExternalTenant
+		got := applicationAuthentication.Tenant.ExternalTenant
+
+		if want != got {
+			t.Errorf(`the application authentication doesn't come with the related tenant. Want external tenant "%s", got "%s"`, want, got)
+		}
+	}
+
+	want := fixtures.TestTenantData[0].ExternalTenant
+	got := deletedApplication.Tenant.ExternalTenant
+
+	if want != got {
+		t.Errorf(`the application doesn't come with the related tenant. Want external tenant "%s", got "%s"`, want, got)
+	}
+
 	DropSchema("delete")
 }
 

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -7,7 +7,6 @@ import (
 
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
-	"gorm.io/gorm/clause"
 )
 
 type authenticationDaoDbImpl struct {
@@ -497,23 +496,39 @@ func (add *authenticationDaoDbImpl) ListIdsForResource(resourceType string, reso
 }
 
 func (add *authenticationDaoDbImpl) BulkDelete(authentications []m.Authentication) ([]m.Authentication, error) {
+	// Collect the ids to be able to find all the authentication objects for them.
 	var authIds = make([]int64, len(authentications))
 	for i, auth := range authentications {
 		authIds[i] = auth.DbID
 	}
 
-	var deletedAuthentications []m.Authentication
+	// The authentications are fetched with the "Tenant" table preloaded, so that all the objects are returned with the
+	// "external_tenant" column populated. This is required to be able to raise events with the "tenant" key populated.
+	//
+	// The "len(objects) != 0" check to delete the resources is necessary to avoid Gorm issuing the "cannot batch
+	// delete without a where condition" error. In theory this should not happen, since this function is expected to
+	// be called with a "len(authentications) != 0" slice, but just to be safe...
+	var dbAuths []m.Authentication
 	err := DB.
 		Debug().
-		Model(m.Authentication{}).
-		Clauses(clause.Returning{}).
-		Where("id IN ?", authIds).
-		Delete(&deletedAuthentications).
+		Preload("Tenant").
+		Find(&dbAuths, authIds).
 		Error
 
 	if err != nil {
 		return nil, err
 	}
 
-	return deletedAuthentications, nil
+	if len(dbAuths) != 0 {
+		err = DB.
+			Debug().
+			Delete(&dbAuths).
+			Error
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return dbAuths, nil
 }

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -1041,5 +1041,16 @@ func TestBulkDelete(t *testing.T) {
 		}
 	}
 
+	// Check that the deleted resources come with the related tenant. This is necessary since otherwise the events will
+	// not have the "tenant" key populated.
+	for _, auth := range deletedAuths {
+		want := fixtures.TestTenantData[0].ExternalTenant
+		got := auth.Tenant.ExternalTenant
+
+		if want != got {
+			t.Errorf(`the authentication doesn't come with the related tenant. Want external tenant "%s", got "%s"`, want, got)
+		}
+	}
+
 	DropSchema("authentications_db")
 }

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -44,7 +44,8 @@ func createAuthenticationFixture(t *testing.T) {
 // if the minimum data is provided for an authentication.
 func TestAuthenticationDbCreate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
+
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
 	auth := setUpValidAuthentication()
@@ -55,14 +56,15 @@ func TestAuthenticationDbCreate(t *testing.T) {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestAuthenticationDbBulkCreate tests that the "BulkCreate" function does not present any problems at creating new
 // entities if the minimum data is provided for an authentication.
 func TestAuthenticationDbBulkCreate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
+
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
 	auth := setUpValidAuthentication()
@@ -72,13 +74,14 @@ func TestAuthenticationDbBulkCreate(t *testing.T) {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestAuthenticationDbList tests that the "list" operation returns the expected number of authentications.
 func TestAuthenticationDbList(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
+
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
 	// Create another authentication to see if the listing function also brings it back.
@@ -108,13 +111,13 @@ func TestAuthenticationDbList(t *testing.T) {
 		t.Errorf(`the fixture that was inserted did not come in the authentications list. Something went wrong.`)
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestAuthenticationDbGet tests that the "get" operation is able to fetch the expected authentication.
 func TestAuthenticationDbGetById(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
@@ -139,13 +142,13 @@ func TestAuthenticationDbGetById(t *testing.T) {
 		t.Errorf(`wrong authentication fetched. Want "%s" authtype, got "%s"`, want, got)
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestAuthenticationDbUpdate tests that the "update" operation is able to properly update the authentication.
 func TestAuthenticationDbUpdate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
@@ -180,13 +183,13 @@ func TestAuthenticationDbUpdate(t *testing.T) {
 		t.Errorf(`deleted the wrong authentication. Want authtype "%s", got "%s"`, want, got)
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestAuthenticationDbGet tests that the "delete" operation is able to delete the expected authentication.
 func TestAuthenticationDbDelete(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
@@ -218,14 +221,14 @@ func TestAuthenticationDbDelete(t *testing.T) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestAuthenticationDbGet tests the "delete" operation returns a "not found" error when trying to delete a
 // non-existing authentication.
 func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
 	_, err := dao.Delete("12345")
@@ -233,7 +236,7 @@ func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestTenantId is a trivial test which tests that a correct tenant ID is returned in the function.
@@ -252,7 +255,7 @@ func TestTenantId(t *testing.T) {
 // TestListForSource tests if "list for source" only lists the authentications of the related source, and no more.
 func TestListForSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
 	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
@@ -305,14 +308,14 @@ func TestListForSource(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestListForSourceNotFound tests if a not found error is returned when a nonexistent source is given to the function
 // under test.
 func TestListForSourceNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
 
@@ -327,14 +330,14 @@ func TestListForSourceNotFound(t *testing.T) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestListForApplication tests if "list for Application" only lists the authentications of the related application, and no
 // more.
 func TestListForApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
 	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
@@ -399,14 +402,14 @@ func TestListForApplication(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestListForApplicationNotFound tests if a not found error is returned when a nonexistent application is given to the
 // function under test.
 func TestListForApplicationNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
 
@@ -421,14 +424,14 @@ func TestListForApplicationNotFound(t *testing.T) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestListForApplicationAuthentication tests if "list for ApplicationAuthentication" only lists the authentications of
 // the related ApplicationAuthentication, and no more.
 func TestListForApplicationAuthentication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
 	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
@@ -508,14 +511,14 @@ func TestListForApplicationAuthentication(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestListForApplicationAuthenticationNotFound tests if a not found error is returned when a nonexistent application
 // authentication is given to the function under test.
 func TestListForApplicationAuthenticationNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
 
@@ -530,13 +533,13 @@ func TestListForApplicationAuthenticationNotFound(t *testing.T) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestListForEndpoint tests if "list for Endpoint" only lists the authentications of the related endpoint, and no more.
 func TestListForEndpoint(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
 	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
@@ -600,14 +603,14 @@ func TestListForEndpoint(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestListForEndpointNotFound tests if a not found error is returned when a nonexistent endpoint is given to the
 // function under test.
 func TestListForEndpointNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
 
@@ -622,13 +625,13 @@ func TestListForEndpointNotFound(t *testing.T) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestFetchAndUpdateBy tests if "FetchAndUpdateBy" updates the timestamps as expected.
 func TestFetchAndUpdateBy(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
@@ -708,13 +711,13 @@ func TestFetchAndUpdateBy(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestToEventJSON tests if "FetchAndUpdateBy" returns the expected output for the given resource.
 func TestToEventJSON(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
@@ -753,7 +756,7 @@ func TestToEventJSON(t *testing.T) {
 		t.Errorf(`"ToEventJSON" didn't return the expected result. Want "%s", got "%s"'`, want, got)
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestBulkMessage tests if "BulkMessage" returns the expected output for the given resource. It simply calls the
@@ -761,7 +764,7 @@ func TestToEventJSON(t *testing.T) {
 // test also "BulkMessageFromSource".
 func TestBulkMessage(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
@@ -818,14 +821,14 @@ func TestBulkMessage(t *testing.T) {
 		t.Errorf(`"BulkMessage" didn't return the expected result. Want "%s", got "%s"'`, want, got)
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestListIdsForResource tests that the function under test is able to fetch the authentications belonging to a
 // resource type and a resource id.
 func TestListIdsForResource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// In this test we want a clean "authentications" table.
 	err := DB.
@@ -936,14 +939,14 @@ func TestListIdsForResource(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }
 
 // TestBulkDelete tests that the BulkDelete function only deletes the authentications that were passed. N
 // authentications are created for multiple resource types and the function tries to bulk delete them all.
 func TestBulkDelete(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("authentications_db")
+	SwitchSchema("authentications_db")
 
 	// Specify the resources we will be creating the authentications for.
 	resources := []struct {
@@ -1038,5 +1041,5 @@ func TestBulkDelete(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("authentications_db")
+	DropSchema("authentications_db")
 }

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -13,7 +13,7 @@ import (
 // TestDeleteEndpoint tests that an endpoint gets correctly deleted, and its data returned.
 func TestDeleteEndpoint(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	endpointDao := GetEndpointDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -53,14 +53,14 @@ func TestDeleteEndpoint(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 // TestDeleteEndpointNotExists tests that when an endpoint that doesn't exist is tried to be deleted, an error is
 // returned.
 func TestDeleteEndpointNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	endpointDao := GetEndpointDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -71,5 +71,5 @@ func TestDeleteEndpointNotExists(t *testing.T) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -29,6 +29,11 @@ type SourceDao interface {
 	// Unpause resumes the given source and all its dependant applications.
 	Unpause(id int64) error
 	IsSuperkey(id int64) bool
+	// DeleteCascade deletes the source along with all its related sub resources. It returns all the deleted
+	// sub resources and the source itself.
+	DeleteCascade(sourceId int64) ([]m.ApplicationAuthentication, []m.Application, []m.Endpoint, []m.RhcConnection, *m.Source, error)
+	// Exists returns true if the source exists.
+	Exists(sourceId int64) (bool, error)
 }
 
 type ApplicationDao interface {
@@ -48,6 +53,10 @@ type ApplicationDao interface {
 	Unpause(id int64) error
 	GetByIdWithPreload(id *int64, preloads ...string) (*m.Application, error)
 	IsSuperkey(id int64) bool
+	// DeleteCascade deletes the application along with all its related application authentications.
+	DeleteCascade(applicationId int64) ([]m.ApplicationAuthentication, *m.Application, error)
+	// Exists returns true if the application exists.
+	Exists(applicationId int64) (bool, error)
 }
 
 type AuthenticationDao interface {
@@ -66,6 +75,11 @@ type AuthenticationDao interface {
 	BulkMessage(resource util.Resource) (map[string]interface{}, error)
 	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error
 	ToEventJSON(resource util.Resource) ([]byte, error)
+	// ListIdsForResource fetches all the authentication IDs for the given resource. The rest of the fields will be
+	// either nil or default values.
+	ListIdsForResource(resourceType string, resourceIds []int64) ([]m.Authentication, error)
+	// BulkDelete deletes all the authentications given as a list, and returns the ones that were deleted.
+	BulkDelete(authentications []m.Authentication) ([]m.Authentication, error)
 }
 
 type ApplicationAuthenticationDao interface {

--- a/dao/rhc_connection_dao_test.go
+++ b/dao/rhc_connection_dao_test.go
@@ -38,7 +38,7 @@ func setUpValidRhcConnection() *model.RhcConnection {
 // associated row in the "rhc_connections" and "source_rhc_connections" tables.
 func TestRhcConnectionCreate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	want := setUpValidRhcConnection()
 	got, err := rhcConnectionDao.Create(want)
@@ -86,7 +86,7 @@ func TestRhcConnectionCreate(t *testing.T) {
 		t.Errorf(`want "%d", got "%d"`, got.ID, gotJoinTable.SourceId)
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestRhcConnectionCreateExistingSourceDifferentTenant tests that when querying for a source from a tenant that is not
@@ -94,7 +94,7 @@ func TestRhcConnectionCreate(t *testing.T) {
 // able to link connections to sources from other tenants.
 func TestRhcConnectionCreateExistingSourceDifferentTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	rhcConnection := setUpValidRhcConnection()
 
@@ -111,7 +111,7 @@ func TestRhcConnectionCreateExistingSourceDifferentTenant(t *testing.T) {
 
 	// Set the tenant back to its original value
 	rhcConnectionDao.TenantID = &tenantId
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestRhcConnectionCreateExisting tests that when an already existing "RhcConnection" is given to the "Create"
@@ -119,7 +119,7 @@ func TestRhcConnectionCreateExistingSourceDifferentTenant(t *testing.T) {
 // an error.
 func TestRhcConnectionCreateExisting(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	want := setUpValidRhcConnection()
 	want.RhcId = fixtures.TestRhcConnectionData[2].RhcId
@@ -180,14 +180,14 @@ func TestRhcConnectionCreateExisting(t *testing.T) {
 		t.Errorf(`want to find "%d" in "%v", but it was not found`, want.Sources[0].ID, gotJoinTable)
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestRhcConnectionCreateSourceNotExists tests that a proper error is returned when a non-existing related source is
 // given.
 func TestRhcConnectionCreateSourceNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	// Modify the valid object to make it point to a non-existing source.
 	rhcConnection := setUpValidRhcConnection()
@@ -203,14 +203,14 @@ func TestRhcConnectionCreateSourceNotExists(t *testing.T) {
 		t.Errorf(`want "%s" type, got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestRhcConnectionCreateAlreadyExistingAssociation tests that when an error is returned when an already existing
 // association between the source and the rhcConnection exists in the join table.
 func TestRhcConnectionCreateAlreadyExistingAssociation(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	rhcConnection := setUpValidRhcConnection()
 
@@ -226,14 +226,14 @@ func TestRhcConnectionCreateAlreadyExistingAssociation(t *testing.T) {
 		t.Errorf(`want "%s", got "%s"`, want, err)
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestRhcConnectionDelete tests that when an rhcConnection is deleted, its associations in the join table are also
 // deleted.
 func TestRhcConnectionDelete(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	_, err := rhcConnectionDao.Delete(&fixtures.TestRhcConnectionData[0].ID)
 	if err != nil {
@@ -256,14 +256,14 @@ func TestRhcConnectionDelete(t *testing.T) {
 		t.Errorf(`want "rhcConnection" deleted, data found`)
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestRhcConnectionDeleteNotFound tests that when a non-existent ID is given to the delete function, a "not found"
 // error is returned.
 func TestRhcConnectionDeleteNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	nonExistentId := int64(12345)
 
@@ -277,13 +277,13 @@ func TestRhcConnectionDeleteNotFound(t *testing.T) {
 		t.Errorf(`want "%s" type, got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestRhcConnectionListForSources tests whether the correct connections are fetched from the related source or not.
 func TestRhcConnectionListForSources(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	sourceId := int64(1)
 
@@ -320,7 +320,7 @@ func TestRhcConnectionListForSources(t *testing.T) {
 
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestRhcConnectionRowsClosed is a regression test for https://issues.redhat.com/browse/RHCLOUD-18192. It tests that
@@ -328,7 +328,7 @@ func TestRhcConnectionListForSources(t *testing.T) {
 // error.
 func TestRhcConnectionRowsClosed(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	// Find all the connections that we will remove from the DB.
 	dbRhcConnections := make([]model.RhcConnection, 0)
@@ -365,13 +365,13 @@ func TestRhcConnectionRowsClosed(t *testing.T) {
 		t.Errorf(`want "%d" connections from the database, got "%d"`, want, got)
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // TestDeleteRhcConnection tests that an rhcConnection gets correctly deleted, and its data returned.
 func TestDeleteRhcConnection(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	rhcConnection := fixtures.TestRhcConnectionData[0]
 	// Set the ID to 0 to let GORM know it should insert a new rhcConnection and not update an existing one.
@@ -410,14 +410,14 @@ func TestDeleteRhcConnection(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 // TestDeleteRhcConnectionNotExists tests that when an rhcConnection that doesn't exist is tried to be deleted, an
 // error is returned.
 func TestDeleteRhcConnectionNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	RhcConnectionDao := GetRhcConnectionDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -428,5 +428,5 @@ func TestDeleteRhcConnectionNotExists(t *testing.T) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }

--- a/dao/seeding_test.go
+++ b/dao/seeding_test.go
@@ -21,6 +21,9 @@ func getSeedFilesystemDir() string {
 
 func TestSeedingSourceTypes(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	CloseConnection()
+	ConnectToTestDB("seeding")
+	MigrateSchema()
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")
@@ -157,4 +160,6 @@ func TestSeedingApplicationMetadata(t *testing.T) {
 	if len(appmdata) != count {
 		t.Errorf("Seeding did not match values, got %v expected %v", len(appmdata), count)
 	}
+
+	DropSchema("seeding")
 }

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -1,13 +1,16 @@
 package dao
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
@@ -183,4 +186,448 @@ func TestDeleteSourceNotExists(t *testing.T) {
 	}
 
 	DoneWithFixtures("delete")
+}
+
+// TestDeleteCascade is a long test function, but very simple in essence. Essentially what it does is:
+//
+// - It checks that when a source with no subresources is deleted, only that particular source is deleted.
+// - It creates N applications, endpoints and rhcConnections for a fixture source.
+// - Cascade deletes the source with the function under test.
+// - Checks that the deleted subresources and source are the ones that have been created in this very same test.
+func TestDeleteCascade(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("delete")
+
+	// Create a new source fixture to avoid mixing the applications with the ones that already exist.
+	fixtureSource := model.Source{
+		Name:         "fixture-source",
+		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
+		TenantID:     fixtures.TestTenantData[0].Id,
+		Uid:          util.StringRef("new-shiny-source"),
+	}
+
+	// Try inserting the source in the database.
+	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
+	err := sourceDao.Create(&fixtureSource)
+	if err != nil {
+		t.Errorf(`error creating a fixture source: %s`, err)
+	}
+
+	// Check that the only deleted resource should be the source itself, since it doesn't have any subresources.
+	applicationAuthentications, applications, endpoints, rhcConnections, deletedSource, err := sourceDao.DeleteCascade(fixtureSource.ID)
+	if err != nil {
+		t.Errorf(`unexpected error received when cascade deleting the source: %s`, err)
+	}
+
+	// Double-check the "deleted" resources and the source itself.
+	{
+		want := 0
+		got := len(applicationAuthentications)
+		if want != got {
+			t.Errorf(`unexpected application authentications deleted. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := 0
+		got := len(applications)
+		if want != got {
+			t.Errorf(`unexpected applications deleted. Want "%d", got "%d"`, want, got)
+		}
+	}
+	{
+		want := 0
+		got := len(endpoints)
+		if len(endpoints) != 0 {
+			t.Errorf(`unexpected endpoints deleted. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := 0
+		got := len(rhcConnections)
+		if len(rhcConnections) != 0 {
+			t.Errorf(`unexpected rhcConnections deleted. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := fixtureSource.ID
+		got := deletedSource.ID
+		if want != got {
+			t.Errorf(`wrong source deleted. Want source with ID "%d", got ID "%d"`, want, got)
+		}
+	}
+
+	// Reinsert the source.
+	fixtureSource.ID = 0
+	err = sourceDao.Create(&fixtureSource)
+	if err != nil {
+		t.Errorf(`error creating a fixture source: %s`, err)
+	}
+
+	// Grab the DAOs which we will use to create the subresources.
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	applicationsDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	authenticationDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
+	rhcConnectionsDao := GetRhcConnectionDao(&fixtures.TestTenantData[0].Id)
+
+	// Establish a maximum number of subresources we want to insert.
+	maximumSubresourcesToCreate := 5
+
+	// We want the created subresources so that we can compare them later to the deleted ones.
+	var createdApplications []model.Application
+	var createdApplicationAuthentications []model.ApplicationAuthentication
+	var createdEndpoints []model.Endpoint
+	var createdRhcConnections []model.RhcConnection
+
+	// Create all the subresources.
+	for i := 0; i < maximumSubresourcesToCreate; i++ {
+		// Create the related applications.
+		extra := fmt.Sprintf(`{"idx": "%d"}`, i)
+		app := model.Application{
+			Extra:             []byte(extra),
+			SourceID:          fixtureSource.ID,
+			TenantID:          fixtureSource.TenantID,
+			ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
+		}
+
+		err := applicationsDao.Create(&app)
+		if err != nil {
+			t.Errorf(`error creating the application fixture: %s`, err)
+		}
+
+		createdApplications = append(createdApplications, app)
+
+		// Create one authentication per application.
+		authentication := setUpValidAuthentication()
+		authentication.ResourceType = "Application"
+		authentication.ResourceID = app.ID
+
+		err = authenticationDao.Create(authentication)
+		if err != nil {
+			t.Errorf(`could not create the fixture authentication: %s`, err)
+		}
+
+		// Create the association between the application and its authentication.
+		appAuth := model.ApplicationAuthentication{
+			TenantID:          fixtures.TestTenantData[0].Id,
+			ApplicationID:     app.ID,
+			AuthenticationID:  authentication.DbID,
+			AuthenticationUID: fmt.Sprintf("%d", i),
+		}
+
+		err = applicationAuthenticationDao.Create(&appAuth)
+		if err != nil {
+			t.Errorf(`could not create the fixture application authentication: %s`, err)
+		}
+		createdApplicationAuthentications = append(createdApplicationAuthentications, appAuth)
+
+		// Create the related endpoints.
+		host := fmt.Sprintf(`domain%d.com`, i)
+		endpoint := model.Endpoint{
+			Host:     &host,
+			SourceID: fixtureSource.ID,
+			TenantID: fixtureSource.TenantID,
+		}
+
+		err = endpointDao.Create(&endpoint)
+		if err != nil {
+			t.Errorf(`error creating the endpoint fixture: %s`, err)
+		}
+
+		createdEndpoints = append(createdEndpoints, endpoint)
+
+		// Create the related rhcConnections.
+		rhcId := fmt.Sprintf(`rhc-id-%d`, i)
+		rhcConnection := model.RhcConnection{
+			RhcId:   rhcId,
+			Sources: []model.Source{{ID: fixtureSource.ID}},
+		}
+
+		_, err = rhcConnectionsDao.Create(&rhcConnection)
+		if err != nil {
+			t.Errorf(`error creating the rhcConnection fixture: %s`, err)
+		}
+
+		createdRhcConnections = append(createdRhcConnections, rhcConnection)
+	}
+
+	// Call the function under test.
+	deletedApplicationAuthentications, deletedApplications, deletedEndpoints, deletedRhcConnections, deletedSource, err := sourceDao.DeleteCascade(fixtureSource.ID)
+	if err != nil {
+		t.Errorf(`unexpected error when calling source delete cascade: %s`, err)
+	}
+
+	// Count the application authentications from the given source, to check that they were deleted.
+	var appAuthsCount int64
+	err = DB.
+		Debug().
+		Model(model.ApplicationAuthentication{}).
+		Joins(`INNER JOIN "applications" ON "application_authentications"."application_id" = "applications"."id"`).
+		Where(`applications.source_id = ?`, fixtureSource.ID).
+		Where(`applications.tenant_id = ?`, fixtures.TestTenantData[0].Id).
+		Count(&appAuthsCount).
+		Error
+
+	if err != nil {
+		t.Errorf(`error counting the application authentications related to the source: %s`, err)
+	}
+
+	// Check if the application authentications were deleted or not.
+	{
+		want := int64(0)
+		got := appAuthsCount
+		if want != got {
+			t.Errorf(`the application authentications were not deleted. Want a count of "%d", got "%d"`, want, got)
+		}
+	}
+
+	// Check that the expected applicationAuthentications were deleted.
+	for i := 0; i < maximumSubresourcesToCreate; i++ {
+		{
+			want := createdApplicationAuthentications[i].ID
+			got := deletedApplicationAuthentications[i].ID
+
+			if want != got {
+				t.Errorf(`unexpected application authentication deleted. Want application with ID "%d", got ID "%d"`, want, got)
+			}
+		}
+
+		{
+			want := createdApplicationAuthentications[i].ApplicationID
+			got := deletedApplicationAuthentications[i].ApplicationID
+
+			if want != got {
+				t.Errorf(`unexpected application authentication deleted. Want application authentication with application ID "%d", got "%d"`, want, got)
+			}
+		}
+	}
+
+	// Count the applications from the given source, to check that they were deleted.
+	var appCount int64
+	err = DB.
+		Debug().
+		Model(model.Application{}).
+		Where("source_id = ?", fixtureSource.ID).
+		Where("tenant_id = ?", fixtures.TestTenantData[0].Id).
+		Count(&appCount).
+		Error
+
+	if err != nil {
+		t.Errorf(`error counting the applications related to the source: %s`, err)
+	}
+
+	// Check if the applications were deleted or not.
+	{
+		want := int64(0)
+		got := appCount
+		if want != got {
+			t.Errorf(`the applications were not deleted. Want a count of "%d", got "%d"`, want, got)
+		}
+	}
+
+	// Check that the expected applications were deleted.
+	for i := 0; i < maximumSubresourcesToCreate; i++ {
+		{
+			want := createdApplications[i].ID
+			got := deletedApplications[i].ID
+
+			if want != got {
+				t.Errorf(`unexpected application deleted. Want application with ID "%d", got ID "%d"`, want, got)
+			}
+		}
+
+		{
+			want := createdApplications[i].Extra
+			got := deletedApplications[i].Extra
+
+			if !bytes.Equal(want, got) {
+				t.Errorf(`unexpected application deleted. Want application with extra "%s", got extra "%s"`, want, got)
+			}
+		}
+	}
+
+	// Count the endpoints from the given source, to check that they were deleted.
+	var endpointCount int64
+	err = DB.
+		Debug().
+		Model(model.Endpoint{}).
+		Where("source_id = ?", fixtureSource.ID).
+		Where("tenant_id = ?", fixtures.TestTenantData[0].Id).
+		Count(&endpointCount).
+		Error
+
+	if err != nil {
+		t.Errorf(`error counting the endpoints related to the source: %s`, err)
+	}
+
+	// Check if the endpoints were deleted or not.
+	{
+		want := int64(0)
+		got := endpointCount
+		if want != got {
+			t.Errorf(`the endpoints were not deleted. Want a count of "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := len(createdEndpoints)
+		got := len(deletedEndpoints)
+
+		if want != got {
+			t.Errorf(`unexpected amount of endpoints deleted. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	// Check that the expected endpoints were deleted.
+	for i := 0; i < maximumSubresourcesToCreate; i++ {
+		{
+			want := createdEndpoints[i].ID
+			got := deletedEndpoints[i].ID
+
+			if want != got {
+				t.Errorf(`unexpected endpoint deleted. Want endpoint with ID "%d", got ID "%d"`, want, got)
+			}
+		}
+
+		{
+			want := *createdEndpoints[i].Host
+			got := *deletedEndpoints[i].Host
+
+			if want != got {
+				t.Errorf(`unexpected endpoint deleted. Want endpoint with host "%s", got host "%s"`, want, got)
+			}
+		}
+	}
+
+	// Count the rhcConnections from the given source, to check that they were deleted.
+	var rhcConnectionsCount int64
+	err = DB.
+		Debug().
+		Model(model.RhcConnection{}).
+		Joins(`INNER JOIN "source_rhc_connections" "sr" ON "rhc_connections"."id" = "sr"."rhc_connection_id"`).
+		Where(`"sr"."source_id" = ?`, fixtureSource.ID).
+		Where(`"sr"."tenant_id" = ?`, fixtures.TestTenantData[0].Id).
+		Count(&rhcConnectionsCount).
+		Error
+
+	if err != nil {
+		t.Errorf(`error counting the rhcConnections related to the source: %s`, err)
+	}
+
+	// Check if the rhcConnections were deleted or not.
+	{
+		want := int64(0)
+		got := rhcConnectionsCount
+		if want != got {
+			t.Errorf(`the rhcConnections were not deleted. Want a count of "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := len(createdRhcConnections)
+		got := len(deletedRhcConnections)
+
+		if want != got {
+			t.Errorf(`unexpected amount of rhcConnections deleted. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	// Check that the expected rhcConnections were deleted.
+	for i := 0; i < maximumSubresourcesToCreate; i++ {
+		{
+			want := createdRhcConnections[i].ID
+			got := deletedRhcConnections[i].ID
+
+			if want != got {
+				t.Errorf(`unexpected rhcConnection deleted. Want rhcConnection with ID "%d", got ID "%d"`, want, got)
+			}
+		}
+
+		{
+			want := createdRhcConnections[i].RhcId
+			got := deletedRhcConnections[i].RhcId
+
+			if want != got {
+				t.Errorf(`unexpected rhcConnection deleted. Want rhcConnection with RhcId "%s", got RhcId "%s"`, want, got)
+			}
+		}
+	}
+
+	// Try to fetch the deleted source.
+	var deletedSourceCheck *model.Source
+	err = DB.
+		Debug().
+		Model(model.Source{}).
+		Where(`id = ?`, fixtureSource.ID).
+		Where(`tenant_id = ?`, fixtures.TestTenantData[0].Id).
+		Find(&deletedSourceCheck).
+		Error
+
+	if err != nil {
+		t.Errorf(`unexpected error: %s`, err)
+	}
+
+	// Check that the expected source was deleted.
+	if deletedSourceCheck.ID != 0 {
+		t.Errorf(`unexpected source fetched. It should be deleted, but this source was fetched: %v`, deletedSourceCheck)
+	}
+
+	{
+		want := fixtureSource.Name
+		got := deletedSource.Name
+
+		if want != got {
+			t.Errorf(`wrong source deleted. Want source with name "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := fixtureSource.ID
+		got := deletedSource.ID
+
+		if want != got {
+			t.Errorf(`wrong source deleted. Want source with id "%d", got "%d"`, want, got)
+		}
+	}
+
+	DoneWithFixtures("delete")
+}
+
+// TestSourceExists tests whether the function exists returns true when the given source exists.
+func TestSourceExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("exists")
+	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
+
+	got, err := sourceDao.Exists(fixtures.TestSourceData[0].ID)
+	if err != nil {
+		t.Errorf(`unexpected error when checking that the source exists: %s`, err)
+	}
+
+	if !got {
+		t.Errorf(`the source does exist but the "Exist" function returns otherwise. Want "true", got "%t"`, got)
+	}
+
+	DoneWithFixtures("exists")
+}
+
+// TestSourceNotExists tests whether the function exists returns false when the given source does not exist.
+func TestSourceNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("exists")
+	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
+
+	got, err := sourceDao.Exists(12345)
+	if err != nil {
+		t.Errorf(`unexpected error when checking that the source exists: %s`, err)
+	}
+
+	if got {
+		t.Errorf(`the source doesn't exist but the "Exist" function returns otherwise. Want "false", got "%t"`, got)
+	}
+
+	DoneWithFixtures("exists")
 }

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -21,7 +21,7 @@ var sourceDao = sourceDaoImpl{
 // TestSourcesListForRhcConnections tests whether the correct sources are fetched from the related connection or not.
 func TestSourcesListForRhcConnections(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures(RHC_CONNECTION_SCHEMA)
+	SwitchSchema(RHC_CONNECTION_SCHEMA)
 
 	rhcConnectionId := int64(1)
 
@@ -58,7 +58,7 @@ func TestSourcesListForRhcConnections(t *testing.T) {
 
 	}
 
-	DoneWithFixtures(RHC_CONNECTION_SCHEMA)
+	DropSchema(RHC_CONNECTION_SCHEMA)
 }
 
 // testSource holds the test source that will be used through tests. It is saved in a variable to avoid having to write
@@ -68,7 +68,7 @@ var testSource = fixtures.TestSourceData[0]
 // TestPausingSource checks whether the "paused_at" column gets successfully modified when pausing a source.
 func TestPausingSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("pause_unpause")
+	SwitchSchema("pause_unpause")
 
 	sourceDao := GetSourceDao(&testSource.TenantID)
 	err := sourceDao.Pause(testSource.ID)
@@ -92,14 +92,13 @@ func TestPausingSource(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("pause_unpause")
+	DropSchema("pause_unpause")
 }
 
 // TestResumingSource checks whether the "paused_at" column gets set as "NULL" when resuming a source.
 func TestResumingSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-
-	CreateFixtures("pause_unpause")
+	SwitchSchema("pause_unpause")
 
 	sourceDao := GetSourceDao(&testSource.TenantID)
 	err := sourceDao.Unpause(fixtures.TestSourceData[0].ID)
@@ -123,13 +122,13 @@ func TestResumingSource(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("pause_unpause")
+	DropSchema("pause_unpause")
 }
 
 // TestDeleteSource tests that a source gets correctly deleted, and its data returned.
 func TestDeleteSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	sourceDao := GetSourceDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -168,13 +167,13 @@ func TestDeleteSource(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 // TestDeleteSourceNotExists tests that when a source that doesn't exist is tried to be deleted, an error is returned.
 func TestDeleteSourceNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	sourceDao := GetSourceDao(&fixtures.TestSourceData[0].TenantID)
 
@@ -185,7 +184,7 @@ func TestDeleteSourceNotExists(t *testing.T) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 // TestDeleteCascade is a long test function, but very simple in essence. Essentially what it does is:
@@ -196,7 +195,7 @@ func TestDeleteSourceNotExists(t *testing.T) {
 // - Checks that the deleted subresources and source are the ones that have been created in this very same test.
 func TestDeleteCascade(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("delete")
+	SwitchSchema("delete")
 
 	// Create a new source fixture to avoid mixing the applications with the ones that already exist.
 	fixtureSource := model.Source{
@@ -593,13 +592,14 @@ func TestDeleteCascade(t *testing.T) {
 		}
 	}
 
-	DoneWithFixtures("delete")
+	DropSchema("delete")
 }
 
 // TestSourceExists tests whether the function exists returns true when the given source exists.
 func TestSourceExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("exists")
+	SwitchSchema("exists")
+
 	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
 
 	got, err := sourceDao.Exists(fixtures.TestSourceData[0].ID)
@@ -611,13 +611,14 @@ func TestSourceExists(t *testing.T) {
 		t.Errorf(`the source does exist but the "Exist" function returns otherwise. Want "true", got "%t"`, got)
 	}
 
-	DoneWithFixtures("exists")
+	DropSchema("exists")
 }
 
 // TestSourceNotExists tests whether the function exists returns false when the given source does not exist.
 func TestSourceNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("exists")
+	SwitchSchema("exists")
+
 	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
 
 	got, err := sourceDao.Exists(12345)
@@ -629,5 +630,5 @@ func TestSourceNotExists(t *testing.T) {
 		t.Errorf(`the source doesn't exist but the "Exist" function returns otherwise. Want "false", got "%t"`, got)
 	}
 
-	DoneWithFixtures("exists")
+	DropSchema("exists")
 }

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -592,6 +592,42 @@ func TestDeleteCascade(t *testing.T) {
 		}
 	}
 
+	// Check that the deleted resources come with the related tenant. This is necessary since otherwise the events will
+	// not have the "tenant" key populated.
+	for _, applicationAuthentication := range deletedApplicationAuthentications {
+		want := fixtures.TestTenantData[0].ExternalTenant
+		got := applicationAuthentication.Tenant.ExternalTenant
+
+		if want != got {
+			t.Errorf(`the application authentication doesn't come with the related tenant. Want external tenant "%s", got "%s"`, want, got)
+		}
+	}
+
+	for _, application := range deletedApplications {
+		want := fixtures.TestTenantData[0].ExternalTenant
+		got := application.Tenant.ExternalTenant
+
+		if want != got {
+			t.Errorf(`the application doesn't come with the related tenant. Want external tenant "%s", got "%s"`, want, got)
+		}
+	}
+
+	for _, endpoint := range deletedEndpoints {
+		want := fixtures.TestTenantData[0].ExternalTenant
+		got := endpoint.Tenant.ExternalTenant
+
+		if want != got {
+			t.Errorf(`the endpoint doesn't come with the related tenant. Want external tenant "%s", got "%s"`, want, got)
+		}
+	}
+
+	want := fixtures.TestTenantData[0].ExternalTenant
+	got := deletedSource.Tenant.ExternalTenant
+
+	if want != got {
+		t.Errorf(`the source doesn't come with the related tenant. Want external tenant "%s", got "%s"`, want, got)
+	}
+
 	DropSchema("delete")
 }
 

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -210,12 +210,12 @@ func EndpointDelete(c echo.Context) error {
 
 	c.Logger().Infof("Deleting Endpoint Id %v", id)
 
-	endpt, err := endpointDao.Delete(&id)
+	// Cascade delete the endpoint.
+	headers := service.ForwadableHeaders(c)
+	err = service.DeleteCascade(endpointDao.Tenant(), "Endpoint", id, headers)
 	if err != nil {
-		return err
+		return util.NewErrBadRequest(err)
 	}
-
-	setEventStreamResource(c, endpt)
 
 	return c.NoContent(http.StatusNoContent)
 }

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -45,9 +45,9 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 
 		// Raise an event for the deleted application authentications.
 		for _, appAuth := range applicationAuthentications {
-			err = RaiseEvent("ApplicationAuthentication.delete", &appAuth, headers)
+			err = RaiseEvent("ApplicationAuthentication.destroy", &appAuth, headers)
 			if err != nil {
-				logging.Log.Errorf(`Event "ApplicationAuthentication.delete" could not be raised for application authentication %v: %s`, appAuth.ToEvent(), err)
+				logging.Log.Errorf(`Event "ApplicationAuthentication.destroy" could not be raised for application authentication %v: %s`, appAuth.ToEvent(), err)
 			}
 		}
 
@@ -55,9 +55,9 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 		var appIds []int64
 		for _, app := range applications {
 			appIds = append(appIds, app.ID)
-			err := RaiseEvent("Application.delete", &app, headers)
+			err := RaiseEvent("Application.destroy", &app, headers)
 			if err != nil {
-				logging.Log.Errorf(`Event "Application.delete" could not be raised for application %v: %s`, app.ToEvent(), err)
+				logging.Log.Errorf(`Event "Application.destroy" could not be raised for application %v: %s`, app.ToEvent(), err)
 			}
 		}
 
@@ -65,24 +65,24 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 		var endpointIds []int64
 		for _, endpoint := range endpoints {
 			endpointIds = append(endpointIds, endpoint.ID)
-			err := RaiseEvent("Endpoint.delete", &endpoint, headers)
+			err := RaiseEvent("Endpoint.destroy", &endpoint, headers)
 			if err != nil {
-				logging.Log.Errorf(`Event "Endpoint.delete" could not be raised for endpoint %v: %s`, endpoint.ToEvent(), err)
+				logging.Log.Errorf(`Event "Endpoint.destroy" could not be raised for endpoint %v: %s`, endpoint.ToEvent(), err)
 			}
 		}
 
 		// Raise events for the deleted connections.
 		for _, connection := range rhcConnections {
-			err := RaiseEvent("RhcConnection.delete", &connection, headers)
+			err := RaiseEvent("RhcConnection.destroy", &connection, headers)
 			if err != nil {
-				logging.Log.Errorf(`Event "RhcConnection.delete" could not be raised for rhcConnection %v: %s`, connection.ToEvent(), err)
+				logging.Log.Errorf(`Event "RhcConnection.destroy" could not be raised for rhcConnection %v: %s`, connection.ToEvent(), err)
 			}
 		}
 
 		// Raise an event for the source itself.
-		err = RaiseEvent("Source.delete", source, headers)
+		err = RaiseEvent("Source.destroy", source, headers)
 		if err != nil {
-			logging.Log.Errorf(`Event "Source.delete" could not be raised for source %v: %s`, source.ToEvent(), err)
+			logging.Log.Errorf(`Event "Source.destroy" could not be raised for source %v: %s`, source.ToEvent(), err)
 		}
 
 		// Fetch all the authentications from the resources.
@@ -113,16 +113,16 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 
 		// Raise an event for the deleted application authentications.
 		for _, appAuth := range applicationAuthentications {
-			err = RaiseEvent("ApplicationAuthentication.delete", &appAuth, headers)
+			err = RaiseEvent("ApplicationAuthentication.destroy", &appAuth, headers)
 			if err != nil {
-				logging.Log.Errorf(`Event "ApplicationAuthentication.delete" could not be raised for application authentication %v: %s`, appAuth.ToEvent(), err)
+				logging.Log.Errorf(`Event "ApplicationAuthentication.destroy" could not be raised for application authentication %v: %s`, appAuth.ToEvent(), err)
 			}
 		}
 
 		// Raise an event for the deleted application itself.
-		err = RaiseEvent("Application.delete", application, headers)
+		err = RaiseEvent("Application.destroy", application, headers)
 		if err != nil {
-			logging.Log.Errorf(`Event "Application.delete" could not be raised for application %v: %s`, application.ToEvent(), err)
+			logging.Log.Errorf(`Event "Application.destroy" could not be raised for application %v: %s`, application.ToEvent(), err)
 		}
 
 		// Fetch all the application's authentications.
@@ -141,9 +141,9 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 		}
 
 		// Raise an event for the deleted endpoint.
-		err = RaiseEvent("Endpoint.delete", endpoint, headers)
+		err = RaiseEvent("Endpoint.destroy", endpoint, headers)
 		if err != nil {
-			logging.Log.Errorf(`Event "Endpoint.delete" could not be raised for endpoint %v: %s`, endpoint.ToEvent(), err)
+			logging.Log.Errorf(`Event "Endpoint.destroy" could not be raised for endpoint %v: %s`, endpoint.ToEvent(), err)
 		}
 
 		// Fetch all the endpoint's authentications.
@@ -163,9 +163,9 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 
 	for _, deletedAuth := range deletedAuths {
 		// Raise an event for the deleted authentication.
-		err = RaiseEvent("Authentication.delete", &deletedAuth, headers)
+		err = RaiseEvent("Authentication.destroy", &deletedAuth, headers)
 		if err != nil {
-			logging.Log.Errorf(`Could not raise "Authentication.delete" event for authentication %v`, err)
+			logging.Log.Errorf(`Could not raise "Authentication.destroy" event for authentication %v`, err)
 		}
 	}
 

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/kafka"
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/model"
+)
+
+// DeleteCascade removes the resource type and all its dependants, raising an event for every deleted resource. Returns
+// an error when the resources and its dependants could not be successfully removed.
+//
+// - In the case of the resource being a "Source", it removes its applications, its endpoints and its Red Hat Connector
+// connections.
+// - In the other cases, it removes the resource itself.
+//
+// In both cases the authentications are fetched for every single resource and sub resource, and they get deleted in
+// batch.
+//
+// In the case of not being able to delete authentications, we simply log the error and leave them dangling, since we
+// might either have a database or Vault backing our authentications, and we might need manual action to remove the
+// ones that were left undeleted. In the case of a database it is true that it could be wrapped in a transaction, but
+// with Vault that is not possible. What if we start deleting authentications and then some of them error out? We would
+// be able to recover the database data, but some of their authentications would be gone, therefore leaving the
+// resource in an inconsistent state.
+//
+// Plus, it's not the client's fault that we weren't able to delete the authentications, so by taking this approach
+// the clients don't keep an "unremovable" resource because of some failure in deleting the authentications.
+//
+// Finally, those authentications are safely encrypted so they can stay in their datastores until we manually remove
+// them.
+func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, headers []kafka.Header) error {
+	authenticationsDao := dao.GetAuthenticationDao(tenantId)
+	var authentications []model.Authentication
+
+	switch resourceType {
+	case "Source":
+		sourceDao := dao.GetSourceDao(tenantId)
+		applicationAuthentications, applications, endpoints, rhcConnections, source, err := sourceDao.DeleteCascade(resourceId)
+		if err != nil {
+			return fmt.Errorf(`could not completely delete the source: %s`, err)
+		}
+
+		// Raise an event for the deleted application authentications.
+		for _, appAuth := range applicationAuthentications {
+			err = RaiseEvent("ApplicationAuthentication.delete", &appAuth, headers)
+			if err != nil {
+				logging.Log.Errorf(`Event "ApplicationAuthentication.delete" could not be raised for application authentication %v: %s`, appAuth.ToEvent(), err)
+			}
+		}
+
+		// Raise events for the deleted applications.
+		var appIds []int64
+		for _, app := range applications {
+			appIds = append(appIds, app.ID)
+			err := RaiseEvent("Application.delete", &app, headers)
+			if err != nil {
+				logging.Log.Errorf(`Event "Application.delete" could not be raised for application %v: %s`, app.ToEvent(), err)
+			}
+		}
+
+		// Raise events for the deleted endpoints.
+		var endpointIds []int64
+		for _, endpoint := range endpoints {
+			endpointIds = append(endpointIds, endpoint.ID)
+			err := RaiseEvent("Endpoint.delete", &endpoint, headers)
+			if err != nil {
+				logging.Log.Errorf(`Event "Endpoint.delete" could not be raised for endpoint %v: %s`, endpoint.ToEvent(), err)
+			}
+		}
+
+		// Raise events for the deleted connections.
+		for _, connection := range rhcConnections {
+			err := RaiseEvent("RhcConnection.delete", &connection, headers)
+			if err != nil {
+				logging.Log.Errorf(`Event "RhcConnection.delete" could not be raised for rhcConnection %v: %s`, connection.ToEvent(), err)
+			}
+		}
+
+		// Raise an event for the source itself.
+		err = RaiseEvent("Source.delete", source, headers)
+		if err != nil {
+			logging.Log.Errorf(`Event "Source.delete" could not be raised for source %v: %s`, source.ToEvent(), err)
+		}
+
+		// Fetch all the authentications from the resources.
+		resourceTypes := []struct {
+			ResourceType string
+			ResourceIds  []int64
+		}{
+			{ResourceType: "Application", ResourceIds: appIds},
+			{ResourceType: "Endpoint", ResourceIds: endpointIds},
+			{ResourceType: "Source", ResourceIds: []int64{resourceId}},
+		}
+
+		for _, res := range resourceTypes {
+			auths, err := authenticationsDao.ListIdsForResource(res.ResourceType, res.ResourceIds)
+			if err != nil {
+				logging.Log.Errorf(`[resource_type: "%s"][resource_ids: "%v"] Could not fetch authentications: %s`, res.ResourceType, res.ResourceIds, err)
+			}
+
+			authentications = append(authentications, auths...)
+		}
+
+	case "Application":
+		applicationsDao := dao.GetApplicationDao(tenantId)
+		applicationAuthentications, application, err := applicationsDao.DeleteCascade(resourceId)
+		if err != nil {
+			return fmt.Errorf(`could not completely delete the application: %s`, err)
+		}
+
+		// Raise an event for the deleted application authentications.
+		for _, appAuth := range applicationAuthentications {
+			err = RaiseEvent("ApplicationAuthentication.delete", &appAuth, headers)
+			if err != nil {
+				logging.Log.Errorf(`Event "ApplicationAuthentication.delete" could not be raised for application authentication %v: %s`, appAuth.ToEvent(), err)
+			}
+		}
+
+		// Raise an event for the deleted application itself.
+		err = RaiseEvent("Application.delete", application, headers)
+		if err != nil {
+			logging.Log.Errorf(`Event "Application.delete" could not be raised for application %v: %s`, application.ToEvent(), err)
+		}
+
+		// Fetch all the application's authentications.
+		auths, err := authenticationsDao.ListIdsForResource("Application", []int64{resourceId})
+		if err != nil {
+			logging.Log.Errorf(`[resource_type: "Application"][resource_id: "%v"] Could not fetch authentications: %s`, resourceId, err)
+		}
+
+		authentications = append(authentications, auths...)
+	case "Endpoint":
+		// Delete the endpoint.
+		endpointDao := dao.GetEndpointDao(tenantId)
+		endpoint, err := endpointDao.Delete(&resourceId)
+		if err != nil {
+			return fmt.Errorf(`could not delete the endpoint: %s`, err)
+		}
+
+		// Raise an event for the deleted endpoint.
+		err = RaiseEvent("Endpoint.delete", endpoint, headers)
+		if err != nil {
+			logging.Log.Errorf(`Event "Endpoint.delete" could not be raised for endpoint %v: %s`, endpoint.ToEvent(), err)
+		}
+
+		// Fetch all the endpoint's authentications.
+		auths, err := authenticationsDao.ListIdsForResource("Endpoint", []int64{resourceId})
+		if err != nil {
+			logging.Log.Errorf(`[resource_type: "Endpoint"][resource_id: "%v"] Could not fetch authentications: %s`, resourceId, err)
+		}
+
+		authentications = append(authentications, auths...)
+	}
+
+	// Delete all the authentications.
+	deletedAuths, err := authenticationsDao.BulkDelete(authentications)
+	if err != nil {
+		logging.Log.Errorf(`Could not delete authentications: %s`, err)
+	}
+
+	for _, deletedAuth := range deletedAuths {
+		// Raise an event for the deleted authentication.
+		err = RaiseEvent("Authentication.delete", &deletedAuth, headers)
+		if err != nil {
+			logging.Log.Errorf(`Could not raise "Authentication.delete" event for authentication %v`, err)
+		}
+	}
+
+	return nil
+}

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -927,6 +927,8 @@ func TestSourceEditBadRequest(t *testing.T) {
 }
 
 func TestSourceDelete(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	c, rec := request.CreateTestContext(
 		http.MethodDelete,
 		"/api/sources/v3.1/sources/100",


### PR DESCRIPTION
Implements deleting the following resources with cascade:

- Source
- Application
- Endpoint

The way it has been done is the following:

1. All the resources and sub resources are deleted from the database in a transaction. We use the "RETURNING" statement to get all the deleted resources.
2. We raise an event for every single resources we have deleted.
3. We collect all the authentications for every resource we have deleted.
4. We delete the authentications in batch and raise an event for every authentication deleted.

This has been done to not leave the client with dangling resources on the database. Not being able to delete authentications isn't that bad, since:

1. They are encrypted.
2. Nobody else will have a reference to them, so they will be unrecoverable from the app.

This situation, if it happens, will require manual action from our side. I assumed that it is better and easier to clean up dangling authentications than it is to clean dangling resources and sub resources.

---

As a collateral change: I refactored the tests so that we only use one connection for each test, instead of opening a new one. Until now every time a test was ran a new connection was being opened, which has ended up making Postgres complain about "too many active connections".

## Links

[[RHCLOUD-18723]](https://issues.redhat.com/browse/RHCLOUD-18723)