### PR TITLE
Add support for feature flags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,12 @@ type SourcesApiConfig struct {
 	DatabaseUser              string
 	DatabasePassword          string
 	DatabaseName              string
+	FeatureFlagsEnvironment   string
+	FeatureFlagsHost          string
+	FeatureFlagsPort          string
+	FeatureFlagsSchema        string
+	FeatureFlagsAPIToken      string
+	FeatureFlagsService       string
 	CacheHost                 string
 	CachePort                 int
 	CachePassword             string
@@ -81,6 +87,11 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("CacheHost", cfg.InMemoryDb.Hostname)
 		options.SetDefault("CachePort", cfg.InMemoryDb.Port)
 		options.SetDefault("CachePassword", cfg.InMemoryDb.Password)
+
+		options.SetDefault("FeatureFlagsHost", cfg.FeatureFlags.Hostname)
+		options.SetDefault("FeatureFlagsPort", cfg.FeatureFlags.Port)
+		options.SetDefault("FeatureFlagsSchema", string(cfg.FeatureFlags.Scheme))
+		options.SetDefault("FeatureFlagsAPIToken", cfg.FeatureFlags.ClientAccessToken)
 	} else {
 		options.SetDefault("AwsRegion", "us-east-1")
 		options.SetDefault("AwsAccessKeyId", os.Getenv("CW_AWS_ACCESS_KEY_ID"))
@@ -104,6 +115,19 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("CacheHost", os.Getenv("REDIS_CACHE_HOST"))
 		options.SetDefault("CachePort", os.Getenv("REDIS_CACHE_PORT"))
 		options.SetDefault("CachePassword", os.Getenv("REDIS_CACHE_PASSWORD"))
+
+		options.SetDefault("FeatureFlagsHost", os.Getenv("FEATURE_FLAGS_HOST"))
+		options.SetDefault("FeatureFlagsPort", os.Getenv("FEATURE_FLAGS_PORT"))
+		options.SetDefault("FeatureFlagsSchema", os.Getenv("FEATURE_FLAGS_SCHEMA"))
+		options.SetDefault("FeatureFlagsAPIToken", os.Getenv("FEATURE_FLAGS_API_TOKEN"))
+	}
+
+	options.SetDefault("FeatureFlagsService", os.Getenv("FEATURE_FLAGS_SERVICE"))
+
+	if os.Getenv("SOURCES_ENV") == "prod" {
+		options.SetDefault("FeatureFlagsEnvironment", "production")
+	} else {
+		options.SetDefault("FeatureFlagsEnvironment", "development")
 	}
 
 	options.SetDefault("KafkaGroupID", "sources-api-go")
