### PR TITLE
Add ApplicationType to Query Resolver for Ansible Landing Page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/go-gormigrate/gormigrate/v2 v2.0.0
 	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/golang-migrate/migrate/v4 v4.15.1
+	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
-    github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/vault/api v1.1.1
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jackc/pgx/v4 v4.15.0

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -76,3 +76,7 @@ models:
     fields:
       id:
         resolver: true
+  ApplicationType:
+    fields:
+      sources:
+        resolver: true

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -30,7 +30,7 @@ input SortBy{
   direction: Direction
 }
 
-# Base Query Object, which returns the array of sources with metadata
+# Base Query Object, which returns the array of sources (or application types) with metadata
 type Query {
   sources(
     limit: Int,
@@ -38,6 +38,13 @@ type Query {
     sort_by: [SortBy]
     filter: [Filter]
     ): [Source!]!
+
+  application_types(
+    limit: Int,
+    offset: Int,
+    sort_by: [SortBy]
+    filter: [Filter]
+  ): [ApplicationType]
 
   meta: Meta!
 }
@@ -107,4 +114,15 @@ type Authentication {
 
 type Meta {
   count: Int!
+}
+
+type ApplicationType {
+  id: ID!
+  name: String!
+  display_name: String!
+  dependent_applications: Any
+  supported_source_types: Any
+  supported_authentication_types: Any
+
+  sources: [Source]!
 }


### PR DESCRIPTION
As @rvsia [found out](https://github.com/RedHatInsights/ansible-platform-dashboard/blob/88d8edca5d4741d2fb599c9671138d3980aafdfd/src/helpers/catalog/catalog-helper.js#L11) - apparently the Ansible Landing Page is using GraphQL as well so I'm adding the ApplicationType resolver which allows a user to fetch apptypes and their subresources. 

UI PR here: https://github.com/RedHatInsights/ansible-platform-dashboard/pull/76