### PR TITLE
[RHCLOUD-19004] Support older filtering options like `?name=test` on top of regular `filter[name]=test`

### DIFF
--- a/middleware/filtering.go
+++ b/middleware/filtering.go
@@ -51,6 +51,16 @@ func parseFilter(c echo.Context) []util.Filter {
 			}
 
 			f = append(f, filter)
+		} else if !strings.HasPrefix(key, "sort_by") {
+			// This is to ensure backward compatibility with the Rails API. Any
+			// query parameters that do not have `filter` or `sort_by` at the
+			// beginning need to be treated as "raw" output filters. e.g. if
+			// someone passes `id=25` we need to support that as equivalent to
+			// `filter[id]=25`
+			//
+			// if the column doesn't exist PG will throw a sqlstate error -
+			// which is expected.
+			f = append(f, util.Filter{Name: key, Value: values})
 		}
 	}
 

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -38,7 +38,7 @@ func TestParseFilterWithOperation(t *testing.T) {
 }
 
 func TestParseFilterWithoutOperation(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?filter[name]=test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[name]=test", nil)
 	c := e.NewContext(req, nil)
 
 	filters := parseFilter(c)
@@ -63,7 +63,7 @@ func TestParseFilterWithoutOperation(t *testing.T) {
 }
 
 func TestParseSorting(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?sort_by=name", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?sort_by=name", nil)
 	c := e.NewContext(req, nil)
 
 	sortFilter := parseSorting(c)
@@ -85,7 +85,7 @@ func TestParseSorting(t *testing.T) {
 }
 
 func TestParseSortingMultiple(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?sort_by=name&sort_by=uid", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?sort_by=name&sort_by=uid", nil)
 	c := e.NewContext(req, nil)
 
 	sortFilter := parseSorting(c)
@@ -138,7 +138,7 @@ func TestParseSubresourceFilterWithOperation(t *testing.T) {
 }
 
 func TestParseSubresourceFilterWithoutOperation(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v2.1/sources?filter[source_type][name]=test", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[source_type][name]=test", nil)
 	c := e.NewContext(req, nil)
 
 	filters := parseFilter(c)
@@ -163,5 +163,21 @@ func TestParseSubresourceFilterWithoutOperation(t *testing.T) {
 
 	if f.Value[0] != "test" {
 		t.Error("did not parse value correctly")
+	}
+}
+
+func TestParseFilteringWithoutFilterArg(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?name=test", nil)
+	c := e.NewContext(req, nil)
+
+	filters := parseFilter(c)
+	f := filters[0]
+
+	if f.Name != "name" {
+		t.Errorf("did not parse name correctly")
+	}
+
+	if f.Value[0] != "test" {
+		t.Errorf("did not parse value correctly")
 	}
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-19004

Ok so this one has some history. Here we go.

---

My initial filtering implementation was _only_ to support the "more advanced" filtering option via query parameters like this: `filter[name][not_eq]=test` which allows for a huge number of awesome options like contains, equal but ignoring case, etc. 

I went through and made sure that cost/swatch have updated their code to use this "blessed" filtering way. 

Where the wrench :wrench: came in was that fifi (satellite) cannot update their code on older versions of satellite, which rely on this type of filtering for initial registration so we are being forced to hold up backwards compatibility. 

---

It actually is a pretty simple solution - we just pass any erroneous query params along as filters and if they break the query to the db we just let the db complain. We're using prepared statements so it _should_ be fine. 