### PR TITLE
[RHCLOUD-18864] fixed logic in SubCollectionList() methods in mock dao

### DIFF
--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -84,24 +85,8 @@ func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit
 			return nil, 0, util.NewErrNotFound("application type")
 		}
 
-		// Application type exists = find applications with given app type
-		// and save list of related source IDs
-		var sourceIDs []int64
-		for _, app := range fixtures.TestApplicationData {
-			if app.ApplicationTypeID == object.Id {
-				sourceIDs = append(sourceIDs, app.SourceID)
-			}
-		}
-
-		// For each source ID find source
-		for _, sourceID := range sourceIDs {
-			for _, s := range src.Sources {
-				if s.ID == sourceID {
-					sources = append(sources, s)
-				}
-
-			}
-		}
+		// Application type exists = find related sources
+		sources = testutils.GetSourcesWithAppType(object.Id)
 
 	default:
 		return nil, 0, fmt.Errorf("unexpected primary collection type")

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -84,10 +84,22 @@ func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit
 			return nil, 0, util.NewErrNotFound("application type")
 		}
 
-		// Application type exists = return sources subcollection
-		for index, source := range src.Sources {
-			if source.ID == object.Id {
-				sources = append(sources, src.Sources[index])
+		// Application type exists = find applications with given app type
+		// and save list of related source IDs
+		var sourceIDs []int64
+		for _, app := range fixtures.TestApplicationData {
+			if app.ApplicationTypeID == object.Id {
+				sourceIDs = append(sourceIDs, app.SourceID)
+			}
+		}
+
+		// For each source ID find source
+		for _, sourceID := range sourceIDs {
+			for _, s := range src.Sources {
+				if s.ID == sourceID {
+					sources = append(sources, s)
+				}
+
 			}
 		}
 
@@ -333,7 +345,6 @@ func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}
 	}
 
 	count := int64(len(appTypesOut))
-
 	return appTypesOut, count, nil
 }
 

--- a/internal/testutils/fixtures/application.go
+++ b/internal/testutils/fixtures/application.go
@@ -27,4 +27,11 @@ var TestApplicationData = []m.Application{
 		SourceID:          1,
 		TenantID:          1,
 	},
+	{
+		ID:                4,
+		Extra:             datatypes.JSON("{\"extra\": false}"),
+		ApplicationTypeID: 1,
+		SourceID:          2,
+		TenantID:          1,
+	},
 }

--- a/internal/testutils/fixtures/application.go
+++ b/internal/testutils/fixtures/application.go
@@ -16,6 +16,13 @@ var TestApplicationData = []m.Application{
 	{
 		ID:                2,
 		Extra:             datatypes.JSON("{\"extra\": false}"),
+		ApplicationTypeID: 1,
+		SourceID:          2,
+		TenantID:          1,
+	},
+	{
+		ID:                3,
+		Extra:             datatypes.JSON("{\"extra\": false}"),
 		ApplicationTypeID: 2,
 		SourceID:          1,
 		TenantID:          1,

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -6,6 +6,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+	"github.com/RedHatInsights/sources-api-go/model"
 )
 
 var conf = config.Get()
@@ -24,14 +25,30 @@ func SkipIfNotSecretStoreDatabase(t *testing.T) {
 	}
 }
 
-func GetSourcesCountWithAppType(appTypeId int64) int {
-	var sourcesCount int
+func GetSourcesWithAppType(appTypeId int64) []model.Source {
+	var sourceIds = make(map[int64]struct{})
 
+	// Find applications with given application type and get
+	// list of unique source IDs
 	for _, app := range fixtures.TestApplicationData {
 		if app.ApplicationTypeID == appTypeId {
-			sourcesCount++
+			_, ok := sourceIds[app.SourceID]
+			if !ok {
+				sourceIds[app.SourceID] = struct{}{}
+			}
 		}
 	}
 
-	return sourcesCount
+	// Find sources for source IDs
+	var sources []model.Source
+	for id := range sourceIds {
+		for _, src := range fixtures.TestSourceData {
+			if id == src.ID {
+				sources = append(sources, src)
+				break
+			}
+		}
+	}
+
+	return sources
 }

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 )
 
