### PR TITLE
[RHCLOUD-17795] fix: change the marketplace authentication type to "marketplace-token"

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -385,7 +385,7 @@ rh-marketplace:
   vendor: Red Hat
   schema:
     authentication:
-    - type: token
+    - type: marketplace-token
       name: API Token
       fields:
       - component: text-field


### PR DESCRIPTION
Instead of having a generic "token" authentication type name which could clash with some other authentication type, by giving a unique name to these authentications processing them will be straightforward.

This was already fixed in https://github.com/RedHatInsights/sources-api/pull/475, but I forgot to bring it over to the rewrite.

## Links

[[RHCLOUD-17795]](https://issues.redhat.com/browse/RHCLOUD-17795)