### PR TITLE
refactor: return error 500 on an internal error

### DIFF
--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -211,7 +211,7 @@ func EndpointDelete(c echo.Context) error {
 	// Check if the endpoint exists before proceeding.
 	endpointExists, err := endpointDao.Exists(id)
 	if err != nil {
-		return util.NewErrBadRequest(err)
+		return err
 	}
 
 	if !endpointExists {


### PR DESCRIPTION
It is better to return a 500 letting the caller know they did not do anything wrong when calling the endpoint.