@@ -176,6 +200,12 @@ func Get() *SourcesApiConfig {
 		DatabaseUser:              options.GetString("DatabaseUser"),
 		DatabasePassword:          options.GetString("DatabasePassword"),
 		DatabaseName:              options.GetString("DatabaseName"),
+		FeatureFlagsHost:          options.GetString("FeatureFlagsHost"),
+		FeatureFlagsEnvironment:   options.GetString("FeatureFlagsEnvironment"),
+		FeatureFlagsPort:          options.GetString("FeatureFlagsPort"),
+		FeatureFlagsAPIToken:      options.GetString("FeatureFlagsApiToken"),
+		FeatureFlagsSchema:        options.GetString("FeatureFlagsSchema"),
+		FeatureFlagsService:       options.GetString("FeatureFlagsService"),
 		CacheHost:                 options.GetString("CacheHost"),
 		CachePort:                 options.GetInt("CachePort"),
 		CachePassword:             options.GetString("CachePassword"),

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -107,6 +107,8 @@ objects:
               name: cloud-connector-psk
               key: client-id
               optional: true
+        - name: FEATURE_FLAGS_SERVICE
+          value: ${FEATURE_FLAGS_SERVICE}
         readinessProbe:
           tcpSocket:
             port: 8000
@@ -282,3 +284,6 @@ parameters:
 - name: CLOUD_CONNECTOR_CHECK_PATH
   required: true
   value: "/connection_status"
+- description: Specify name of service for Feature Flags
+  name: FEATURE_FLAGS_SERVICE
+  value: 'unleash'

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.2
 	github.com/RedHatInsights/rbac-client-go v1.0.0
 	github.com/RedHatInsights/tenant-utils v0.0.0-20220322192943-150a1a665a5f
+	github.com/Unleash/unleash-client-go/v3 v3.3.1
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/aws/aws-sdk-go v1.42.22
 	github.com/gertd/go-pluralize v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/sarama v1.30.0/go.mod h1:zujlQQx1kzHsh4jfV1USnptCQrHAEZ2Hk8fTKCulPVs=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/Shopify/toxiproxy/v2 v2.1.6-0.20210914104332-15ea381dcdae/go.mod h1:/cvHQkZ1fst0EmZnA5dFtiQdWCNCFYzb+uE2vqVgvx0=
+github.com/Unleash/unleash-client-go/v3 v3.3.1 h1:Kf22zUOvSTueKjg6RHQ6IAY3/OaYc5vsDizeR9SpcMs=
+github.com/Unleash/unleash-client-go/v3 v3.3.1/go.mod h1:jAf7F2WWpfJbfn1n8bZ74p7hkAhijrqH4TpWoT7kWLc=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
@@ -1038,6 +1040,7 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
 github.com/neko-neko/echo-logrus/v2 v2.0.1 h1:BX2U6uv2N3UiUY75y+SntQak5S1AJIel9j+5Y6h4Nb4=
 github.com/neko-neko/echo-logrus/v2 v2.0.1/go.mod h1:GDYWo9CY4VXk/vn5ac5reoutYEkZEexlFI01MzHXVG0=
@@ -1298,6 +1301,7 @@ github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5J
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -1317,6 +1321,8 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
+github.com/twmb/murmur3 v1.1.5 h1:i9OLS9fkuLzBXjt6dptlAEyk58fJsSTXbRg3SgVyqgk=
+github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -2020,6 +2026,8 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
+gopkg.in/h2non/gock.v1 v1.0.10 h1:D4j796HhgidcxF0LnDyFXcoEbEZWoLEWf0kRh61p22w=
+gopkg.in/h2non/gock.v1 v1.0.10/go.mod h1:KHI4Z1sxDW6P4N3DfTWSEza07YpkQP7KJBfglRMEjKY=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:aPpfJ7XW+gOuirDoZ8gHhLh3kZ1B08FtV2bbmy7Jv3s=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/service/feature_flags.go
+++ b/service/feature_flags.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/RedHatInsights/sources-api-go/config"
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/Unleash/unleash-client-go/v3"
+)
+
+const appName = "sources-api"
+const projectName = "default"
+const refreshInterval = 60 // seconds
+const metricsInterval = 60 // seconds
+
+var conf = config.Get()
+
+var ready = false
+
+func featureFlagsServiceUnleash() bool {
+	return conf.FeatureFlagsService == "unleash"
+}
+
+type FeatureFlagListener struct{}
+
+func (l FeatureFlagListener) OnError(err error) {
+	logging.Log.Errorf("unleash error: %v\n", err)
+}
+
+func (l FeatureFlagListener) OnWarning(warning error) {
+	logging.Log.Warnf("unleash warning: %v\n", warning)
+}
+
+func (l FeatureFlagListener) OnReady() {
+	ready = true
+	logging.Log.Info("connection to unleash instance is ready")
+}
+
+func (l FeatureFlagListener) OnCount(_ string, _ bool) {
+}
+
+func (l FeatureFlagListener) OnSent(_ unleash.MetricsData) {
+}
+
+func (l FeatureFlagListener) OnRegistered(_ unleash.ClientData) {
+}
+
+func init() {
+	if featureFlagsServiceUnleash() {
+		logging.InitLogger(conf)
+
+		unleashUrl := fmt.Sprintf("%s://%s:%s/api", conf.FeatureFlagsSchema, conf.FeatureFlagsHost, conf.FeatureFlagsPort)
+		unleashConfig := []unleash.ConfigOption{unleash.WithAppName(appName),
+			unleash.WithListener(&FeatureFlagListener{}),
+			unleash.WithUrl(unleashUrl),
+			unleash.WithEnvironment(conf.FeatureFlagsEnvironment),
+			unleash.WithRefreshInterval(refreshInterval * time.Second),
+			unleash.WithMetricsInterval(metricsInterval * time.Second),
+			unleash.WithProjectName(projectName),
+			unleash.WithCustomHeaders(http.Header{"Authorization": {conf.FeatureFlagsAPIToken}})}
+
+		err := unleash.Initialize(unleashConfig...)
+		if err != nil {
+			logging.Log.Errorf("unable to initialize unleash: %v", err.Error())
+		}
+	}
+}
+
+func FeatureEnabled(feature string) bool {
+	if !featureFlagsServiceUnleash() {
+		return false
+	}
+
+	if !ready {
+		return false
+	}
+
+	return unleash.IsEnabled(feature)
+}


