### PR TITLE
Don't ignore Authentication#CreatedAt

### DIFF
--- a/model/authentication.go
+++ b/model/authentication.go
@@ -15,7 +15,7 @@ import (
 type Authentication struct {
 	DbID      int64     `gorm:"primaryKey; column:id" json:"-"`
 	ID        string    `json:"id"`
-	CreatedAt time.Time `json:"created_at" gorm:"-"`
+	CreatedAt time.Time `json:"created_at"`
 
 	Name        *string                `json:"name,omitempty"`
 	AuthType    string                 `gorm:"column:authtype" json:"authtype"`


### PR DESCRIPTION
it was added [here](https://github.com/RedHatInsights/sources-api-go/commit/148504a80004630014a8096efff42d27add60599#diff-6f4c5eb652adbd7eaab690990defd18e51f568a9680e56167248cc071c3f2109R18)

with `gorm:"-"` `created_at``s are empty  on authentications (after create with bulk_create or with POST auth. endpoint )


or @lindgrenj6 as you added - do we need it ? 

 