### PR TITLE
[RHCLOUD-18936] Fix marketplace's error 500 when fetching authentications

### DIFF
--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -644,7 +644,21 @@ func setMarketplaceTokenAuthExtraField(auth *m.Authentication) error {
 			return errors.New("API key not present for the marketplace authentication")
 		}
 
-		marketplaceTokenProvider = GetMarketplaceTokenProvider(*auth.Password)
+		var apiKey string
+		if config.IsVaultOn() {
+			apiKey = *auth.Password
+		} else {
+			// When using the database backed authentications we need to decrypt the API Key to be able to fetch a proper
+			// token from the marketplace.
+			decryptedPassword, err := util.Decrypt(*auth.Password)
+			if err != nil {
+				return err
+			}
+
+			apiKey = decryptedPassword
+		}
+
+		marketplaceTokenProvider = GetMarketplaceTokenProvider(apiKey)
 
 		token, err = marketplaceTokenProvider.RequestToken()
 		if err != nil {
@@ -680,6 +694,12 @@ func setMarketplaceTokenAuthExtraField(auth *m.Authentication) error {
 			err := json.Unmarshal(auth.ExtraDb, &tmpContent)
 			if err != nil {
 				return err
+			}
+
+			// If the "ExtraDb" field is "null" —JSON value "null", not Golang's "nil"— the "Unmarshal" function sets
+			// "tmpContent" as nil, so we need to make sure it is properly initialized to avoid a panic.
+			if tmpContent == nil {
+				tmpContent = make(map[string]interface{})
 			}
 
 			// Append the token and marshal the content back, so that it is ready to be sent.

--- a/util/encryption.go
+++ b/util/encryption.go
@@ -12,16 +12,20 @@ import (
 
 var (
 	// "the key" to encrypt/decrypt passwords with
-	key        = os.Getenv("ENCRYPTION_KEY")
+	key        string
 	keyPresent = false
 )
 
 // init for this file basically just decodes the ENCRYPTION_KEY env var to the
 // plain text equivalent
 func init() {
-	if key == "" {
-		return
-	}
+	InitializeEncryption()
+}
+
+// InitializeEncryption allows reinitializing the encryption key by reading from the "ENCRYPTION_KEY" environment
+// variable again. Useful for testing purposes outside the "util" package.
+func InitializeEncryption() {
+	key = os.Getenv("ENCRYPTION_KEY")
 
 	// the key is base64 encoded in the ENV
 	decoded, err := base64.RawStdEncoding.DecodeString(key)


### PR DESCRIPTION
There were two main issues with this bug:

1. When using database backed authentications, the passwords weren't
   being decrypted, and that resulted in using encrypted API keys as the
   authorization keys for the marketplace. Of course, the marketplace
   complained.

2. It seems that the "ExtraDb" field gets initialized as the JSON value
   "null" sometimes, which causes "json.Unmarshal" to turn the target
   object as "nil". This caused a panic because the targetting map
   wasn't getting initialized, and the code below was trying to put
   content in that map's "marketplace" key.

---

Regarding adding the "ENCRYPTION_KEY" environment variable to the `Makefile`... The problem is that it gets initialized on an `init()` function, and that function gets called before any of the overrides I've tried setting up on the `TestMain` and the test functions themselves.

Our options are:

1. Add them in the `Makefile` like I did.
2. Move the `init`'s logic to a `InitializeEncryption` kind of function, which would read the `env var` and try to set the key. That way we would be able to call this function in the tests with the env var overridden.
3. Add them to the `config` env vars like the rest.

My thoughts:

1. It is very easy to forget about adding this environment variable if you're running the tests without `make`, and can be a little bit tedious to set up for certain tests.
2. It exposes a function that only would be used in tests.
3. It stores an env var that would only be used in tests.

I'm debating on what's the best approach here... I think I would vote for #2. What do you think?

**EDIT:** In fact I implemented the 2nd option since the 1st one implies changing the GitHub checks too... But I'll wait for your feedback.

## Links

[[RHCLOUD-18936]](https://issues.redhat.com/browse/RHCLOUD-18936)