### PR TITLE
Add backtrace on error or warn in logger.go

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -87,7 +87,7 @@ func LogrusLogLevelFrom(configLogLevel string) logrus.Level {
 	return logLevel
 }
 
-func backtrace() string {
+func backtrace() []string {
 	var filenames []string
 
 	pc := make([]uintptr, 1000)
@@ -95,10 +95,10 @@ func backtrace() string {
 	frames := runtime.CallersFrames(pc[:n])
 
 	for frame, isNextFrameValid := frames.Next(); isNextFrameValid; frame, isNextFrameValid = frames.Next() {
-		filenames = append(filenames, fmt.Sprintf("%s:%d", frame.File, frame.Line))
+		filenames = append(filenames, fmt.Sprintf("%s(%s:%d)", frame.Function, frame.File, frame.Line))
 	}
 
-	return strings.Join(filenames, ";")
+	return filenames
 }
 
 type CustomLoggerFormatter struct {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -86,6 +87,20 @@ func LogrusLogLevelFrom(configLogLevel string) logrus.Level {
 	return logLevel
 }
 
+func backtrace() string {
+	var filenames []string
+
+	pc := make([]uintptr, 1000)
+	n := runtime.Callers(0, pc)
+	frames := runtime.CallersFrames(pc[:n])
+
+	for frame, isNextFrameValid := frames.Next(); isNextFrameValid; frame, isNextFrameValid = frames.Next() {
+		filenames = append(filenames, fmt.Sprintf("%s:%d", frame.File, frame.Line))
+	}
+
+	return strings.Join(filenames, ";")
+}
+
 type CustomLoggerFormatter struct {
 	Hostname              string
 	AppName               string
@@ -135,6 +150,10 @@ func (f *CustomLoggerFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	if entry.Logger.Level == logrus.DebugLevel && entry.Caller != nil && !f.InjectedToOtherLogger {
 		data["filename"] = fmt.Sprintf("%s:%d", entry.Caller.File, entry.Caller.Line)
+	}
+
+	if entry.Level == logrus.ErrorLevel || entry.Level == logrus.WarnLevel {
+		data["backtrace"] = backtrace()
 	}
 
 	for k, v := range entry.Data {


### PR DESCRIPTION
This adds "backtrace" attribute to our logs:

```json
{
   "@timestamp":"2022-04-19T10:11:24.579Z",
   "@version":1,
   "app":"source-api-go",
   "backtrace":"/usr/local/opt/go/libexec/src/runtime/extern.go:227;/Users/liborpichler/Projects/sources-api-go/logger/logger.go:94;/Users/liborpichler/Projects/sources-api-go/logger/logger.go:156;/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:279;/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:251;/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:293;/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:338;/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/logger.go:151;/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/logger.go:183;/Users/liborpichler/Projects/sources-api-go/source_handlers.go:31;/Users/liborpichler/Projects/sources-api-go/middleware/pagination.go:17;/Users/liborpichler/Projects/sources-api-go/middleware/filtering.go:18;/Users/liborpichler/Projects/sources-api-go/middleware/tenancy.go:70;/Users/liborpichler/Projects/sources-api-go/middleware/headers.go:78;/Users/liborpichler/Projects/sources-api-go/middleware/error_handling.go:13;/Users/liborpichler/Projects/sources-api-go/middleware/timings.go:19;/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:552;/Users/liborpichler/go/pkg/mod/github.com/labstack/echo-contrib@v0.12.0/prometheus/prometheus.go:382;/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/logger.go:117;/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/recover.go:98;/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:662;/usr/local/opt/go/libexec/src/net/http/server.go:2879;/usr/local/opt/go/libexec/src/net/http/server.go:1930",
   "caller":"main.SourceList",
   "filename":"/Users/liborpichler/Projects/sources-api-go/source_handlers.go:31",
   "hostname":"lpichler1-mac",
   "labels":{
      "app":"source-api-go"
   },
   "level":"error",
   "message":"This is error.",
   "tags":[
      "source-api-go"
   ]
}
```



