### PR TITLE
Add ENCRYPTION_KEY env var to deployment(s)

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -19,6 +19,11 @@ objects:
         env:
         - name: LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-secrets
+              key: encryption-key
         resources:
           limits:
             cpu: ${AVAILABILITY_LISTENER_CPU_LIMIT}
@@ -56,6 +61,11 @@ objects:
               name: sources-api-secrets
               key: psks
               optional: true
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-secrets
+              key: encryption-key
         readinessProbe:
           tcpSocket:
             port: 8000


### PR DESCRIPTION
I missed this when testing locally. This way the same encryption key gets mounted everywhere in both deployments. 