### PR TITLE
[RHCLOUD-18515] Offset fix version 2

### DIFF
--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"net/http"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	m "github.com/RedHatInsights/sources-api-go/model"

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"net/http"
 	"testing"
 
@@ -51,7 +52,7 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 		t.Error("offset not set correctly")
 	}
 
-	if len(out.Data) != 1 {
+	if len(out.Data) != 2 {
 		t.Error("not enough objects passed back from DB")
 	}
 
@@ -61,7 +62,7 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 			t.Error("model did not deserialize as a source")
 		}
 
-		if s["display_name"] != "test app type" {
+		if s["id"] == "1" && s["display_name"] != "test app type" {
 			t.Error("ghosts infected the return")
 		}
 	}
@@ -183,7 +184,7 @@ func TestApplicationTypeList(t *testing.T) {
 		t.Error("offset not set correctly")
 	}
 
-	if len(out.Data) != 1 {
+	if len(out.Data) != len(fixtures.TestApplicationTypeData) {
 		t.Error("not enough objects passed back from DB")
 	}
 
@@ -193,7 +194,7 @@ func TestApplicationTypeList(t *testing.T) {
 			t.Error("model did not deserialize as a application type response")
 		}
 
-		if s["display_name"] != "test app type" {
+		if s["id"] == "1" && s["display_name"] != "test app type" {
 			t.Error("ghosts infected the return")
 		}
 	}

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -101,7 +101,6 @@ func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 	appAuths := make([]m.ApplicationAuthentication, 0, limit)
 	query := DB.Debug().
 		Model(&m.ApplicationAuthentication{}).
-		Offset(offset).
 		Where("tenant_id = ?", a.TenantID)
 
 	query, err := applyFilters(query, filters)
@@ -112,7 +111,7 @@ func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 	count := int64(0)
 	query.Count(&count)
 
-	result := query.Limit(limit).Find(&appAuths)
+	result := query.Limit(limit).Offset(offset).Find(&appAuths)
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -248,7 +248,7 @@ func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
 // and correct count of returned objects
 func TestApplicationAuthenticationListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 	wantCount := int64(len(fixtures.TestApplicationAuthenticationData))

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -243,3 +243,38 @@ func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
 
 	DropSchema("appauthfind")
 }
