### PR TITLE
[RHCLOUD-18920] Application authentications are fetched by a non-existent column name

### DIFF
--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -37,10 +37,14 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplicati
 		applicationIDs = append(applicationIDs, value.ID)
 	}
 
-	err := DB.Debug().
+	err := DB.
+		Debug().
 		Preload("Tenant").
 		Where("application_id IN ?", applicationIDs).
-		Find(&applicationAuthentications).Error
+		Where("tenant_id = ?", a.TenantID).
+		Find(&applicationAuthentications).
+		Error
+
 	if err != nil {
 		return nil, err
 	}

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
@@ -62,4 +63,87 @@ func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
 	}
 
 	DropSchema("delete")
+}
+
+// TestApplicationAuthenticationsByAuthenticationsDatabase tests that when using a database datastore, the function under
+// test only fetches the application authentications related to the given list of authentications.
+func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("appauthfind")
+
+	// Get all the DAOs we are going to work with.
+	authDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+
+	// Maximum of authentications to create.
+	maxCreatedAuths := 5
+
+	// Store both the authentications and the application authentications for later.
+	var createdAuths = make([]model.Authentication, 0, maxCreatedAuths)
+	var createdAppAuths = make([]model.ApplicationAuthentication, 0, maxCreatedAuths)
+	for i := 0; i < maxCreatedAuths; i++ {
+		// Create the authentication.
+		auth := setUpValidAuthentication()
+		auth.ResourceID = fixtures.TestApplicationData[0].ID
+		auth.ResourceType = "Application"
+
+		err := authDao.Create(auth)
+		if err != nil {
+			t.Errorf(`could not create fixture authentication: %s`, err)
+		}
+
+		createdAuths = append(createdAuths, *auth)
+
+		// Create the application authentication.
+		appAuth := model.ApplicationAuthentication{
+			ApplicationID:    fixtures.TestApplicationData[0].ID,
+			AuthenticationID: auth.DbID,
+			TenantID:         fixtures.TestTenantData[0].Id,
+		}
+
+		err = appAuthDao.Create(&appAuth)
+		if err != nil {
+			t.Errorf(`could not create fixture application authentication: %s`, err)
+		}
+
+		createdAppAuths = append(createdAppAuths, appAuth)
+	}
+
+	// Call the function under test.
+	dbAppAuths, err := appAuthDao.ApplicationAuthenticationsByResource("NotASource", []model.Application{}, createdAuths)
+	if err != nil {
+		t.Errorf(`unexpected error when fetching the application authentications: %s`, err)
+	}
+
+	// Check that we fetched the correct amount of application authentications.
+	{
+		want := maxCreatedAuths
+		got := len(dbAppAuths)
+
+		if want != got {
+			t.Errorf(`incorrect amount of application authentications fetched. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	// Check that we fetched the correct application authentications.
+	for i := 0; i < maxCreatedAuths; i++ {
+		{
+			want := createdAppAuths[i].ID
+			got := dbAppAuths[i].ID
+
+			if want != got {
+				t.Errorf(`incorrect application authentication fetched. Want application authentication with id "%d", got "%d"`, want, got)
+			}
+		}
+		{
+			want := createdAuths[i].DbID
+			got := dbAppAuths[i].AuthenticationID
+
+			if want != got {
+				t.Errorf(`incorrect application authentication fetched. Want application authentication with authentication id "%d", got "%d"`, want, got)
+			}
+		}
+	}
+
+	DropSchema("appauthfind")
 }

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -65,6 +65,102 @@ func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
 	DropSchema("delete")
 }
 
+// TestApplicationAuthenticationsByApplicationsDatabase tests that when using a database datastore, the function under
+// test only fetches the application authentications related to the given list of applications.
+func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("appauthfind")
+
+	// Get all the DAOs we are going to work with.
+	authDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	appDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+
+	// Maximum of resources to create.
+	maxCreatedResources := 5
+
+	// Store the resources for later.
+	var createdApps = make([]model.Application, 0, maxCreatedResources)
+	var createdAppAuths = make([]model.ApplicationAuthentication, 0, maxCreatedResources)
+	for i := 0; i < maxCreatedResources; i++ {
+		// Create the authentication.
+		auth := setUpValidAuthentication()
+		auth.ResourceID = fixtures.TestApplicationData[0].ID
+		auth.ResourceType = "Application"
+
+		err := authDao.Create(auth)
+		if err != nil {
+			t.Errorf(`could not create fixture authentication: %s`, err)
+		}
+
+		// Create the application.
+		app := model.Application{
+			ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
+			SourceID:          fixtures.TestSourceData[0].ID,
+			TenantID:          fixtures.TestTenantData[0].Id,
+		}
+
+		err = appDao.Create(&app)
+		if err != nil {
+			t.Errorf(`could not create fixture application: %s`, err)
+		}
+
+		createdApps = append(createdApps, app)
+
+		// Create the application authentication.
+		appAuth := model.ApplicationAuthentication{
+			ApplicationID:    app.ID,
+			AuthenticationID: auth.DbID,
+			TenantID:         fixtures.TestTenantData[0].Id,
+		}
+
+		err = appAuthDao.Create(&appAuth)
+		if err != nil {
+			t.Errorf(`could not create fixture application authentication: %s`, err)
+		}
+
+		createdAppAuths = append(createdAppAuths, appAuth)
+	}
+
+	// Call the function under test.
+	dbAppAuths, err := appAuthDao.ApplicationAuthenticationsByResource("Source", createdApps, []model.Authentication{})
+	if err != nil {
+		t.Errorf(`unexpected error when fetching the application authentications: %s`, err)
+	}
+
+	// Check that we fetched the correct amount of application authentications.
+	{
+		want := maxCreatedResources
+		got := len(dbAppAuths)
+
+		if want != got {
+			t.Errorf(`incorrect amount of application authentications fetched. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	// Check that we fetched the correct application authentications.
+	for i := 0; i < maxCreatedResources; i++ {
+		{
+			want := createdAppAuths[i].ID
+			got := dbAppAuths[i].ID
+
+			if want != got {
+				t.Errorf(`incorrect application authentication fetched. Want application authentication with id "%d", got "%d"`, want, got)
+			}
+		}
+		{
+			want := createdApps[i].ID
+			got := dbAppAuths[i].ApplicationID
+
+			if want != got {
+				t.Errorf(`incorrect application authentication fetched. Want application authentication with application id "%d", got "%d"`, want, got)
+			}
+		}
+	}
+
+	DropSchema("appauthfind")
+}
+
 // TestApplicationAuthenticationsByAuthenticationsDatabase tests that when using a database datastore, the function under
 // test only fetches the application authentications related to the given list of authentications.
 func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -182,3 +182,20 @@ func (a *endpointDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
 
 	return data, err
 }
+
+func (a *endpointDaoImpl) Exists(endpointId int64) (bool, error) {
+	var endpointExists bool
+
+	err := DB.Model(&m.Application{}).
+		Select("1").
+		Where("id = ?", endpointId).
+		Where("tenant_id = ?", a.TenantID).
+		Scan(&endpointExists).
+		Error
+
+	if err != nil {
+		return false, err
+	}
+
+	return endpointExists, nil
+}

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -73,3 +73,41 @@ func TestDeleteEndpointNotExists(t *testing.T) {
 
 	DropSchema("delete")
 }
+
+// TestEndpointExists tests whether the function exists returns true when the given endpoint exists.
+func TestEndpointExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("exists")
+
+	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
+
+	got, err := endpointDao.Exists(fixtures.TestEndpointData[0].ID)
+	if err != nil {
+		t.Errorf(`unexpected error when checking that the endpoint exists: %s`, err)
+	}
+
+	if !got {
+		t.Errorf(`the endpoint does exist but the "Exist" function returns otherwise. Want "true", got "%t"`, got)
+	}
+
+	DropSchema("exists")
+}
+
+// TestEndpointNotExists tests whether the function exists returns false when the given endpoint does not exist.
+func TestEndpointNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("exists")
+
+	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
+
+	got, err := endpointDao.Exists(12345)
+	if err != nil {
+		t.Errorf(`unexpected error when checking that the endpoint exists: %s`, err)
+	}
+
+	if got {
+		t.Errorf(`the endpoint doesn't exist but the "Exist" function returns otherwise. Want "false", got "%t"`, got)
+	}
+
+	DropSchema("exists")
+}

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -123,6 +123,8 @@ type EndpointDao interface {
 	BulkMessage(resource util.Resource) (map[string]interface{}, error)
 	FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) error
 	ToEventJSON(resource util.Resource) ([]byte, error)
