### PR TITLE
Move Where tenant_id = ? in AuthenticationDAO#List function

### DIFF
--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -16,6 +16,7 @@ type authenticationDaoDbImpl struct {
 func (add *authenticationDaoDbImpl) List(limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
 	query := DB.
 		Debug().
+		Where("authentications.tenant_id = ?", add.TenantID).
 		Model(&m.Authentication{})
 
 	query, err := applyFilters(query, filters)
@@ -30,8 +31,6 @@ func (add *authenticationDaoDbImpl) List(limit, offset int, filters []util.Filte
 	// limiting + running the actual query.
 	authentications := make([]m.Authentication, 0, limit)
 	err = query.
-		Debug().
-		Where("tenant_id = ?", add.TenantID).
 		Limit(limit).
 		Offset(offset).
 		Find(&authentications).


### PR DESCRIPTION
Kind of grasping at straws here - but the only info I have after running this query:
```
k logs sources-api-go-svc-7f5944bd46-k2vst -f  | grep 144179 | jq -r .message,.rows
```

is this:
```
SELECT count(*) FROM "authentications" WHERE authentications.source_id = '144179'
1
SELECT * FROM "authentications" WHERE authentications.source_id = '144179' AND tenant_id = 8 LIMIT 100
0
```

So it looks like the count is returning one - but the actual query is returning 0. 