### PR TITLE
don't marshal metadata in Kafka message for notifications service

### DIFF
--- a/service/notifications.go
+++ b/service/notifications.go
@@ -44,8 +44,8 @@ type notificationMetadata struct {
 }
 
 type notificationEvent struct {
-	Metadata string `json:"metadata"`
-	Payload  string `json:"payload"`
+	Metadata notificationMetadata `json:"metadata"`
+	Payload  string               `json:"payload"`
 }
 
 type notificationRecipients struct {
@@ -84,13 +84,7 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(a
 		return err
 	}
 
-	metadata, err := json.Marshal(&notificationMetadata{})
-	if err != nil {
-		l.Log.Warnf(`error when marshalling the email notification metadata: %s`, err)
-		return err
-	}
-
-	event := notificationEvent{Metadata: string(metadata), Payload: string(payload)}
+	event := notificationEvent{Metadata: notificationMetadata{}, Payload: string(payload)}
 
 	msg := &kafka.Message{}
 	err = msg.AddValueAsJSON(&notificationMessage{


### PR DESCRIPTION
there is `metadata` field point 8: https://core-platform-apps.pages.redhat.com/notifications-docs/dev/user-guide/send-notification.html

We marshalled this field redundantly like field 9 but it is not allowed. We need just have `{}` in Kafka message:

before:
```json
{"version":"v1.1.0","bundle":"console","application":"sources","event_type":"availability-status","timestamp":"2022-04-21T20:58:32+02:00","account_id":"123456","context":"{\"resource_display_name\":\"Source\",\"current_availability_status\":\"available\",\"previous_availability_status\":\"unavailable\",\"source_id\":\"7\",\"source_name\":\"asadasda\"}","events":[{"metadata":"{}","payload":"{}"}],"recipients":[]}
```


after:

```json
{"version":"v1.1.0","bundle":"console","application":"sources","event_type":"availability-status","timestamp":"2022-04-21T21:00:13+02:00","account_id":"123456","context":"{\"resource_display_name\":\"Source\",\"current_availability_status\":\"unavailable\",\"previous_availability_status\":\"available\",\"source_id\":\"7\",\"source_name\":\"asadasda\"}","events":[{"metadata":{},"payload":"{}"}],"recipients":[]}
```


cc @lindgrenj6 @MikelAlejoBR 