+	// Exists returns true if the endpoint exists.
+	Exists(endpointId int64) (bool, error)
 }
 
 type MetaDataDao interface {

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -566,6 +566,10 @@ func (m *MockEndpointDao) SourceHasEndpoints(sourceId int64) bool {
 	return true
 }
 
+func (m *MockEndpointDao) Exists(endpointId int64) (bool, error) {
+	return true, nil
+}
+
 func (m *MockEndpointDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
 	return nil, nil
 }

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -208,6 +208,16 @@ func EndpointDelete(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
+	// Check if the endpoint exists before proceeding.
+	endpointExists, err := endpointDao.Exists(id)
+	if err != nil {
+		return util.NewErrBadRequest(err)
+	}
+
+	if !endpointExists {
+		return util.NewErrNotFound("endpoint")
+	}
+
 	c.Logger().Infof("Deleting Endpoint Id %v", id)
 
 	// Cascade delete the endpoint.

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -532,7 +532,7 @@ func TestEndpointEditBadRequest(t *testing.T) {
 }
 
 func TestEndpointDelete(t *testing.T) {
-	t.Skip("TODO: fix the test")
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	c, rec := request.CreateTestContext(
 		http.MethodDelete,
@@ -601,7 +601,7 @@ func TestEndpointDeleteBadRequest(t *testing.T) {
 }
 
 func TestEndpointDeleteNotFound(t *testing.T) {
-	t.Skip("TODO: fix the test")
+	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	c, rec := request.CreateTestContext(
 		http.MethodDelete,

--- a/model/application_authentication_http.go
+++ b/model/application_authentication_http.go
@@ -14,5 +14,5 @@ type ApplicationAuthenticationResponse struct {
 
 	ApplicationID     string `json:"application_id"`
 	AuthenticationID  string `json:"authentication_id"`
-	AuthenticationUID string `json:"authentication_uid"`
+	AuthenticationUID string `json:"-"`
 }


### PR DESCRIPTION
We were seeing the following error in the stage environment:

```json
{"@timestamp":"2022-04-12T15:27:58.183Z","@version":1,"app":"source-api-go","caller":"github.com/RedHatInsights/sources-api-go/statuslistener.(*AvailabilityStatusListener).processEvent","filename":"/build/statuslistener/statuslistener.go:138","hostname":"sources-api-go-availability-status-listener-65cd86db8b-bxp6v","labels":{"app":"source-api-go"},"level":"error","message":"Error in raising event for update: error in BulkMessage: ERROR: column \"authentication_uid\" does not exist (SQLSTATE 42703), resource: Application(130166)","tags":["source-api-go"]}
```

It seems that we were trying to fetch the application authentications by the `authentication_uid` column which doesn't exist. I have fixed it to fetch the app auths by the `authentication_id` column instead, which is the FK to the `authentications` table.

I also modified the `ApplicationAuthenticationsByApplications` function to add a missing `WHERE tenant_id = ?` condition, and provided a test for it.

## Links

[[RHCLOUD-18920]](https://issues.redhat.com/browse/RHCLOUD-18920)