### PR TITLE
[RHCLOUD-18907] fix: bulk delete fetches all the resources

### DIFF
--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -378,6 +378,7 @@ func (add *authenticationDaoDbImpl) BulkCreate(auth *m.Authentication) error {
 func (add *authenticationDaoDbImpl) Update(authentication *m.Authentication) error {
 	return DB.
 		Debug().
+		Where("tenant_id = ?", add.TenantID).
 		Updates(authentication).
 		Error
 }
@@ -398,6 +399,7 @@ func (add *authenticationDaoDbImpl) Delete(id string) (*m.Authentication, error)
 
 	err = DB.
 		Debug().
+		Where("tenant_id = ?", add.TenantID).
 		Delete(authentication).
 		Error
 
@@ -485,6 +487,7 @@ func (add *authenticationDaoDbImpl) ListIdsForResource(resourceType string, reso
 		Model(m.Authentication{}).
 		Where("resource_type = ?", resourceType).
 		Where("resource_id IN ?", resourceIds).
+		Where("tenant_id = ?", add.TenantID).
 		Find(&authentications).
 		Error
 
@@ -513,6 +516,7 @@ func (add *authenticationDaoDbImpl) BulkDelete(authentications []m.Authenticatio
 		Debug().
 		Preload("Tenant").
 		Where("id IN ?", authIds).
+		Where("tenant_id = ?", add.TenantID).
 		Find(&dbAuths).
 		Error
 
@@ -523,6 +527,7 @@ func (add *authenticationDaoDbImpl) BulkDelete(authentications []m.Authenticatio
 	if len(dbAuths) != 0 {
 		err = DB.
 			Debug().
+			Where("tenant_id = ?", add.TenantID).
 			Delete(&dbAuths).
 			Error
 

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -512,7 +512,8 @@ func (add *authenticationDaoDbImpl) BulkDelete(authentications []m.Authenticatio
 	err := DB.
 		Debug().
 		Preload("Tenant").
-		Find(&dbAuths, authIds).
+		Where("id IN ?", authIds).
+		Find(&dbAuths).
 		Error
 
 	if err != nil {

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -182,3 +182,20 @@ func (a *endpointDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
 
 	return data, err
 }
+
+func (a *endpointDaoImpl) Exists(endpointId int64) (bool, error) {
+	var endpointExists bool
+
+	err := DB.Model(&m.Application{}).
+		Select("1").
+		Where("id = ?", endpointId).
+		Where("tenant_id = ?", a.TenantID).
+		Scan(&endpointExists).
+		Error
+
+	if err != nil {
+		return false, err
+	}
+
+	return endpointExists, nil
+}

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -73,3 +73,41 @@ func TestDeleteEndpointNotExists(t *testing.T) {
 
 	DropSchema("delete")
 }
+
+// TestEndpointExists tests whether the function exists returns true when the given endpoint exists.
+func TestEndpointExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("exists")
+
+	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
+
+	got, err := endpointDao.Exists(fixtures.TestEndpointData[0].ID)
+	if err != nil {
+		t.Errorf(`unexpected error when checking that the endpoint exists: %s`, err)
+	}
+
+	if !got {
+		t.Errorf(`the endpoint does exist but the "Exist" function returns otherwise. Want "true", got "%t"`, got)
+	}
+
+	DropSchema("exists")
+}
+
+// TestEndpointNotExists tests whether the function exists returns false when the given endpoint does not exist.
+func TestEndpointNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("exists")
+
+	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
+
+	got, err := endpointDao.Exists(12345)
+	if err != nil {
+		t.Errorf(`unexpected error when checking that the endpoint exists: %s`, err)
+	}
+
+	if got {
+		t.Errorf(`the endpoint doesn't exist but the "Exist" function returns otherwise. Want "false", got "%t"`, got)
+	}
+
+	DropSchema("exists")
+}

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -123,6 +123,8 @@ type EndpointDao interface {
 	BulkMessage(resource util.Resource) (map[string]interface{}, error)
 	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error
 	ToEventJSON(resource util.Resource) ([]byte, error)
+	// Exists returns true if the endpoint exists.
+	Exists(endpointId int64) (bool, error)
 }
 
 type MetaDataDao interface {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -566,6 +566,10 @@ func (m *MockEndpointDao) SourceHasEndpoints(sourceId int64) bool {
 	return true
 }
 
+func (m *MockEndpointDao) Exists(endpointId int64) (bool, error) {
+	return true, nil
+}
+
 func (m *MockEndpointDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
 	return nil, nil
 }

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -208,6 +208,16 @@ func EndpointDelete(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
+	// Check if the endpoint exists before proceeding.
+	endpointExists, err := endpointDao.Exists(id)
+	if err != nil {
+		return util.NewErrBadRequest(err)
+	}
+
+	if !endpointExists {
+		return util.NewErrNotFound("endpoint")
+	}
+
 	c.Logger().Infof("Deleting Endpoint Id %v", id)
 
 	// Cascade delete the endpoint.

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -532,7 +532,7 @@ func TestEndpointEditBadRequest(t *testing.T) {
 }
 
 func TestEndpointDelete(t *testing.T) {
-	t.Skip("TODO: fix the test")
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	c, rec := request.CreateTestContext(
 		http.MethodDelete,
@@ -601,7 +601,7 @@ func TestEndpointDeleteBadRequest(t *testing.T) {
 }
 
 func TestEndpointDeleteNotFound(t *testing.T) {
-	t.Skip("TODO: fix the test")
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	c, rec := request.CreateTestContext(
 		http.MethodDelete,


### PR DESCRIPTION
The "Find" function of Gorm can take a slice of IDs so that the function adds a "WHERE ... IN" condition automatically. The catch is that when the slice is empty Gorm doesn't add any where condition, which ends up resulting in a "SELECT * FROM" query, which fetches the whole table.

## Links

[[RHCLOUD-18907]](https://issues.redhat.com/browse/RHCLOUD-18907)