### PR TITLE
Change GraphQL Resolvers to only load subresources related to base-source objects returned by query

### DIFF
--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -134,10 +134,18 @@ func (r *queryResolver) Sources(ctx context.Context, limit *int, offset *int, so
 	srces, count, err := dao.GetSourceDao(tenantIdFromCtx(ctx)).List(*limit, *offset, f)
 	sendCount(ctx, count)
 
+	// storing the IDs of relevant sources on the request context for later subresources
+	sourceIDs := make([]string, len(srces))
+
+	// output data needs to be pointers for some reason.
 	out := make([]*model.Source, len(srces))
 	for i := range srces {
 		out[i] = &srces[i]
+		sourceIDs[i] = strconv.FormatInt(srces[i].ID, 10)
 	}
+
+	// this will unlock the source mutex and let the subresources go
+	getRequestDataFromCtx(ctx).SetSourceIDs(sourceIDs)
 	return out, err
 }
 

--- a/graph/types.go
+++ b/graph/types.go
@@ -32,6 +32,10 @@ type RequestData struct {
 // wrapper around a mutex that only loads applications up one time and makes any
 // other routines wait until the map is ready
 func (rd *RequestData) EnsureApplicationsAreLoaded() error {
+	if rd.applicationMap != nil {
+		return nil
+	}
+
 	rd.ApplicationMutex.Lock()
 	defer rd.ApplicationMutex.Unlock()
 
@@ -40,7 +44,9 @@ func (rd *RequestData) EnsureApplicationsAreLoaded() error {
 	defer rd.SourceMutex.Unlock()
 
 	// load up the application map if it isn't present - this will only happen
-	// once and any other threads will wait for it to complete
+	// once and any other threads will wait for it to complete. We have to check
+	// again due to the fact that multiple threads might have locked this the
+	// first time
 	if rd.applicationMap == nil {
 		apps, _, err := dao.GetApplicationDao(&rd.TenantID).List(defaultLimit, 0, []util.Filter{{Name: "source_id", Value: *rd.sourceIdList}})
 		if err != nil {
@@ -61,6 +67,10 @@ func (rd *RequestData) EnsureApplicationsAreLoaded() error {
 
 // largely a copy/paste of above - so I won't duplicate the comments
 func (rd *RequestData) EnsureEndpointsAreLoaded() error {
+	if rd.endpointMap != nil {
+		return nil
+	}
+
 	rd.EndpointMutex.Lock()
 	defer rd.EndpointMutex.Unlock()
 
@@ -85,7 +95,12 @@ func (rd *RequestData) EnsureEndpointsAreLoaded() error {
 	return nil
 }
 
+// largely a copy/paste of above - so I won't duplicate the comments
 func (rd *RequestData) EnsureAuthenticationsAreLoaded() error {
+	if rd.authenticationMap != nil {
+		return nil
+	}
+
 	rd.AuthenticationMutex.Lock()
 	defer rd.AuthenticationMutex.Unlock()
 


### PR DESCRIPTION
During my initial GraphQL implementation I did remove the N+1 problem for subresources (we'd only ever query the database one time), but only half way. We were still yoinking _all_ of the applications/endpoints/authentications, but only once. Today that `// TODO` goes away!

This PR adds a bit more state to the GraphQL request struct to store the relevant source IDs. It works like this:
- Initializing the `SourceMutex` in the Lock'd state, that way we block everything _until the relevant source IDs are loaded_
- The Application/Endpoint/Authentication resolvers wait until the mutex is unlocked (and thus when the source IDs are available
- The ^^^^^^ resolvers pass along a `Filter{Name: "source_id", Value: []string{all of the source ids!}` Thus only loading the relevant resources

This speeds up the graphQL endpoint on my local from ~5ms to ~3-4ms so ~20%, but it'll probably be more significant on the RDS side of things where the DB isn't sub-millisecond latency away. This also could have resulted in a bug if a user ended up with more than 500 subresources eventually (not likely, but still possible).

Here is the output of the database queries before and after, I used `jq` to spit out the message (the sql query) and the following line is the rows returned.

Before this change:
```
[ ~m~ ] /ramdisk 
$> jq <before.txt .message,.rows -r
Looking up Tenant ID for account number 6089719
null
SELECT * FROM "tenants" WHERE external_tenant = '6089719' ORDER BY "tenants"."id" LIMIT 1
1
SELECT count(*) FROM "sources" WHERE sources.tenant_id = 2 AND sources.name LIKE '165038%' AND sources.name LIKE '%6'
1
SELECT * FROM "sources" WHERE sources.tenant_id = 2 AND sources.name LIKE '165038%' AND sources.name LIKE '%6' LIMIT 20
6
SELECT count(*) FROM "applications" WHERE applications.tenant_id = 2
1
SELECT * FROM "applications" WHERE applications.tenant_id = 2 LIMIT 500
103
SELECT count(*) FROM "authentications" WHERE authentications.tenant_id = 2
1
SELECT * FROM "authentications" WHERE authentications.tenant_id = 2 LIMIT 500
152

null
```

After this change:
```
[ ~m~ ] /ramdisk 
$> jq <after.txt .message,.rows -r
Looking up Tenant ID for account number 6089719
null
SELECT * FROM "tenants" WHERE external_tenant = '6089719' ORDER BY "tenants"."id" LIMIT 1
1
SELECT count(*) FROM "sources" WHERE sources.tenant_id = 2 AND sources.name LIKE '165038%' AND sources.name LIKE '%6'
1
SELECT * FROM "sources" WHERE sources.tenant_id = 2 AND sources.name LIKE '165038%' AND sources.name LIKE '%6' LIMIT 20
6
SELECT count(*) FROM "applications" WHERE applications.tenant_id = 2 AND applications.source_id IN ('90','96','106','115','125','134')
1
SELECT * FROM "applications" WHERE applications.tenant_id = 2 AND applications.source_id IN ('90','96','106','115','125','134') LIMIT 500
12
SELECT count(*) FROM "authentications" WHERE authentications.tenant_id = 2 AND authentications.source_id IN ('90','96','106','115','125','134')
1
SELECT * FROM "authentications" WHERE authentications.tenant_id = 2 AND authentications.source_id IN ('90','96','106','115','125','134') LIMIT 500
18

null
```