### PR TITLE
Set unknown status for empty status in ToEmail() functions

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -554,7 +554,7 @@ func TestApplicationEdit(t *testing.T) {
 
 	emailNotificationInfo := &m.EmailNotificationInfo{ResourceDisplayName: "Application",
 		CurrentAvailabilityStatus:  "available",
-		PreviousAvailabilityStatus: "",
+		PreviousAvailabilityStatus: "unknown",
 		SourceName:                 fixtures.TestSourceData[0].Name,
 		SourceID:                   strconv.FormatInt(fixtures.TestSourceData[0].ID, 10),
 	}

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -319,7 +319,7 @@ func TestAuthenticationEdit(t *testing.T) {
 
 	emailNotificationInfo := &m.EmailNotificationInfo{ResourceDisplayName: "Authentication",
 		CurrentAvailabilityStatus:  newAvailabilityStatus,
-		PreviousAvailabilityStatus: "",
+		PreviousAvailabilityStatus: "unknown",
 		SourceName:                 fixtures.TestSourceData[0].Name,
 		SourceID:                   strconv.FormatInt(fixtures.TestSourceData[0].ID, 10),
 	}

--- a/model/application.go
+++ b/model/application.go
@@ -117,7 +117,7 @@ func (app *Application) ToEmail(previousStatus string) *EmailNotificationInfo {
 		SourceID:                   strconv.FormatInt(app.SourceID, 10),
 		SourceName:                 app.Source.Name,
 		ResourceDisplayName:        "Application",
-		CurrentAvailabilityStatus:  app.AvailabilityStatus,
-		PreviousAvailabilityStatus: previousStatus,
+		CurrentAvailabilityStatus:  util.FormatAvailabilityStatus(app.AvailabilityStatus),
+		PreviousAvailabilityStatus: util.FormatAvailabilityStatus(previousStatus),
 	}
 }

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -186,8 +186,8 @@ func (auth *Authentication) ToEmail(previousStatus string) *EmailNotificationInf
 
 	return &EmailNotificationInfo{
 		ResourceDisplayName:        "Authentication",
-		CurrentAvailabilityStatus:  availabilityStatus,
-		PreviousAvailabilityStatus: previousStatus,
+		CurrentAvailabilityStatus:  util.FormatAvailabilityStatus(availabilityStatus),
+		PreviousAvailabilityStatus: util.FormatAvailabilityStatus(previousStatus),
 		SourceName:                 auth.Source.Name,
 		SourceID:                   strconv.FormatInt(auth.SourceID, 10),
 	}

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -148,7 +148,7 @@ func (endpoint *Endpoint) ToEmail(previousStatus string) *EmailNotificationInfo 
 		SourceID:                   strconv.FormatInt(endpoint.SourceID, 10),
 		SourceName:                 endpoint.Source.Name,
 		ResourceDisplayName:        "Endpoint",
-		CurrentAvailabilityStatus:  endpoint.AvailabilityStatus,
-		PreviousAvailabilityStatus: previousStatus,
+		CurrentAvailabilityStatus:  util.FormatAvailabilityStatus(endpoint.AvailabilityStatus),
+		PreviousAvailabilityStatus: util.FormatAvailabilityStatus(previousStatus),
 	}
 }

--- a/model/rhc_connection.go
+++ b/model/rhc_connection.go
@@ -72,7 +72,7 @@ func (r *RhcConnection) SourceIDs() []string {
 func (r *RhcConnection) ToEmail(previousStatus string) *EmailNotificationInfo {
 	return &EmailNotificationInfo{
 		ResourceDisplayName:        "RHC Connection",
-		CurrentAvailabilityStatus:  r.AvailabilityStatus,
-		PreviousAvailabilityStatus: previousStatus,
+		CurrentAvailabilityStatus:  util.FormatAvailabilityStatus(r.AvailabilityStatus),
+		PreviousAvailabilityStatus: util.FormatAvailabilityStatus(previousStatus),
 	}
 }

--- a/model/source.go
+++ b/model/source.go
@@ -112,7 +112,7 @@ func (src *Source) ToEmail(previousStatus string) *EmailNotificationInfo {
 		SourceName:                 src.Name,
 		SourceID:                   strconv.FormatInt(src.ID, 10),
 		ResourceDisplayName:        "Source",
-		CurrentAvailabilityStatus:  src.AvailabilityStatus,
-		PreviousAvailabilityStatus: previousStatus,
+		CurrentAvailabilityStatus:  util.FormatAvailabilityStatus(src.AvailabilityStatus),
+		PreviousAvailabilityStatus: util.FormatAvailabilityStatus(previousStatus),
 	}
 }

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -422,7 +422,7 @@ func TestConsumeStatusMessage(t *testing.T) {
 	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	sourceTestData := TestData{StatusMessage: statusMessage, MessageHeaders: headers, RaiseEventCalled: true}
 
-	emailNotificationInfo := &m.EmailNotificationInfo{SourceID: "1", SourceName: "Source1", CurrentAvailabilityStatus: "available", ResourceDisplayName: "Application"}
+	emailNotificationInfo := &m.EmailNotificationInfo{SourceID: "1", SourceName: "Source1", PreviousAvailabilityStatus: "unknown", CurrentAvailabilityStatus: "available", ResourceDisplayName: "Application"}
 	statusMessageApplication := types.StatusMessage{ResourceType: "Application", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	applicationTestData := TestData{StatusMessage: statusMessageApplication, MessageHeaders: headers, RaiseEventCalled: true, ExpectedEmitAvailabilityStatusCallCounter: 1, EmailNotificationInfo: emailNotificationInfo}
 

--- a/util/resource.go
+++ b/util/resource.go
@@ -34,3 +34,11 @@ func ParseStatusMessageToResource(resource *Resource, statusMessage types.Status
 	resource.ResourceID = resourceID
 	return resource, nil
 }
+
+func FormatAvailabilityStatus(status string) string {
+	if status == "" {
+		return "unknown"
+	}
+
+	return status
+}


### PR DESCRIPTION
Function `ToEmail()` on models return data for email template but when resource (Source, ...) is created it has empty availability status field which set in `EmailNotificationInfo#CurrentAvailabilityStatus` - this change formats empty av. status to "unknown" and it is visible in notification emails/payload.


