### PR TITLE
[RHCLOUD-19007] Secret store tests

### DIFF
--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -69,6 +69,7 @@ func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
 // test only fetches the application authentications related to the given list of applications.
 func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("appauthfind")
 
 	// Get all the DAOs we are going to work with.
@@ -165,6 +166,7 @@ func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 // test only fetches the application authentications related to the given list of authentications.
 func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("appauthfind")
 
 	// Get all the DAOs we are going to work with.

--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/mocks"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"gorm.io/datatypes"
@@ -25,6 +26,7 @@ var defaultSchema = "dao"
 func TestMain(t *testing.M) {
 	flags = parser.ParseFlags()
 	if flags.Integration {
+		Vault = &mocks.MockVault{}
 		ConnectAndMigrateDB("dao")
 	}
 

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -3,13 +3,22 @@ package testutils
 import (
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 )
+
+var conf = config.Get()
 
 // SkipIfNotRunningIntegrationTests is a helper function which skips a test if the integration tests don't want to be
 // run.
 func SkipIfNotRunningIntegrationTests(t *testing.T) {
 	if !parser.RunningIntegrationTests {
 		t.Skip("Skipping integration test")
+	}
+}
+
+func SkipIfNotSecretStoreDatabase(t *testing.T) {
+	if conf.SecretStore == "vault" {
+		t.Skip("Skipping test")
 	}
 }


### PR DESCRIPTION
[RHCLOUD-19007](https://issues.redhat.com/browse/RHCLOUD-19007)

When you use in env variables the`SECRET_STORE=vault`, the tests fail.

We forgot to set the vault mock in `dao/main_test.go `
+
We need to skip some tests written only for the option when the secret store is database.