### PR TITLE
[RHCLOUD-19078] fix: marketplace token doesn't get serialized to "extra.marketplace"

### DIFF
--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -508,7 +508,11 @@ func TestAuthFromDbExtraNoContent(t *testing.T) {
 		t.Errorf("want no error, got %s", err)
 	}
 
-	want, err := json.Marshal(setUpBearerToken())
+	// tmpWant will hold the structure to what we are expecting to get in return when calling the function under test.
+	tmpWant := make(map[string]interface{})
+	tmpWant["marketplace"] = setUpBearerToken()
+
+	want, err := json.Marshal(tmpWant)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}


### PR DESCRIPTION
Apparently I forgot to include the token in the "extra.marketplace" key
in one case, and the test I wrote for it didn't catch that because it
was expecting the token in the "extra" key.

I've changed the implementation so that the token always gets serialized
to the "extra.marketplace" key, and so that the test looks at having the
token in the "extra.marketplace" key.

## Links

[[RHCLOUD-19078]](https://issues.redhat.com/browse/RHCLOUD-19078)