@@ -21,4 +22,16 @@ func SkipIfNotSecretStoreDatabase(t *testing.T) {
 	if conf.SecretStore == "vault" {
 		t.Skip("Skipping test")
 	}
+}
+
+func GetSourcesCountWithAppType(appTypeId int64) int {
+	var sourcesCount int
+
+	for _, app := range fixtures.TestApplicationData {
+		if app.ApplicationTypeID == appTypeId {
+			sourcesCount++
+		}
+	}
+
+	return sourcesCount
 }

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -379,7 +379,7 @@ func TestSourceTypeSourceSubcollectionListBadRequestInvalidFilter(t *testing.T) 
 
 func TestApplicatioTypeListSourceSubcollectionList(t *testing.T) {
 	appTypeId := int64(1)
-	wantSourcesCount := testutils.GetSourcesCountWithAppType(appTypeId)
+	wantSourcesCount := len(testutils.GetSourcesWithAppType(appTypeId))
 
 	c, rec := request.CreateTestContext(
 		http.MethodGet,

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -378,6 +378,9 @@ func TestSourceTypeSourceSubcollectionListBadRequestInvalidFilter(t *testing.T) 
 }
 
 func TestApplicatioTypeListSourceSubcollectionList(t *testing.T) {
+	appTypeId := int64(1)
+	wantSourcesCount := testutils.GetSourcesCountWithAppType(appTypeId)
+
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
 		"/api/sources/v3.1/application_types/1/sources",
@@ -391,14 +394,14 @@ func TestApplicatioTypeListSourceSubcollectionList(t *testing.T) {
 	)
 
 	c.SetParamNames("application_type_id")
-	c.SetParamValues("1")
+	c.SetParamValues(fmt.Sprintf("%d", appTypeId))
 
 	err := ApplicationTypeListSource(c)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if rec.Code != 200 {
+	if rec.Code != http.StatusOK {
 		t.Error("Did not return 200")
 	}
 
@@ -416,7 +419,7 @@ func TestApplicatioTypeListSourceSubcollectionList(t *testing.T) {
 		t.Error("offset not set correctly")
 	}
 
-	if len(out.Data) != 1 {
+	if len(out.Data) != wantSourcesCount {
 		t.Error("not enough objects passed back from DB")
 	}
 
@@ -426,7 +429,7 @@ func TestApplicatioTypeListSourceSubcollectionList(t *testing.T) {
 			t.Error("model did not deserialize as a source")
 		}
 
-		if s["name"] != "Source1" {
+		if s["id"] == 1 && s["name"] != "Source1" {
 			t.Error("ghosts infected the return")
 		}
 	}

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -19,7 +19,7 @@
       "extra": {
         "extra": false
       },
-      "id": 2,
+      "id": 3,
       "last_available_at": null,
       "last_checked_at": null,
       "paused_at": null,

--- a/statuslistener/test_data/bulk_message_Endpoint_1.json
+++ b/statuslistener/test_data/bulk_message_Endpoint_1.json
@@ -10,7 +10,7 @@
       "extra": {
         "extra": false
       },
-      "id": 2,
+      "id": 3,
       "last_available_at": null,
       "last_checked_at": null,
       "paused_at": null,

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -36,7 +36,7 @@
       "extra": {
         "extra": false
       },
-      "id": 2,
+      "id": 3,
       "last_available_at": null,
       "last_checked_at": null,
       "paused_at": null,


### PR DESCRIPTION
[RHCLOUD-18864](https://issues.redhat.com/browse/RHCLOUD-18864)

Logic in SubCollectionList() methods needed to be fixed. 

I found out in mock daos for `SubCollectionList()` for sources that there is not good logic for route `application_types/id/sources` ... before, we returned sources where source id = application type id (and it was working because our test data was not so perfect)

line 88 from mock_daos.go
```
// Application type exists = return sources subcollection
for index, source := range src.Sources {
    if source.ID == object.Id {
        sources = append(sources, src.Sources[index]
    )
```

but it is simply wrong ... first we need to find out if application type exists (if not, we return not found error) and then we need to find all applications with given app type, get source ids from these apps and then return list of these sources

similar situation was for `SubCollectionList() `for app type (`sources/id/application_types`) ... first we need to find out if source exists and if so, then find all applications with given source id and create list of app types and then return the list with app types objects

then I updated our fixtures to have there 2 apps with different app type for 1 source id and because this, I needed to update test data for status listener too