### PR TITLE
[RHCLOUD-19011] fix: endpoint doesn't exist when trying to delete it

### DIFF
--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -186,7 +186,7 @@ func (a *endpointDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
 func (a *endpointDaoImpl) Exists(endpointId int64) (bool, error) {
 	var endpointExists bool
 
-	err := DB.Model(&m.Application{}).
+	err := DB.Model(&m.Endpoint{}).
 		Select("1").
 		Where("id = ?", endpointId).
 		Where("tenant_id = ?", a.TenantID).


### PR DESCRIPTION
The model that the "Exists" function was checking against was "Application" instead of "Endpoint", so it only allowed deleting the endpoint whenever the requested ID to be deleted luckily matched any of the application IDs of the database.

## Links

[[RHCLOUD-19011]](https://issues.redhat.com/browse/RHCLOUD-19011)