+
+// TestApplicationAuthenticationListOffsetAndLimit tests that List() in app auth dao returns correct count value
+// and correct count of returned objects
+func TestApplicationAuthenticationListOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	wantCount := int64(len(fixtures.TestApplicationAuthenticationData))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		appAuths, gotCount, err := appAuthDao.List(d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the application authentications: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of application authentications, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(appAuths)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DropSchema("offset_limit")
+}

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -58,7 +58,6 @@ func (a *applicationDaoImpl) SubCollectionList(primaryCollection interface{}, li
 func (a *applicationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
 	applications := make([]m.Application, 0, limit)
 	query := DB.Debug().Model(&m.Application{}).
-		Offset(offset).
 		Where("tenant_id = ?", a.TenantID)
 
 	query, err := applyFilters(query, filters)
@@ -69,7 +68,7 @@ func (a *applicationDaoImpl) List(limit int, offset int, filters []util.Filter) 
 	count := int64(0)
 	query.Count(&count)
 
-	result := query.Limit(limit).Find(&applications)
+	result := query.Limit(limit).Offset(offset).Find(&applications)
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -325,7 +325,7 @@ func TestApplicationNotExists(t *testing.T) {
 //  correct count value and correct count of returned objects
 func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
 	sourceId := fixtures.TestSourceData[0].ID
@@ -367,7 +367,7 @@ func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
 // and correct count of returned objects
 func TestApplicationListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
 	wantCount := int64(len(fixtures.TestApplicationData))

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/model"
+	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
@@ -318,4 +319,81 @@ func TestApplicationNotExists(t *testing.T) {
 	}
 
 	DropSchema("exists")
+}
+
+// TestApplicationSubcollectionListWithOffsetAndLimit tests that SubCollectionList() in application dao returns
+//  correct count value and correct count of returned objects
+func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	sourceId := fixtures.TestSourceData[0].ID
+
+	var wantCount int64
+	for _, i := range fixtures.TestApplicationData {
+		if i.SourceID == sourceId {
+			wantCount++
+		}
+	}
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		applications, gotCount, err := applicationDao.SubCollectionList(m.Source{ID: sourceId}, d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the applications: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of applications, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(applications)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DropSchema("offset_limit")
+}
+
+// TestApplicationListOffsetAndLimit tests that List() in application dao returns correct count value
+// and correct count of returned objects
+func TestApplicationListOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	wantCount := int64(len(fixtures.TestApplicationData))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		applications, gotCount, err := applicationDao.List(d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the applications: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of applications, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(applications)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DropSchema("offset_limit")
 }

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -13,7 +13,7 @@ import (
 //  correct count value and correct count of returned objects
 func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
 	sourceId := int64(1)
@@ -49,14 +49,14 @@ func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
-	DoneWithFixtures("offset_limit")
+	DropSchema("offset_limit")
 }
 
 // TestApplicationTypeListOffsetAndLimit tests that List() in application type dao returns correct
 // count value and correct count of returned objects
 func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
 	wantCount := int64(len(fixtures.TestApplicationTypeData))
@@ -84,5 +84,5 @@ func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
-	DoneWithFixtures("offset_limit")
+	DropSchema("offset_limit")
 }

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -1,0 +1,88 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// TestApplicationTypeSubCollectionListOffsetAndLimit tests that SubCollectionList() in application type dao returns
+//  correct count value and correct count of returned objects
+func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	sourceId := int64(1)
+
+	var appTypeList []int64
+	for _, app := range fixtures.TestApplicationData {
+		if app.SourceID == sourceId {
+			appTypeList = append(appTypeList, app.ApplicationTypeID)
+		}
+	}
+	wantCount := int64(len(appTypeList))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		appTypes, gotCount, err := appTypeDao.SubCollectionList(m.Source{ID: sourceId}, d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the application types: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of application types, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(appTypes)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DoneWithFixtures("offset_limit")
+}
+
+// TestApplicationTypeListOffsetAndLimit tests that List() in application type dao returns correct
+// count value and correct count of returned objects
+func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	wantCount := int64(len(fixtures.TestApplicationTypeData))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		appTypes, gotCount, err := appTypeDao.List(d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the app types: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of app types, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(appTypes)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DoneWithFixtures("offset_limit")
+}

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -101,6 +101,9 @@ func (a *authenticationDaoImpl) List(limit int, offset int, filters []util.Filte
 	} else {
 		end = limit
 	}
+	if offset > limit {
+		return nil, int64(len(keys)), nil
+	}
 
 	// Initialize the marketplace token cacher as it will be used in the underlying "authFromVault" function, inside
 	// ".getKey"
@@ -114,7 +117,7 @@ func (a *authenticationDaoImpl) List(limit int, offset int, filters []util.Filte
 
 		out = append(out, *secret)
 	}
-	count := int64(len(out))
+	count := int64(len(keys))
 
 	return out, count, nil
 }

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -647,11 +647,12 @@ func TestFindKeysByResourceTypeAndId(t *testing.T) {
 		}
 	}
 }
