### PR TITLE
[RHCLOUD-18936] fix: marketplace host is not being included in deployment

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -47,6 +47,8 @@ objects:
           value: ${KOKU_SOURCES_API_SCHEME}://${KOKU_SOURCES_API_HOST}:${KOKU_SOURCES_API_PORT}${KOKU_SOURCES_API_APP_CHECK_PATH}
         - name: SOURCES_ENV
           value: ${SOURCES_ENV}
+        - name: MARKETPLACE_HOST
+          value: ${MARKETPLACE_HOST}
         - name: SOURCES_PSKS
           valueFrom:
             secretKeyRef:
@@ -201,7 +203,7 @@ parameters:
   name: RBAC_PATH
   required: true
   value: /api/rbac/v1
-- description: Host to user for the marketplace URL.
+- description: Host to use for the marketplace URL.
   displayName: Marketplace host URL
   name: MARKETPLACE_HOST
   required: true


### PR DESCRIPTION
It seems that even though I included the environment variable in the parameters list in https://github.com/RedHatInsights/sources-api-go/pull/55, I forgot to specify it in the deployment spec, which caused the mentioned bug in the ticket.

## Links

[[RHCLOUD-18936]](https://issues.redhat.com/browse/RHCLOUD-18936)