### PR TITLE
add middleware to strip trailing slashes

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ func runServer() {
 	// set the binder to the one that does not allow extra parameters in payload
 	e.Binder = &NoUnknownFieldsBinder{}
 
+	// strip trailing slashes
+	e.Pre(middleware.RemoveTrailingSlash())
 	// recover from any `panic()`'s that happen in the handler, so the server doesn't crash.
 	e.Use(middleware.Recover())
 	// set up logging with our custom logger


### PR DESCRIPTION
Turns out we're getting requests with a trailing slash - which causes a 500 since the routes don't match it.

We'll just strip the slash while we process it - should fix the issue. 