### PR TITLE
delete unused function CloseTestDbConnection() from dao/main_test.go

### DIFF
--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -144,17 +144,6 @@ func DropSchema(dbSchema string) {
 	}
 }
 
-func CloseTestDbConnection() {
-	rawDB, err := DB.DB()
-	if err != nil {
-		log.Fatal(err)
-	}
-	rawDB.Close()
-
-	CloseConnection()
-	ConnectToTestDB(defaultSchema)
-}
-
 // MigrateSchema migrates all the models for the current schema.
 func MigrateSchema() {
 	// Use a custom "authentication" table to avoid Gorm creating FKs when the real databases don't have them.


### PR DESCRIPTION
without JIRA ticket

after merging https://github.com/RedHatInsights/sources-api-go/pull/208 we forgot to delete unused function `CloseTestDbConnection()` ... we are now using `CloseConnection()` instead