### PR TITLE
[RHCLOUD-19051] Tests fix

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -93,6 +93,7 @@ func TestAuthenticationList(t *testing.T) {
 
 func TestAuthenticationGet(t *testing.T) {
 	var id string
+	originalSecretStore := conf.SecretStore
 
 	// If we're running integration tests without Vault...
 	if parser.RunningIntegrationTests && !config.IsVaultOn() {
@@ -140,6 +141,7 @@ func TestAuthenticationGet(t *testing.T) {
 			t.Errorf(`wrong authentication fetched. Want "%s", got "%s"`, id, outAuthentication.ID)
 		}
 	}
+	conf.SecretStore = originalSecretStore
 }
 
 func TestAuthenticationGetNotFound(t *testing.T) {

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -219,6 +219,8 @@ func TestAuthFromVaultMarketplaceProviderEmptyPassword(t *testing.T) {
 // TestAuthFromVaultMarketplaceProviderSuccess tests that a proper serialized token is returned when there's a cache
 // miss and the token is successfully requested to the marketplace.
 func TestAuthFromVaultMarketplaceProviderSuccess(t *testing.T) {
+	originalSecretStore := conf.SecretStore
+	conf.SecretStore = "vault"
 	// In this test we need to simulate a cache miss, and then a proper token caching. So the fake TokenCacher should
 	// both miss the cache and be able to cache the provided token.
 	GetMarketplaceTokenCacher = func(tenantId *int64) redis.TokenCacher {
@@ -248,12 +250,16 @@ func TestAuthFromVaultMarketplaceProviderSuccess(t *testing.T) {
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
 	}
+
+	conf.SecretStore = originalSecretStore
 }
 
 // TestAuthFromVaultMarketplaceProviderSuccessCacheFailure tests that even if caching the requested token from the
 // marketplace fails, the process continues and a serialized token is returned. Having an issue when caching the token
 // should not impede to return the requested token from the marketplace.
 func TestAuthFromVaultMarketplaceProviderSuccessCacheFailure(t *testing.T) {
+	originalSecretStore := conf.SecretStore
+	conf.SecretStore = "vault"
 	// In this test case we need a cache miss but an error when caching the token.
 	GetMarketplaceTokenCacher = func(tenantId *int64) redis.TokenCacher {
 		return &marketplaceTokenCacherNotCached{
@@ -282,11 +288,14 @@ func TestAuthFromVaultMarketplaceProviderSuccessCacheFailure(t *testing.T) {
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
 	}
+	conf.SecretStore = originalSecretStore
 }
 
 // TestAuthFromVaultMarketplaceProviderFailure tests that if there is an error when requesting the token to the
 // marketplace, a nil authentication object is returned.
 func TestAuthFromVaultMarketplaceProviderFailure(t *testing.T) {
+	originalSecretStore := conf.SecretStore
+	conf.SecretStore = "vault"
 	// In this test the token cacher should simulate a cache miss and the cache function should return no error.
 	GetMarketplaceTokenCacher = func(tenantId *int64) redis.TokenCacher {
 		return &marketplaceTokenCacherNotCachedButCacheable{
@@ -314,6 +323,7 @@ func TestAuthFromVaultMarketplaceProviderFailure(t *testing.T) {
 	if err == nil {
 		t.Error("want error, got nil")
 	}
+	conf.SecretStore = originalSecretStore
 }
 
 // TestAuthFromVault tests that when Vault returns a properly formatted authentication, the authFromvault function is

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -132,6 +132,7 @@ func TestNotMarketplaceAuthNotProcessed(t *testing.T) {
 // TestAuthFromVaultMarketplaceCacheHit tests that when there's a cache hit with the marketplace token, it simply
 // returns the token on the "extra" field.
 func TestAuthFromVaultMarketplaceCacheHit(t *testing.T) {
+	originalSecretStore := conf.SecretStore
 	// We need to simulate that the Vault is online.
 	conf.SecretStore = "vault"
 
@@ -180,6 +181,7 @@ func TestAuthFromVaultMarketplaceCacheHit(t *testing.T) {
 			t.Errorf(`invalid token expiration. Want "%d", got "%d"`, want, got)
 		}
 	}
+	conf.SecretStore = originalSecretStore
 }
 
 // TestAuthFromVaultMarketplaceProviderEmptyPassword tests that if no API key is stored on Vault, and if there's a
@@ -463,6 +465,7 @@ func TestAuthFromVault(t *testing.T) {
 // miss and the token is successfully requested to the marketplace. It simulates the extra field not having any
 // previous content.
 func TestAuthFromDbExtraNoContent(t *testing.T) {
+	originalSecretStore := conf.SecretStore
 	// Simulate that the Vault instance is off, and that we're pulling authentications from the database.
 	conf.SecretStore = "database"
 	// Initialize the encryption key to the following: aaaaaaaaaaaaaaaa
@@ -516,6 +519,7 @@ func TestAuthFromDbExtraNoContent(t *testing.T) {
 	if !bytes.Equal(want, auth.ExtraDb) {
 		t.Errorf(`want "%s", got "%s"`, want, auth.ExtraDb)
 	}
+	conf.SecretStore = originalSecretStore
 }
 
 // TestAuthFromDbExtraNullContent is a regression test. It simulates the extra field coming with a valid JSON "null"
@@ -586,6 +590,7 @@ func TestAuthFromDbExtraNullContent(t *testing.T) {
 // miss and the token is successfully requested to the marketplace. It simulates the extra field having previous
 // content.
 func TestAuthFromDbExtraPreviousContent(t *testing.T) {
+	originalSecretStore := conf.SecretStore
 	// Simulate that the Vault instance is off, and that we're pulling authentications from the database.
 	conf.SecretStore = "database"
 	// Initialize the encryption key to the following: aaaaaaaaaaaaaaaa
@@ -645,6 +650,7 @@ func TestAuthFromDbExtraPreviousContent(t *testing.T) {
 	if !bytes.Equal(want, auth.ExtraDb) {
 		t.Errorf(`want "%s", got "%s"`, want, auth.ExtraDb)
 	}
+	conf.SecretStore = originalSecretStore
 }
 
 // TestSecretPathDidntChange is a flag test which tells us when the path of the Vault secrets changed. This potentially
@@ -743,6 +749,7 @@ func TestFindKeysByResourceTypeAndId(t *testing.T) {
 func TestAuthenticationListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")
+	originalSecretStore := conf.SecretStore
 
 	wantCount := int64(len(fixtures.TestAuthenticationData))
 	Vault = &mocks.MockVault{}
@@ -779,4 +786,5 @@ func TestAuthenticationListOffsetAndLimit(t *testing.T) {
 		}
 	}
 	DropSchema("offset_limit")
+	conf.SecretStore = originalSecretStore
 }

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -44,6 +44,7 @@ func createAuthenticationFixture(t *testing.T) {
 // if the minimum data is provided for an authentication.
 func TestAuthenticationDbCreate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
@@ -63,6 +64,7 @@ func TestAuthenticationDbCreate(t *testing.T) {
 // entities if the minimum data is provided for an authentication.
 func TestAuthenticationDbBulkCreate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
@@ -80,6 +82,7 @@ func TestAuthenticationDbBulkCreate(t *testing.T) {
 // TestAuthenticationDbList tests that the "list" operation returns the expected number of authentications.
 func TestAuthenticationDbList(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
@@ -117,6 +120,7 @@ func TestAuthenticationDbList(t *testing.T) {
 // TestAuthenticationDbGet tests that the "get" operation is able to fetch the expected authentication.
 func TestAuthenticationDbGetById(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
@@ -148,6 +152,7 @@ func TestAuthenticationDbGetById(t *testing.T) {
 // TestAuthenticationDbUpdate tests that the "update" operation is able to properly update the authentication.
 func TestAuthenticationDbUpdate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
@@ -189,6 +194,7 @@ func TestAuthenticationDbUpdate(t *testing.T) {
 // TestAuthenticationDbGet tests that the "delete" operation is able to delete the expected authentication.
 func TestAuthenticationDbDelete(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
@@ -228,6 +234,7 @@ func TestAuthenticationDbDelete(t *testing.T) {
 // non-existing authentication.
 func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
@@ -255,6 +262,7 @@ func TestTenantId(t *testing.T) {
 // TestListForSource tests if "list for source" only lists the authentications of the related source, and no more.
 func TestListForSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
@@ -315,6 +323,7 @@ func TestListForSource(t *testing.T) {
 // under test.
 func TestListForSourceNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
@@ -337,6 +346,7 @@ func TestListForSourceNotFound(t *testing.T) {
 // more.
 func TestListForApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
@@ -409,6 +419,7 @@ func TestListForApplication(t *testing.T) {
 // function under test.
 func TestListForApplicationNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
@@ -431,6 +442,7 @@ func TestListForApplicationNotFound(t *testing.T) {
 // the related ApplicationAuthentication, and no more.
 func TestListForApplicationAuthentication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
@@ -518,6 +530,7 @@ func TestListForApplicationAuthentication(t *testing.T) {
 // authentication is given to the function under test.
 func TestListForApplicationAuthenticationNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
@@ -539,6 +552,7 @@ func TestListForApplicationAuthenticationNotFound(t *testing.T) {
 // TestListForEndpoint tests if "list for Endpoint" only lists the authentications of the related endpoint, and no more.
 func TestListForEndpoint(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
@@ -610,6 +624,7 @@ func TestListForEndpoint(t *testing.T) {
 // function under test.
 func TestListForEndpointNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
@@ -631,6 +646,7 @@ func TestListForEndpointNotFound(t *testing.T) {
 // TestFetchAndUpdateBy tests if "FetchAndUpdateBy" updates the timestamps as expected.
 func TestFetchAndUpdateBy(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
@@ -717,6 +733,7 @@ func TestFetchAndUpdateBy(t *testing.T) {
 // TestToEventJSON tests if "FetchAndUpdateBy" returns the expected output for the given resource.
 func TestToEventJSON(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
@@ -764,6 +781,7 @@ func TestToEventJSON(t *testing.T) {
 // test also "BulkMessageFromSource".
 func TestBulkMessage(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Create the authentication fixture that we will be fetching.
@@ -828,6 +846,7 @@ func TestBulkMessage(t *testing.T) {
 // resource type and a resource id.
 func TestListIdsForResource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// In this test we want a clean "authentications" table.
@@ -946,6 +965,7 @@ func TestListIdsForResource(t *testing.T) {
 // authentications are created for multiple resource types and the function tries to bulk delete them all.
 func TestBulkDelete(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// Specify the resources we will be creating the authentications for.
@@ -1063,6 +1083,7 @@ func TestBulkDelete(t *testing.T) {
 // The test checks that in the case of receiving an empty slice, no authentications are deleted.
 func TestBulkDeleteRegression(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
 	// How many authentications will we be creating per resource?

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -727,8 +727,16 @@ func (m MockAuthenticationDao) List(limit, offset int, filters []util.Filter) ([
 
 func (m MockAuthenticationDao) GetById(id string) (*m.Authentication, error) {
 	for _, auth := range m.Authentications {
-		if auth.ID == id {
-			return &auth, nil
+		// If secret store is database, we compare given ID with different field
+		// than if secret store is vault
+		if conf.SecretStore == "database" {
+			if fmt.Sprintf("%d", auth.DbID) == id {
+				return &auth, nil
+			}
+		} else {
+			if auth.ID == id {
+				return &auth, nil
+			}
 		}
 	}
 
@@ -791,8 +799,16 @@ func (m MockAuthenticationDao) Update(auth *m.Authentication) error {
 
 func (m MockAuthenticationDao) Delete(id string) (*m.Authentication, error) {
 	for _, auth := range m.Authentications {
-		if auth.ID == id {
-			return &auth, nil
+		// If secret store is database, we compare given ID with different field
+		// than if secret store is vault
+		if conf.SecretStore == "database" {
+			if fmt.Sprintf("%d", auth.DbID) == id {
+				return &auth, nil
+			}
+		} else {
+			if auth.ID == id {
+				return &auth, nil
+			}
 		}
 	}
 	return nil, util.NewErrNotFound("authentication")

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestSourceListAuthentications(t *testing.T) {
+	originalSecretStore := conf.SecretStore
 	tenantId := fixtures.TestTenantData[0].Id
 
 	// If we're running integration tests without Vault...
@@ -115,6 +116,7 @@ func TestSourceListAuthentications(t *testing.T) {
 	}
 
 	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
+	conf.SecretStore = originalSecretStore
 }
 
 func TestSourceListAuthenticationsNotFound(t *testing.T) {

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -400,6 +400,7 @@ type TestData struct {
 
 func TestConsumeStatusMessage(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	originalSecretStore := config.SecretStore
 	config.SecretStore = "vault"
 
 	dao.Vault = &mocks.MockVault{}
@@ -479,4 +480,5 @@ func TestConsumeStatusMessage(t *testing.T) {
 			}
 		}
 	}
+	config.SecretStore = originalSecretStore
 }


### PR DESCRIPTION
In some tests we are changing secret store (database, vault) = we change original value from environment variables and we dont change it back (in the end of test)

in this PR:
- the original value of secret store is saved in affected tests and changed back as last step in the test
- mock daos updated for `GetById()` and `Delete()` authentication methods because for database we need to compare given ID with `auth.DbID` and for vault with `auth.iD`
- some tests written for database are now skipped when secret store is vault

### Links:

- [RHCLOUD-19051](https://issues.redhat.com/browse/RHCLOUD-19051)
