### PR TITLE
Improve filename in log messages in nested logger calls

### DIFF
--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -18,13 +18,13 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 			switch err.(type) {
 			case util.ErrNotFound:
 				statusCode = http.StatusNotFound
-				message = util.ErrorDoc(err.Error(), "404")
+				message = util.ErrorDocWithoutLogging(err.Error(), "404")
 			case util.ErrBadRequest:
 				statusCode = http.StatusBadRequest
-				message = util.ErrorDoc(err.Error(), "400")
+				message = util.ErrorDocWithoutLogging(err.Error(), "400")
 			default:
 				statusCode = http.StatusInternalServerError
-				message = util.ErrorDoc(fmt.Sprintf("Internal Server Error: %v", err.Error()), "500")
+				message = util.ErrorDocWithoutLogging(fmt.Sprintf("Internal Server Error: %v", err.Error()), "500")
 			}
 			return c.JSON(statusCode, message)
 		}


### PR DESCRIPTION
Attribute `filename` in log message is displayed from place where log function(`Log.Error()`) was called.
This is not useful when  log function(`Log.Error()`)  is present in other common function - then we will have location of this 
common function - and it is not useful we don't know from which file the error came from.

This change adds setting for log message called `caller_depth`:

`Log.WithField("caller_depth", 1).Error("error message")`

this ensure that we will have in filename first outer method. If there will be caller_depth=2 - we will have in filename first and second outer method - etc.

Example(id is not number) - check `filename`:
```
GET http://localhost:{{port}}/api/sources/v3.1/sources/XXX
```

before:
```
{"@timestamp":"2022-04-14T21:23:38.499Z","@version":1,"app":"source-api-go","caller":"","filename":"/Users/liborpichler/Projects/sources-api-go/util/error_document.go:22","hostname":"lpichler1-mac","labels":{"app":"source-api-go"},"level":"error","message":"bad request: strconv.ParseInt: parsing \"XXX\": invalid syntax","tags":["source-api-go"]}
```

after:

```
{"@timestamp":"2022-04-14T21:22:14.655Z","@version":1,"app":"source-api-go","caller":"github.com/RedHatInsights/sources-api-go/util.NewErrBadRequest","caller_depth":2,"filename":"/Users/liborpichler/Projects/sources-api-go/source_handlers.go:79; /Users/liborpichler/Projects/sources-api-go/middleware/tenancy.go:70","hostname":"lpichler1-mac","labels":{"app":"source-api-go"},"level":"error","message":"strconv.ParseInt: parsing \"XXX\": invalid syntax","tags":["source-api-go"]}
```




