### PR TITLE
Fix SuperkeyDestroy SubCollectionList call to not send a pointer

### DIFF
--- a/jobs/superkey.go
+++ b/jobs/superkey.go
@@ -56,7 +56,7 @@ func (sk SuperkeyDestroyJob) sendForSource(id int64) error {
 
 	a := dao.GetApplicationDao(&sk.Tenant)
 
-	apps, _, err := a.SubCollectionList(&m.Source{ID: id}, 100, 0, make([]util.Filter, 0))
+	apps, _, err := a.SubCollectionList(m.Source{ID: id}, 100, 0, make([]util.Filter, 0))
 	if err != nil {
 		return fmt.Errorf("failed to list applications for source: %v", err)
 	}


### PR DESCRIPTION
I was wondering why this was failing - I had chalked it up to the job deleting out of order before, and I PR'd this in once but must have removed the commits.

1. The Relation Object doesn't recognize `*model.Source`, so it returns an error here: https://github.com/RedHatInsights/sources-api-go/blob/8b58b9d33bd7b292c713d09d0e513380b3aea415/model/relation_object.go#L112
2. That error message is *subsequently erased here, without logging* https://github.com/RedHatInsights/sources-api-go/blob/8b58b9d33bd7b292c713d09d0e513380b3aea415/dao/application_dao.go#L37

So we were getting messages for "source not found" when running the superkey delete job. 

I would like to refactor/remove the RelationObject eventually - it could be replaced by a query such as:
```go
func (a *applicationDaoImpl) ListForSource(sourceID int64, limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
	exists, err := GetSourceDao(a.TenantID).Exists(sourceID)
	if !exists || err != nil {
		l.Log.Infof("Source not found %v", sourceID)
		return nil, 0, util.NewErrNotFound("source")
	}

	return a.List(limit, offset, append(filters, util.Filter{Name: "source_id", Value: []string{strconv.FormatInt(sourceID, 10)}}))
}
```
for the simple subcollections that don't involve many to many. 