### PR TITLE
[RHCLOUD-18784] added function for closing test db connection

### DIFF
--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -96,6 +96,7 @@ func CreateFixtures(schema string) {
 // the database in the previous schema.
 func DoneWithFixtures(schema string) {
 	DropSchema(schema)
+	CloseTestDbConnection()
 	ConnectToTestDB("dao")
 }
 
@@ -105,7 +106,14 @@ func DropSchema(dbSchema string) {
 	if result.Error != nil {
 		log.Fatalf("Error in drop schema %s %s: ", dbSchema, result.Error.Error())
 	}
+}
 
+func CloseTestDbConnection() {
+	rawDB, err := DB.DB()
+	if err != nil {
+		log.Fatal(err)
+	}
+	rawDB.Close()
 }
 
 // MigrateSchema migrates all the models.


### PR DESCRIPTION
[RHCLOUD-18784](https://issues.redhat.com/browse/RHCLOUD-18784)

When I was working on tests in dao layer, I started to get this error:

```
2022/04/08 13:55:12 /Users/pcihalov/projects/sources-api-go/dao/main_test.go:53 
failed to connect to `host=localhost user=root database=sources_api_test_go`: server error 
(FATAL: sorry, too many clients already (SQLSTATE 53300))
```

When we call `DoneWithFixtures()`, the `ConnectToTestDB("dao")` is called again and again and connections are not closed. So I added function which closes this connection before we connect again to TestDB again.