### PR DESCRIPTION
This adds function `FeatureEnabled(featureFlagName)` and it returns whether feature flag with name `featureFlagName` was set to enable or disable.

There is **env. variable** to enable feature flags for sources api: `FEATURE_FLAGS_SERVICE` and to use current implementation with unleash - it requires value `unleash` (as is set in `clowdapp.yaml`)

This was testes with minikube locally with clowder and also locally with running unleash server.

Testing 
## Locally with running unleash server

Run unleash server:

### 1. Run DB postgres

```
docker run -e POSTGRES_PASSWORD=some_password \
  -e POSTGRES_USER=unleash_user -e POSTGRES_DB=unleash \
  --network unleash --name postgres postgres
```

### 2. Unleash server
```
docker run -p 4242:4242 \
  -e DATABASE_HOST=postgres -e DATABASE_NAME=unleash \
  -e DATABASE_USERNAME=unleash_user -e DATABASE_PASSWORD=some_password \
  -e DATABASE_SSL=false \
  --network unleash unleashorg/unleash-server
```

### 3. GET Api TOKEN Access
Go to http://localhost:4242
l:admin
p:unleash4all
Configure -> API access - and generate here one token for you 

### 4. Set env. variables
```
FEATURE_FLAGS_SERVICE="unleash"
FEATURE_FLAGS_API_TOKEN=<from point 3>
FEATURE_FLAGS_HOST=localhost 
FEATURE_FLAGS_PORT=4242 
FEATURE_FLAGS_SCHEMA=http
```
### 5. Add testing feature code

- add feature toggle `test.feature` in [ui](http://localhost:4242) and add default strategy 
```go
// required imports:
//"fmt"
//	"github.com/RedHatInsights/sources-api-go/service"

// for example to add on line 32
	go func() {
		for {
			fmt.Printf("==== %v ", service.FeatureEnabled("test.feature"))
			time.Sleep(time.Second * 5)
		}
	}()

```

# minikube 

Normal process and you can do only point 5.
+ you need to expose port to access unleash UI:
`kubectl port-forward svc/dev-env-featureflags 4444:4242` and unleash UI will be on `localhost:4444`

# Additional notes

A) We can ensure that unleash is work when find logs message "connection to unleash instance is ready "

B) [unleash-api-go](https://github.com/Unleash/unleash-client-go) is doing polling to store state of feature flags to storage which is like cache for added feature flags in UI. Unleash client as sent regularly also metric data (how often feature flags were queried ). There are constant to set how frequently is state of feature flags sent/metrics are sent.

C) When there is error with unleash instance [unleash-api-go](https://github.com/Unleash/unleash-client-go) just use cache and last know state of feature flags will be used.
- I was trying to add control on error  and with FeatureFlags listener to turn off all flags in case  but we know only when error occurred  and not when unleash service is ready to reinit it back. Possible solution is to add own feature flag(and add own polling here) and use OnSent method from `FeatureFlagListener` as indication that service is ready again.