+
 // TestAuthenticationListOffsetAndLimit tests that List() in authentication dao returns correct count value
 // and correct count of returned objects
 func TestAuthenticationListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	wantCount := int64(len(fixtures.TestAuthenticationData))
 	Vault = &mocks.MockVault{}

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -58,7 +58,6 @@ func (a *endpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit
 func (a *endpointDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
 	query := DB.Debug().Model(&m.Endpoint{}).
-		Offset(offset).
 		Where("tenant_id = ?", a.TenantID)
 
 	query, err := applyFilters(query, filters)
@@ -69,7 +68,7 @@ func (a *endpointDaoImpl) List(limit int, offset int, filters []util.Filter) ([]
 	count := int64(0)
 	query.Count(&count)
 
-	result := query.Limit(limit).Find(&endpoints)
+	result := query.Limit(limit).Offset(offset).Find(&endpoints)
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -117,7 +117,7 @@ func TestEndpointNotExists(t *testing.T) {
 // and correct count of returned objects
 func TestEndpointListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
 	wantCount := int64(len(fixtures.TestEndpointData))
@@ -152,7 +152,7 @@ func TestEndpointListOffsetAndLimit(t *testing.T) {
 //  correct count value and correct count of returned objects
 func TestEndpointSubCollectionListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
 	sourceId := int64(1)

--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -125,6 +125,8 @@ func CreateFixtures(schema string) {
 
 	DB.Create(&fixtures.TestAuthenticationData)
 
+	DB.Create(&fixtures.TestMetaDataData)
+
 	UpdateTablesSequences(schema)
 }
 

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -60,7 +60,7 @@ func (md *metaDataDaoImpl) List(limit int, offset int, filters []util.Filter) ([
 	count := int64(0)
 	query.Count(&count)
 
-	result := query.Limit(limit).Find(&metaData)
+	result := query.Limit(limit).Offset(offset).Find(&metaData)
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}

--- a/dao/meta_data_dao_test.go
+++ b/dao/meta_data_dao_test.go
@@ -1,0 +1,90 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// TestMetaDataSubcollectionListWithOffsetAndLimit tests that SubCollectionList() in meta data dao
+// returns correct count value and correct count of returned objects
+func TestMetaDataSubcollectionListWithOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	metaDataDao := GetMetaDataDao()
+
+	appTypeId := fixtures.TestApplicationTypeData[0].Id
+	// How many meta data with given application type id is in fixtures
+	var wantCount int64
+	for _, appMetaData := range fixtures.TestMetaDataData {
+		if appMetaData.ApplicationTypeID == appTypeId {
+			wantCount++
+		}
+	}
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		metaDatas, gotCount, err := metaDataDao.SubCollectionList(m.ApplicationType{Id: appTypeId}, d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the meta datas: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of meta datas, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(metaDatas)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DoneWithFixtures("offset_limit")
+}
+
+// TestMetaDataListOffsetAndLimit tests that List() in meta data dao returns correct count value
+// and correct count of returned objects
+func TestMetaDataListOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	metaDataDao := GetMetaDataDao()
+	wantCount := int64(len(fixtures.TestMetaDataData))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		metaDatas, gotCount, err := metaDataDao.List(d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the meta datas: %s`, err)
+		}
+
+		// Check of count value returned form List()
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of meta datas, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		// Check of object's count returned from List()
+		got := len(metaDatas)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DoneWithFixtures("offset_limit")
+}

--- a/dao/meta_data_dao_test.go
+++ b/dao/meta_data_dao_test.go
@@ -13,7 +13,7 @@ import (
 // returns correct count value and correct count of returned objects
 func TestMetaDataSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	metaDataDao := GetMetaDataDao()
 
@@ -49,14 +49,14 @@ func TestMetaDataSubcollectionListWithOffsetAndLimit(t *testing.T) {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
-	DoneWithFixtures("offset_limit")
+	DropSchema("offset_limit")
 }
 
 // TestMetaDataListOffsetAndLimit tests that List() in meta data dao returns correct count value
 // and correct count of returned objects
 func TestMetaDataListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	metaDataDao := GetMetaDataDao()
 	wantCount := int64(len(fixtures.TestMetaDataData))
@@ -86,5 +86,5 @@ func TestMetaDataListOffsetAndLimit(t *testing.T) {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
-	DoneWithFixtures("offset_limit")
+	DropSchema("offset_limit")
 }

--- a/dao/rhc_connection_dao.go
+++ b/dao/rhc_connection_dao.go
@@ -38,17 +38,19 @@ func (s *rhcConnectionDaoImpl) List(limit, offset int, filters []util.Filter) ([
 		Select(`"rhc_connections".*, STRING_AGG(CAST ("jt"."source_id" AS TEXT), ',') AS "source_ids"`).
 		Joins(`INNER JOIN "source_rhc_connections" AS "jt" ON "rhc_connections"."id" = "jt"."rhc_connection_id"`).
 		Where(`"jt"."tenant_id" = ?`, s.TenantID).
-		Group(`"rhc_connections"."id"`).
-		Limit(limit).
-		Offset(offset)
+		Group(`"rhc_connections"."id"`)
 
 	query, err := applyFilters(query, filters)
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
 
+	// Getting the total count (filters included) for pagination.
+	count := int64(0)
+	query.Count(&count)
+
 	// Run the actual query.
-	result, err := query.Rows()
+	result, err := query.Limit(limit).Offset(offset).Rows()
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
@@ -57,7 +59,7 @@ func (s *rhcConnectionDaoImpl) List(limit, offset int, filters []util.Filter) ([
 	// map[string]interface{}, "ScanRows" will already scan every row into that array, thus freeing us from calling
 	// result.Next() again.
 	if !result.Next() {
-		return []m.RhcConnection{}, 0, nil
+		return []m.RhcConnection{}, count, nil
 	}
 
 	// Loop through the rows to map both the connection and its related sources.
@@ -81,10 +83,6 @@ func (s *rhcConnectionDaoImpl) List(limit, offset int, filters []util.Filter) ([
 	if err != nil {
 		return nil, 0, err
 	}
-
-	// Getting the total count (filters included) for pagination.
-	count := int64(0)
-	query.Count(&count)
 
 	return rhcConnections, count, nil
 }
@@ -244,9 +242,7 @@ func (s *rhcConnectionDaoImpl) ListForSource(sourceId *int64, limit, offset int,
 		Model(&m.RhcConnection{}).
 		Joins(`INNER JOIN "source_rhc_connections" "sr" ON "rhc_connections"."id" = "sr"."rhc_connection_id"`).
 		Where(`"sr"."source_id" = ?`, sourceId).
-		Where(`"sr"."tenant_id" = ?`, s.TenantID).
-		Limit(limit).
-		Offset(offset)
+		Where(`"sr"."tenant_id" = ?`, s.TenantID)
 
 	query, err := applyFilters(query, filters)
 	if err != nil {
@@ -258,7 +254,7 @@ func (s *rhcConnectionDaoImpl) ListForSource(sourceId *int64, limit, offset int,
 	query.Count(&count)
 
 	// Run the actual query.
-	err = query.Find(&rhcConnections).Error
+	err = query.Limit(limit).Offset(offset).Find(&rhcConnections).Error
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}

--- a/dao/rhc_connection_dao_test.go
+++ b/dao/rhc_connection_dao_test.go
@@ -435,7 +435,7 @@ func TestDeleteRhcConnectionNotExists(t *testing.T) {
 // count value and correct count of returned objects
 func TestRhcConnectionListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	wantCount := int64(len(fixtures.TestRhcConnectionData))
 
@@ -462,14 +462,14 @@ func TestRhcConnectionListOffsetAndLimit(t *testing.T) {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
-	DoneWithFixtures("offset_limit")
+	DropSchema("offset_limit")
 }
 
 // TestRhcConnectionListForSourceOffsetAndLimit tests that ListForSource() in rhc connection dao
 // returns correct count value and correct count of returned objects
 func TestRhcConnectionListForSourceOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	sourceId := int64(1)
 
@@ -503,5 +503,5 @@ func TestRhcConnectionListForSourceOffsetAndLimit(t *testing.T) {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
-	DoneWithFixtures("offset_limit")
+	DropSchema("offset_limit")
 }

--- a/dao/rhc_connection_dao_test.go
+++ b/dao/rhc_connection_dao_test.go
@@ -430,3 +430,78 @@ func TestDeleteRhcConnectionNotExists(t *testing.T) {
 
 	DropSchema("delete")
 }
+
+// TestRhcConnectionListOffsetAndLimit tests that List() in rhc connection dao returns correct
+// count value and correct count of returned objects
+func TestRhcConnectionListOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	wantCount := int64(len(fixtures.TestRhcConnectionData))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		rhcConnections, gotCount, err := rhcConnectionDao.List(d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the rhc connections: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of rhc connections, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(rhcConnections)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DoneWithFixtures("offset_limit")
+}
+
+// TestRhcConnectionListForSourceOffsetAndLimit tests that ListForSource() in rhc connection dao
+// returns correct count value and correct count of returned objects
+func TestRhcConnectionListForSourceOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	sourceId := int64(1)
+
+	var wantCount int64
+	for _, i := range fixtures.TestSourceRhcConnectionData {
+		if i.SourceId == sourceId {
+			wantCount++
+		}
+	}
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		rhcConnections, gotCount, err := rhcConnectionDao.ListForSource(&sourceId, d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the rhc connections: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of rhc connections, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(rhcConnections)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DoneWithFixtures("offset_limit")
+}

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -674,7 +674,7 @@ func TestSourceNotExists(t *testing.T) {
 //  correct count value and correct count of returned objects
 func TestSourceSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	sourceTypeId := fixtures.TestSourceTypeData[0].Id
 
@@ -715,7 +715,7 @@ func TestSourceSubcollectionListWithOffsetAndLimit(t *testing.T) {
 // and correct count of returned objects
 func TestSourceListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	wantCount := int64(len(fixtures.TestSourceData))
 
@@ -749,7 +749,7 @@ func TestSourceListOffsetAndLimit(t *testing.T) {
 // and correct count of returned objects
 func TestSourceListInternalOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	wantCount := int64(len(fixtures.TestSourceData))
 
@@ -783,7 +783,7 @@ func TestSourceListInternalOffsetAndLimit(t *testing.T) {
 //  correct count value and correct count of returned objects
 func TestSourceListForRhcConnectionWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	rhcConnectionId := fixtures.TestRhcConnectionData[0].ID
 

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/model"
+	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
@@ -667,4 +668,154 @@ func TestSourceNotExists(t *testing.T) {
 	}
 
 	DropSchema("exists")
+}
+
+// TestSourceSubcollectionListWithOffsetAndLimit tests that SubCollectionList() in source dao returns
+//  correct count value and correct count of returned objects
+func TestSourceSubcollectionListWithOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	sourceTypeId := fixtures.TestSourceTypeData[0].Id
+
+	var wantCount int64
+	for _, i := range fixtures.TestSourceData {
+		if i.SourceTypeID == sourceTypeId {
+			wantCount++
+		}
+	}
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		sources, gotCount, err := sourceDao.SubCollectionList(m.SourceType{Id: sourceTypeId}, d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the sources: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of sources, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(sources)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DropSchema("offset_limit")
+}
+
+// TestSourceListOffsetAndLimit tests that List() in source dao returns correct count value
+// and correct count of returned objects
+func TestSourceListOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	wantCount := int64(len(fixtures.TestSourceData))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		sources, gotCount, err := sourceDao.List(d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the sources: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of sources, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(sources)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DropSchema("offset_limit")
+}
+
+// TestSourceListInternalOffsetAndLimit tests that ListInternal() in source dao returns correct count value
+// and correct count of returned objects
+func TestSourceListInternalOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	wantCount := int64(len(fixtures.TestSourceData))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		sources, gotCount, err := sourceDao.ListInternal(d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the sources: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of sources, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(sources)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DropSchema("offset_limit")
+}
+
+// TestSourceListForRhcConnectionWithOffsetAndLimit tests that ListForRhcConnection() in source dao returns
+//  correct count value and correct count of returned objects
+func TestSourceListForRhcConnectionWithOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	rhcConnectionId := fixtures.TestRhcConnectionData[0].ID
+
+	var wantCount int64
+	for _, i := range fixtures.TestSourceRhcConnectionData {
+		if i.RhcConnectionId == rhcConnectionId {
+			wantCount++
+		}
+	}
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		sources, gotCount, err := sourceDao.ListForRhcConnection(&rhcConnectionId, d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the sources: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of sources, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(sources)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DropSchema("offset_limit")
 }

--- a/dao/source_type_dao_test.go
+++ b/dao/source_type_dao_test.go
@@ -1,0 +1,44 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// TestSourceTypeListOffsetAndLimit tests that List() in source type dao returns correct count value
+// and correct count of returned objects
+func TestSourceTypeListOffsetAndLimit(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	CreateFixtures("offset_limit")
+
+	sourceTypeDao := GetSourceTypeDao()
+	wantCount := int64(len(fixtures.TestSourceTypeData))
+
+	for _, d := range fixtures.TestDataOffsetLimit {
+		sourceTypes, gotCount, err := sourceTypeDao.List(d.Limit, d.Offset, []util.Filter{})
+		if err != nil {
+			t.Errorf(`unexpected error when listing the source types: %s`, err)
+		}
+
+		if wantCount != gotCount {
+			t.Errorf(`incorrect count of source types, want "%d", got "%d"`, wantCount, gotCount)
+		}
+
+		got := len(sourceTypes)
+		want := int(wantCount) - d.Offset
+		if want < 0 {
+			want = 0
+		}
+
+		if want > d.Limit {
+			want = d.Limit
+		}
+		if got != want {
+			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
+		}
+	}
+	DoneWithFixtures("offset_limit")
+}

--- a/dao/source_type_dao_test.go
+++ b/dao/source_type_dao_test.go
@@ -12,7 +12,7 @@ import (
 // and correct count of returned objects
 func TestSourceTypeListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CreateFixtures("offset_limit")
+	SwitchSchema("offset_limit")
 
 	sourceTypeDao := GetSourceTypeDao()
 	wantCount := int64(len(fixtures.TestSourceTypeData))
@@ -40,5 +40,5 @@ func TestSourceTypeListOffsetAndLimit(t *testing.T) {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
-	DoneWithFixtures("offset_limit")
+	DropSchema("offset_limit")
 }

--- a/internal/testutils/fixtures/application.go
+++ b/internal/testutils/fixtures/application.go
@@ -16,7 +16,7 @@ var TestApplicationData = []m.Application{
 	{
 		ID:                2,
 		Extra:             datatypes.JSON("{\"extra\": false}"),
-		ApplicationTypeID: 1,
+		ApplicationTypeID: 2,
 		SourceID:          1,
 		TenantID:          1,
 	},

--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -7,4 +7,8 @@ var TestApplicationTypeData = []m.ApplicationType{
 		Id:          1,
 		DisplayName: "test app type",
 	},
+	{
+		Id:          2,
+		DisplayName: "second test app type",
+	},
 }

--- a/internal/testutils/fixtures/offset_limit.go
+++ b/internal/testutils/fixtures/offset_limit.go
@@ -1,0 +1,33 @@
+package fixtures
+
+type OffsetLimit struct {
+	Limit  int
+	Offset int
+}
+
+var TestDataOffsetLimit = []OffsetLimit{
+	{
+		Limit:  10,
+		Offset: 0,
+	},
+	{
+		Limit:  10,
+		Offset: 1,
+	},
+	{
+		Limit:  10,
+		Offset: 100,
+	},
+	{
+		Limit:  1,
+		Offset: 0,
+	},
+	{
+		Limit:  1,
+		Offset: 1,
+	},
+	{
+		Limit:  1,
+		Offset: 100,
+	},
+}

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -12,7 +12,7 @@
   ],
   "applications": [
     {
-      "application_type_id": 1,
+      "application_type_id": 2,
       "availability_status": null,
       "availability_status_error": null,
       "created_at": "2021-12-06 20:03:14 CET",

--- a/statuslistener/test_data/bulk_message_Endpoint_1.json
+++ b/statuslistener/test_data/bulk_message_Endpoint_1.json
@@ -3,7 +3,7 @@
   ],
   "applications": [
     {
-      "application_type_id": 1,
+      "application_type_id": 2,
       "availability_status": null,
       "availability_status_error": null,
       "created_at": "2021-12-06 19:58:14 CET",

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -29,7 +29,7 @@
       "updated_at": "2021-12-06 20:00:14 CET"
     },
     {
-      "application_type_id": 1,
+      "application_type_id": 2,
       "availability_status": null,
       "availability_status_error": null,
       "created_at": "2021-12-06 20:00:14 CET",


### PR DESCRIPTION
[RHCLOUD-18515](https://issues.redhat.com/browse/RHCLOUD-18515)

When we listing resources and we use offset filter, the count value was 0 in many cases (because "count" returns a single row and using offset returns an empty value). Now using of offset is fixed so queries works properly with and without offset.

First version here: https://github.com/RedHatInsights/sources-api-go/pull/207

I decided to create new PR for second version of this fix. 
The tests pass after the "too many clients" error issue is resolved (https://github.com/RedHatInsights/sources-api-go/pull/210).