### PR TITLE
Fix Authentication ID resolver for GraphQL

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -72,3 +72,7 @@ models:
     fields:
       authentications:
         resolver: true
+  Authentication:
+    fields:
+      id:
+        resolver: true

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/graph/generated"
 	generated_model "github.com/RedHatInsights/sources-api-go/graph/model"
@@ -48,6 +49,14 @@ func (r *applicationResolver) Authentications(ctx context.Context, obj *model.Ap
 
 func (r *applicationResolver) TenantID(ctx context.Context, obj *model.Application) (string, error) {
 	return strconv.Itoa(int(*tenantIdFromCtx(ctx))), nil
+}
+
+func (r *authenticationResolver) ID(ctx context.Context, obj *model.Authentication) (string, error) {
+	if config.IsVaultOn() {
+		return obj.ID, nil
+	} else {
+		return strconv.FormatInt(obj.DbID, 10), nil
+	}
 }
 
 func (r *authenticationResolver) ResourceID(ctx context.Context, obj *model.Authentication) (string, error) {


### PR DESCRIPTION
The query that was failing is this:
```graphql
{
	sources(filter: { name: "id", operation: "eq", value: "138" }) {
		applications {
			application_type_id
			id
			availability_status_error
			availability_status
			paused_at
			authentications {
				id
			}
		}
	}
}
```

which was returning:
```json
{
	"data": {
		"sources": [
			{
				"applications": [
					{
						"application_type_id": "2",
						"id": "245",
						"availability_status_error": "",
						"availability_status": "",
						"paused_at": null,
						"authentications": [
							{
								"id": ""
							}
						]
					}
				]
			}
		]
	}
}
```

Notice the `""` on Authentication ID. This was being caused by the resolver incorrectly pulling the string ID we have on the Authentication struct.

So what I did was force the resolver to be generated via editing gqlgen.yml - ran `make generate` then implemented the check. 


---

After the fix the response looks great:
```json
{
	"data": {
		"sources": [
			{
				"applications": [
					{
						"application_type_id": "2",
						"id": "245",
						"availability_status_error": "",
						"availability_status": "",
						"paused_at": null,
						"authentications": [
							{
								"id": "362"
							}
						]
					}
				]
			}
		]
	}
}
```