### PR TITLE
Make various Authentication fields nullable in order for Rails to interop fine.

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -164,9 +164,9 @@ func TestAuthenticationGetNotFound(t *testing.T) {
 func TestAuthenticationCreate(t *testing.T) {
 	util.OverrideEncryptionKey(strings.Repeat("test", 8))
 	requestBody := m.AuthenticationCreateRequest{
-		Name:          "TestRequest",
+		Name:          util.StringRef("TestRequest"),
 		AuthType:      "test",
-		Username:      "testUser",
+		Username:      util.StringRef("testUser"),
 		Password:      util.StringRef("123456"),
 		ResourceType:  "Application",
 		ResourceIDRaw: 1,
@@ -218,9 +218,9 @@ func TestAuthenticationCreate(t *testing.T) {
 
 func TestAuthenticationCreateBadRequest(t *testing.T) {
 	requestBody := m.AuthenticationCreateRequest{
-		Name:         "TestRequest",
+		Name:         util.StringRef("TestRequest"),
 		AuthType:     "test",
-		Username:     "testUser",
+		Username:     util.StringRef("testUser"),
 		Password:     util.StringRef("123456"),
 		ResourceType: "InvalidType",
 		ResourceID:   1,

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -480,9 +480,11 @@ func authFromVault(secret *api.Secret) *m.Authentication {
 	}
 
 	if data["name"] != nil {
-		if auth.Name, ok = data["name"].(string); !ok {
+		var name string
+		if name, ok = data["name"].(string); !ok {
 			return nil
 		}
+		auth.Name = &name
 	}
 	if data["authtype"] != nil {
 		if auth.AuthType, ok = data["authtype"].(string); !ok {
@@ -490,9 +492,11 @@ func authFromVault(secret *api.Secret) *m.Authentication {
 		}
 	}
 	if data["username"] != nil {
-		if auth.Username, ok = data["username"].(string); !ok {
+		var username string
+		if username, ok = data["username"].(string); !ok {
 			return nil
 		}
+		auth.Username = &username
 	}
 	if data["password"] != nil {
 		password, ok := data["password"].(string)
@@ -530,9 +534,11 @@ func authFromVault(secret *api.Secret) *m.Authentication {
 	}
 
 	if data["availability_status"] != nil {
-		if auth.AvailabilityStatus, ok = data["availability_status"].(string); !ok {
+		var availabilityStatus string
+		if availabilityStatus, ok = data["availability_status"].(string); !ok {
 			return nil
 		}
+		auth.AvailabilityStatus = &availabilityStatus
 	}
 
 	if data["last_available_at"] != nil {

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -318,19 +318,15 @@ func TestAuthFromVault(t *testing.T) {
 	createdAt := now.Add(time.Duration(-2) * time.Hour)
 
 	authentication := m.Authentication{
-		Name:                    "test-vault-auth",
-		AuthType:                "test-authtype",
-		Username:                "my-username",
-		Extra:                   nil,
-		AvailabilityStatus:      m.Available,
-		LastAvailableAt:         &lastAvailableCheckedAt,
-		LastCheckedAt:           &lastAvailableCheckedAt,
-		AvailabilityStatusError: "there was an error, wow",
-		ResourceType:            "source",
-		ResourceID:              123,
-		SourceID:                25,
-		CreatedAt:               createdAt,
-		Version:                 "500",
+		AuthType:        "test-authtype",
+		Extra:           nil,
+		LastAvailableAt: &lastAvailableCheckedAt,
+		LastCheckedAt:   &lastAvailableCheckedAt,
+		ResourceType:    "source",
+		ResourceID:      123,
+		SourceID:        25,
+		CreatedAt:       createdAt,
+		Version:         "500",
 	}
 
 	// Use the "ToVaultMap" function to simulate what Vault would store as an authentication.
@@ -352,6 +348,10 @@ func TestAuthFromVault(t *testing.T) {
 	// setting the password manually due to the fact that it can be null therefore not in the db. and if it _were_ in
 	// the vault db it would come back as a regular string and not a pointer.
 	data["password"] = "my-password"
+	data["name"] = "test-vault-auth"
+	data["username"] = "my-username"
+	data["availability_status"] = m.Available
+	data["availability_status_error"] = "there was an error, wow"
 
 	// We also want to test if the metadata gets correctly unmarshalled.
 	version := json.Number(authentication.Version)
@@ -373,10 +373,10 @@ func TestAuthFromVault(t *testing.T) {
 		t.Errorf(`authFromVault didn't correctly parse the secret. Got a nil authentication`)
 	} else {
 		{
-			want := authentication.Name
-			got := resultingAuth.Name
+			want := data["name"]
+			got := *resultingAuth.Name
 			if want != got {
-				t.Errorf(`authentication names are different. Want "%s", got "%s"`, want, got)
+				t.Errorf(`authentication names are different. Want "%v", got "%v"`, want, got)
 			}
 		}
 
@@ -389,15 +389,15 @@ func TestAuthFromVault(t *testing.T) {
 		}
 
 		{
-			want := authentication.Username
-			got := resultingAuth.Username
+			want := data["username"]
+			got := *resultingAuth.Username
 			if want != got {
-				t.Errorf(`authentication usernames are different. Want "%s", got "%s"`, want, got)
+				t.Errorf(`authentication usernames are different. Want "%v", got "%v"`, want, got)
 			}
 		}
 
 		{
-			want := "my-password"
+			want := data["password"]
 			got := *resultingAuth.Password
 			if want != got {
 				t.Errorf(`authentication passwords are different. Want "%v", got "%v"`, want, got)
@@ -429,10 +429,10 @@ func TestAuthFromVault(t *testing.T) {
 		}
 
 		{
-			want := authentication.AvailabilityStatus
-			got := resultingAuth.AvailabilityStatus
+			want := data["availability_status"]
+			got := *resultingAuth.AvailabilityStatus
 			if want != got {
-				t.Errorf(`authentication availability statuses are different. Want "%s", got "%s"`, want, got)
+				t.Errorf(`authentication availability statuses are different. Want "%v", got "%v"`, want, got)
 			}
 		}
 

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -317,6 +318,31 @@ func (add *authenticationDaoDbImpl) ListForEndpoint(endpointID int64, limit, off
 }
 
 func (add *authenticationDaoDbImpl) Create(authentication *m.Authentication) error {
+	query := DB.Select("source_id").Where("tenant_id = ?", *add.TenantID)
+
+	switch strings.ToLower(authentication.ResourceType) {
+	case "application":
+		app := m.Application{ID: authentication.ResourceID}
+		result := query.Model(&app).First(&app)
+		if result.Error != nil {
+			return fmt.Errorf("resource not found with type [%v], id [%v]", authentication.ResourceType, authentication.ResourceID)
+		}
+
+		authentication.SourceID = app.SourceID
+	case "endpoint":
+		endpoint := m.Endpoint{ID: authentication.ResourceID}
+		result := query.Model(&endpoint).First(&endpoint)
+		if result.Error != nil {
+			return fmt.Errorf("resource not found with type [%v], id [%v]", authentication.ResourceType, authentication.ResourceID)
+		}
+
+		authentication.SourceID = endpoint.SourceID
+	case "source":
+		authentication.SourceID = authentication.ResourceID
+	default:
+		return fmt.Errorf("bad resource type, supported types are [Application, Endpoint, Source]")
+	}
+
 	authentication.TenantID = *add.TenantID // the TenantID gets injected in the middleware
 	if authentication.Password != nil {
 		encryptedValue, err := util.Encrypt(*authentication.Password)

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -33,7 +33,7 @@ func createAuthenticationFixture(t *testing.T) {
 
 	auth := setUpValidAuthentication()
 
-	err := dao.Create(auth)
+	err := dao.BulkCreate(auth)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
@@ -48,7 +48,8 @@ func TestAuthenticationDbCreate(t *testing.T) {
 
 	auth := setUpValidAuthentication()
 
-	err := dao.Create(auth)
+	// Using bulk create so we don't check to see if the resource is there first
+	err := dao.BulkCreate(auth)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
@@ -118,7 +119,8 @@ func TestAuthenticationDbGetById(t *testing.T) {
 	authFixture := setUpValidAuthentication()
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
-	err := dao.Create(authFixture)
+	// Using bulk create so we don't check to see if the resource is there first
+	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
@@ -148,7 +150,8 @@ func TestAuthenticationDbUpdate(t *testing.T) {
 	authFixture := setUpValidAuthentication()
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
-	err := dao.Create(authFixture)
+	// Using bulk create so we don't check to see if the resource is there first
+	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
@@ -188,7 +191,8 @@ func TestAuthenticationDbDelete(t *testing.T) {
 	authFixture := setUpValidAuthentication()
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
-	err := dao.Create(authFixture)
+	// Using bulk create so we don't check to see if the resource is there first
+	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
@@ -274,7 +278,8 @@ func TestListForSource(t *testing.T) {
 			TenantID:     fixtures.TestTenantData[1].Id,
 		}
 
-		if err = dao.Create(auth); err != nil {
+		// Using bulk create so we don't check to see if the resource is there first
+		if err = dao.BulkCreate(auth); err != nil {
 			t.Errorf(`error creating authentication: %s`, err)
 		}
 
@@ -367,7 +372,8 @@ func TestListForApplication(t *testing.T) {
 			TenantID:     fixtures.TestTenantData[1].Id,
 		}
 
-		if err = dao.Create(auth); err != nil {
+		// Using bulk create so we don't check to see if the resource is there first
+		if err = dao.BulkCreate(auth); err != nil {
 			t.Errorf(`error creating authentication: %s`, err)
 		}
 
@@ -458,7 +464,8 @@ func TestListForApplicationAuthentication(t *testing.T) {
 		TenantID:     fixtures.TestTenantData[1].Id,
 	}
 
-	if err = dao.Create(auth); err != nil {
+	// Using bulk create so we don't check to see if the resource is there first
+	if err = dao.BulkCreate(auth); err != nil {
 		t.Errorf(`error creating authentication: %s`, err)
 	}
 
@@ -566,7 +573,8 @@ func TestListForEndpoint(t *testing.T) {
 			TenantID:     fixtures.TestTenantData[1].Id,
 		}
 
-		if err = dao.Create(auth); err != nil {
+		// Using bulk create so we don't check to see if the resource is there first
+		if err = dao.BulkCreate(auth); err != nil {
 			t.Errorf(`error creating authentication: %s`, err)
 		}
 
@@ -625,7 +633,8 @@ func TestFetchAndUpdateBy(t *testing.T) {
 	authFixture := setUpValidAuthentication()
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
-	err := dao.Create(authFixture)
+	// Using bulk create so we don't check to see if the resource is there first
+	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
@@ -710,7 +719,8 @@ func TestToEventJSON(t *testing.T) {
 	authFixture := setUpValidAuthentication()
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
-	err := dao.Create(authFixture)
+	// Using bulk create so we don't check to see if the resource is there first
+	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}
@@ -758,7 +768,7 @@ func TestBulkMessage(t *testing.T) {
 	authFixture.ResourceType = "Source"
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
-	err := dao.Create(authFixture)
+	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
 	}

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -682,7 +682,7 @@ func TestFetchAndUpdateBy(t *testing.T) {
 
 	{
 		want := availabilityStatus
-		got := dbAuth.AvailabilityStatus
+		got := *dbAuth.AvailabilityStatus
 
 		if want != got {
 			t.Errorf(`authentication was not updated. Want "availability status" "%s", got "%s"`, want, got)
@@ -691,7 +691,7 @@ func TestFetchAndUpdateBy(t *testing.T) {
 
 	{
 		want := availabilityStatusError
-		got := dbAuth.AvailabilityStatusError
+		got := *dbAuth.AvailabilityStatusError
 
 		if want != got {
 			t.Errorf(`authentication was not updated. Want "availability status error" "%s", got "%s"`, want, got)

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -42,12 +42,12 @@ type AuthenticationInternalResponse struct {
 }
 
 type AuthenticationCreateRequest struct {
-	Name                    string                 `json:"name,omitempty"`
+	Name                    *string                `json:"name,omitempty"`
 	AuthType                string                 `json:"authtype"`
-	Username                string                 `json:"username"`
+	Username                *string                `json:"username"`
 	Password                *string                `json:"password,omitempty"`
 	Extra                   map[string]interface{} `json:"extra,omitempty"`
-	AvailabilityStatusError string                 `json:"availability_status_error,omitempty"`
+	AvailabilityStatusError *string                `json:"availability_status_error,omitempty"`
 
 	ResourceType  string      `json:"resource_type"`
 	ResourceIDRaw interface{} `json:"resource_id"`
@@ -66,13 +66,13 @@ type AuthenticationEditRequest struct {
 
 func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest) error {
 	if update.Name != nil {
-		auth.Name = *update.Name
+		auth.Name = update.Name
 	}
 	if update.AuthType != nil {
 		auth.AuthType = *update.AuthType
 	}
 	if update.Username != nil {
-		auth.Username = *update.Username
+		auth.Username = update.Username
 	}
 	if update.Password != nil {
 		encrypted, err := util.Encrypt(*update.Password)
@@ -96,10 +96,10 @@ func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest)
 	}
 
 	if update.AvailabilityStatus != nil {
-		auth.AvailabilityStatus = *update.AvailabilityStatus
+		auth.AvailabilityStatus = update.AvailabilityStatus
 	}
 	if update.AvailabilityStatusError != nil {
-		auth.AvailabilityStatusError = *update.AvailabilityStatusError
+		auth.AvailabilityStatusError = update.AvailabilityStatusError
 	}
 
 	return nil

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -255,7 +255,7 @@ func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput,
 
 		a.ResourceType = util.Capitalize(auth.ResourceType)
 		a.AuthType = auth.AuthType
-		a.Username = auth.Username
+		a.Username = util.StringValueOrNil(auth.Username)
 		a.Password = auth.Password
 		a.Extra = auth.Extra
 		a.Name = auth.Name

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -50,7 +50,7 @@
     {
       "authtype": "test",
       "availability_status": "available",
-      "availability_status_error": "",
+      "availability_status_error": null,
       "created_at": "2022-01-10T14:58:02.850209Z",
       "extra": {
       },

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -50,7 +50,7 @@
     {
       "authtype": "test",
       "availability_status": "available",
-      "availability_status_error": "",
+      "availability_status_error": null,
       "created_at": "2022-01-10T14:58:02.850209Z",
       "extra": {
       },

--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -9,3 +9,11 @@ func Capitalize(str string) string {
 func StringRef(str string) *string {
 	return &str
 }
+
+func ValueOrBlank(strRef *string) string {
+	if strRef == nil {
+		return ""
+	}
+
+	return *strRef
+}


### PR DESCRIPTION
Found this when testing interoperability between the rails <-> go password fields. some fields such as availability_status and name and others _need to be nullable_. 

This PR fixes that. 