### PR TITLE
[RHCLOUD-19055] fix: typo in application types

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -35,7 +35,7 @@
   - amazon
   - azure
   - google
-  - oracle-cloud-infraestructure
+  - oracle-cloud-infrastructure
   - openshift
   - ibm
   supported_authentication_types:
@@ -47,7 +47,7 @@
     - project_id_service_account_json
     openshift:
     - token
-    oracle-cloud-infraestructure:
+    oracle-cloud-infrastructure:
     - ocid
     ibm:
     - api_token_account_id


### PR DESCRIPTION
The typo was an extra "e" in the word "infrastructure". The typo comes
from the Spanish word "infraestructura": I ended up mixing both words.

## Links

[[RHCLOUD-19055]](https://issues.redhat.com/browse/RHCLOUD-19055)