### PR TITLE
Move Job Engine to a new worker pod, using Redis as the backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ inlinerun:
 listener:
 	go run `ls *.go | grep -v test` -listener
 
+backgroundworker:
+	go run `ls *.go | grep -v test` -background-worker
+
 container:
 	docker build . -t sources-api-go
 

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ type SourcesApiConfig struct {
 	Psks                      []string
 	BypassRbac                bool
 	StatusListener            bool
+	BackgroundWorker          bool
 	MigrationsSetup           bool
 	MigrationsReset           bool
 	SecretStore               string
@@ -124,6 +125,7 @@ func Get() *SourcesApiConfig {
 	// Parse any Flags (using our own flag set to not conflict with the global flag)
 	fs := flag.NewFlagSet("runtime", flag.ContinueOnError)
 	availabilityListener := fs.Bool("listener", false, "run availability status listener")
+	backgroundWorker := fs.Bool("background-worker", false, "run background worker")
 	setUpDatabase := fs.Bool("setup", false, "create the database and exit")
 	resetDatabase := fs.Bool("reset", false, "drop the database, recreate it and exit")
 
@@ -133,6 +135,7 @@ func Get() *SourcesApiConfig {
 	}
 
 	options.SetDefault("StatusListener", *availabilityListener)
+	options.SetDefault("BackgroundWorker", *backgroundWorker)
 	options.SetDefault("MigrationsSetup", *setUpDatabase)
 	options.SetDefault("MigrationsReset", *resetDatabase)
 
@@ -177,6 +180,7 @@ func Get() *SourcesApiConfig {
 		Psks:                      options.GetStringSlice("psks"),
 		BypassRbac:                options.GetBool("BypassRbac"),
 		StatusListener:            options.GetBool("StatusListener"),
+		BackgroundWorker:          options.GetBool("BackgroundWorker"),
 		MigrationsSetup:           options.GetBool("MigrationsSetup"),
 		MigrationsReset:           options.GetBool("MigrationsReset"),
 		SecretStore:               options.GetString("SecretStore"),

--- a/dao/db.go
+++ b/dao/db.go
@@ -117,7 +117,7 @@ func Init() {
 	Vault = vaultClient.Logical()
 
 	// we only want to seed the database when running the api pod - not the status listener
-	if !conf.StatusListener {
+	if !conf.StatusListener && !conf.BackgroundWorker {
 		err = seedDatabase()
 		if err != nil {
 			logging.Log.Fatalf("Failed to seed db: %v", err)

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -10,6 +10,27 @@ objects:
   spec:
     envName: ${ENV_NAME}
     deployments:
+    - name: background-worker
+      minReplicas: 1
+      podSpec:
+        args:
+        - -background-worker
+        image: ${IMAGE}:${IMAGE_TAG}
+        env:
+        - name: LOG_LEVEL
+          value: ${LOG_LEVEL}
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-secrets
+              key: encryption-key
+        resources:
+          limits:
+            cpu: ${AVAILABILITY_LISTENER_CPU_LIMIT}
+            memory: ${AVAILABILITY_LISTENER_MEMORY_LIMIT}
+          requests:
+            cpu: ${AVAILABILITY_LISTENER_CPU_REQUEST}
+            memory: ${AVAILABILITY_LISTENER_MEMORY_REQUEST}
     - name: availability-status-listener
       minReplicas: ${{AVAILABILITY_MIN_REPLICAS}}
       podSpec:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.42.22
 	github.com/gertd/go-pluralize v0.1.7
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
-	github.com/go-redis/redis v6.15.9+incompatible
+	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-migrate/migrate/v4 v4.15.1
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -388,6 +388,8 @@ github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
@@ -494,6 +496,8 @@ github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
+github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
@@ -629,6 +633,7 @@ github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210715191844-86eeefc3e471/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -1056,6 +1061,7 @@ github.com/onsi/ginkgo v1.16.2/go.mod h1:CObGmKUOKaSC0RjmoAK7tKyn4Azo5P2IWuoMnvw
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
+github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1066,8 +1072,10 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
-github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
+github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
+github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
@@ -1704,8 +1712,9 @@ golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211210111614-af8b64212486 h1:5hpz5aRr+W1erYCL5JRhSUBJRph7l9XkNveoExlrKYk=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/testutils/mocks/mock_sender.go
+++ b/internal/testutils/mocks/mock_sender.go
@@ -1,0 +1,16 @@
+package mocks
+
+import "github.com/RedHatInsights/sources-api-go/kafka"
+
+type MockSender struct {
+	Hit     int
+	Headers []kafka.Header
+	Body    string
+}
+
+func (m *MockSender) RaiseEvent(_ string, b []byte, headers []kafka.Header) error {
+	m.Headers = headers
+	m.Body = string(b)
+	m.Hit++
+	return nil
+}

--- a/jobs/async_destroy.go
+++ b/jobs/async_destroy.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -10,11 +11,11 @@ import (
 )
 
 type AsyncDestroyJob struct {
-	Headers     []kafka.Header
-	Tenant      int64
-	WaitSeconds int
-	Model       string
-	Id          int64
+	Headers     []kafka.Header `json:"headers"`
+	Tenant      int64          `json:"tenant"`
+	WaitSeconds int            `json:"wait_seconds"`
+	Model       string         `json:"model"`
+	Id          int64          `json:"id"`
 }
 
 func (ad AsyncDestroyJob) Delay() time.Duration {
@@ -40,7 +41,6 @@ func (ad AsyncDestroyJob) Run() error {
 		if err != nil {
 			return err
 		}
-
 	case "application":
 		err := service.DeleteCascade(&ad.Tenant, "Application", ad.Id, ad.Headers)
 		if err != nil {
@@ -51,4 +51,12 @@ func (ad AsyncDestroyJob) Run() error {
 	}
 
 	return nil
+}
+
+func (ad AsyncDestroyJob) ToJSON() []byte {
+	bytes, err := json.Marshal(&ad)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
 }

--- a/jobs/client.go
+++ b/jobs/client.go
@@ -1,0 +1,67 @@
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	l "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/redis"
+)
+
+type JobRequest struct {
+	JobName string
+	JobRaw  []byte
+	Job     Job
+}
+
+// implementing binary mashaler/unmarshaler interfaces for redis encoding/decoding.
+func (jr JobRequest) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(&jr)
+}
+func (jr *JobRequest) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, jr)
+}
+
+func (jr *JobRequest) Parse() error {
+	switch jr.JobName {
+	case "SuperkeyDestroyJob":
+		sdj := SuperkeyDestroyJob{}
+		err := json.Unmarshal([]byte(jr.JobRaw), &sdj)
+		if err != nil {
+			return err
+		}
+
+		jr.Job = &sdj
+	case "AsyncDestroyJob":
+		adj := AsyncDestroyJob{}
+		err := json.Unmarshal(jr.JobRaw, &adj)
+		if err != nil {
+			return err
+		}
+
+		jr.Job = &adj
+	default:
+		l.Log.Warnf("Unsupported job: %v", jr.JobName)
+		return fmt.Errorf("unsupported job %v", jr.JobName)
+	}
+
+	l.Log.Debugf("Successfully parsed job %v, args %v", jr.Job.Name(), jr.Job.Arguments())
+
+	return nil
+}
+
+// Throws a `job` on the redis list to be picked up by the worker
+func Enqueue(j Job) {
+	l.Log.Infof("Submitting job %v to redis with %v", j.Name(), j.Arguments())
+
+	req := JobRequest{
+		JobName: j.Name(),
+		JobRaw:  j.ToJSON(),
+	}
+
+	err := redis.Client.RPush(context.Background(), workQueue, req).Err()
+	if err != nil {
+		l.Log.Warnf("Failed to submit job: %v", err)
+	}
+}

--- a/jobs/superkey.go
+++ b/jobs/superkey.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -13,11 +14,11 @@ import (
 )
 
 type SuperkeyDestroyJob struct {
-	Headers  []kafka.Header
-	Identity string
-	Tenant   int64
-	Model    string
-	Id       int64
+	Headers  []kafka.Header `json:"headers"`
+	Identity string         `json:"identity"`
+	Tenant   int64          `json:"tenant"`
+	Model    string         `json:"model"`
+	Id       int64          `json:"id"`
 }
 
 func (sk SuperkeyDestroyJob) Delay() time.Duration {
@@ -106,4 +107,12 @@ func (sk SuperkeyDestroyJob) sendForApplication(id int64) error {
 	})
 
 	return nil
+}
+
+func (sk SuperkeyDestroyJob) ToJSON() []byte {
+	bytes, err := json.Marshal(&sk)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
 }

--- a/jobs/types.go
+++ b/jobs/types.go
@@ -14,6 +14,8 @@ import "time"
 	3. Name, for pretty logging
 
 	4. Run, what do we do?
+
+	5. ToJSON, serialize the job into a byte array for sending off to redis
 */
 type Job interface {
 	// how long to wait until performing (just do a sleep)
@@ -24,4 +26,6 @@ type Job interface {
 	Name() string
 	// run the job, using any args on the struct
 	Run() error
+	// serialize the job into JSON
+	ToJSON() []byte
 }

--- a/jobs/worker.go
+++ b/jobs/worker.go
@@ -1,46 +1,82 @@
 package jobs
 
 import (
+	"context"
+	"errors"
 	"time"
 
 	l "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/redis"
 )
 
-var ch chan Job
+// the queue on redis we'll be sending the jobs to
+const workQueue = "sources_api_jobs"
 
-// fire up a worker, initializing the channel to read from inline
-func Init() {
-	// initialize the channel to be used by the job worker. The `RunWorker`
-	// function just takes a channel so we can swap out the backing store for
-	// the jobs for anything we like as long as it can speak through a channel
-	// (maybe redis groups someday.)
-	ch = make(chan Job)
-	l.Log.Infof("Starting Worker for Delayed Jobs")
-	go RunWorker(ch)
-}
+// Runs the worker just consuming off of a redis list
+func Run() {
+	l.Log.Infof("Starting up Background worker listening to redis queue %q", workQueue)
 
-// Package level function to enqueue jobs to the job channel
-func Enqueue(j Job) {
-	ch <- j
-}
+	for {
+		// This is a BLocking Pop that will effectively wait forever until
+		// something gets queued.
+		//
+		// Once it does succeed - we check to see if the error is just
+		// `redis.Nil`, in which case things are fine and we continue.
+		val, err := redis.Client.BLPop(context.Background(), 0, workQueue).Result()
+		if err != nil {
+			if !errors.Is(err, redis.Nil) {
+				l.Log.Warnf("Failed to pop job from queue: %v", err)
+			}
 
-// Runs the worker just consuming off of a channel, right now just firing off
-// individual jobs in goroutines.
+			continue
+		}
 
-// TODO maybe add a choke channel to limit the amount of jobs running
-// concurrently.
-func RunWorker(ch chan Job) {
-	for j := range ch {
-		go RunJobNow(j)
+		jr := JobRequest{}
+		// the val that is returned is a slice in the form [listname, value]
+		// where val[0] is the name of the list (e.g. workQueue above) and
+		// val[1] is the string value, e.g. the output from
+		// jobRequest.MarshalBinary. So we need to unmarshal it.
+		err = jr.UnmarshalBinary([]byte(val[1]))
+		if err != nil {
+			l.Log.Warnf("Failed to unmarshal job from redis: %v", err)
+			continue
+		}
+
+		// Parse is the _very_ important method that looks at the job name and
+		// figures out what kind of job to unmarshal
+		err = jr.Parse()
+		if err != nil {
+			l.Log.Warnf("Failed to unmarshal job from redis: %v", err)
+			continue
+		}
+
+		RunJobAsync(jr.Job)
 	}
+}
+
+// Run a Job with a delay but in the background so it does _not_ block the
+// calling routine.
+func RunJobAsync(j Job) {
+	l.Log.Infof("Running job asyncronously %v, %v", j.Name(), j.Arguments())
+
+	go func() {
+		RunJob(j)
+	}()
+}
+
+// Run a job with a delay in front. This will block the calling thread. If you
+// do not want to block use `RunJobAsync`
+func RunJob(j Job) {
+	l.Log.Infof("Waiting %v for %v, %v", j.Delay(), j.Name(), j.Arguments())
+	time.Sleep(j.Delay())
+
+	RunJobNow(j)
 }
 
 // Package level function to run a job - call this one directly instead of
 // `Enqueue` if you want to run the job immediately.
 func RunJobNow(j Job) {
-	l.Log.Infof("Waiting %v", j.Delay())
-	time.Sleep(j.Delay())
-
+	l.Log.Infof("Running Job %v with %v", j.Name(), j.Arguments())
 	err := j.Run()
 	if err != nil {
 		l.Log.Warnf("Error running job [ %v ], args [ %v ] : [ %v ]", j.Name(), j.Arguments(), err)

--- a/main.go
+++ b/main.go
@@ -26,13 +26,15 @@ func main() {
 	// Redis needs to be initialized first since the database uses a Redis lock to ensure that only one application at
 	// a time can run the migrations.
 	redis.Init()
-	jobs.Init()
 	dao.Init()
 
-	if conf.StatusListener {
+	switch {
+	case conf.StatusListener:
 		dao.GetMarketplaceTokenCacher = dao.GetMarketplaceTokenCacherWithTenantId
 		go statuslistener.Run()
-	} else {
+	case conf.BackgroundWorker:
+		go jobs.Run()
+	default:
 		// launch 2 listeners - one for metrics and one for the actual application,
 		// one on 8000 and one on 9000 (per clowder)
 		go runServer()

--- a/main_test.go
+++ b/main_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/internal/events"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/mocks"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	l "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
@@ -50,6 +52,8 @@ func TestMain(t *testing.M) {
 		getAuthenticationDao = getAuthenticationDaoWithTenant
 
 		dao.Vault = &mocks.MockVault{}
+
+		service.Producer = events.EventStreamProducer{Sender: &mocks.MockSender{}}
 
 		// Set up marketplace's token management functions
 		dao.GetMarketplaceTokenCacher = dao.GetMarketplaceTokenCacherWithTenantId

--- a/middleware/event_stream.go
+++ b/middleware/event_stream.go
@@ -54,6 +54,14 @@ func RaiseEvent(next echo.HandlerFunc) echo.HandlerFunc {
 
 		headers := service.ForwadableHeaders(c)
 
-		return service.RaiseEvent(eventType, resource, headers)
+		// async!
+		go func() {
+			err := service.RaiseEvent(eventType, resource, headers)
+			if err != nil {
+				l.Log.Warnf("Error raising event %v: %v", eventType, err)
+			}
+		}()
+
+		return nil
 	}
 }

--- a/redis/client.go
+++ b/redis/client.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 
 	"github.com/RedHatInsights/sources-api-go/config"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v8"
 )
 
 var Client *redis.Client
+
+// error used for checking if the error coming back from redis is nil or not
+const Nil = redis.Nil
 
 func Init() {
 	cfg := config.Get()

--- a/redis/marketplace_token.go
+++ b/redis/marketplace_token.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -29,7 +30,7 @@ type MarketplaceTokenCacher struct {
 func (mtc *MarketplaceTokenCacher) FetchToken() (*marketplace.BearerToken, error) {
 	redisKey := fmt.Sprintf(redisKeySuffix, mtc.TenantID)
 
-	cachedToken, err := Client.Get(redisKey).Result()
+	cachedToken, err := Client.Get(context.Background(), redisKey).Result()
 	if err != nil {
 		return nil, fmt.Errorf("token not present in Redis: %s", err)
 	}
@@ -56,6 +57,7 @@ func (mtc *MarketplaceTokenCacher) CacheToken(token *marketplace.BearerToken) er
 	}
 
 	err := Client.Set(
+		context.Background(),
 		redisKey,
 		token,
 		redisExpiration,

--- a/redis/marketplace_token_test.go
+++ b/redis/marketplace_token_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/marketplace"
-	"github.com/go-redis/redis"
+	"github.com/go-redis/redis/v8"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Been working on this for a bit - might as well open it now since we're moving forward. This will make it easier to track in the stage ENV.

1. Moves the job worker to its own deployment, which is listening on a redis queue. It pops jobs from there and runs them. 
2. `jobs.Enqueue(jobs.Job)` now just pushes the job onto a queue to be handled later rather than the in-memory channel.
3. Side effect is that I also upgraded our redis library to v8, I had forgotten to upgrade it for the longest time. The biggest API change is that everything takes a context all the way down. 