### PR TITLE
Remove created_at from authentication responses

### DIFF
--- a/model/authentication.go
+++ b/model/authentication.go
@@ -60,7 +60,6 @@ func (auth *Authentication) ToResponse() *AuthenticationResponse {
 	id, extra := mapIdExtraFields(auth)
 	return &AuthenticationResponse{
 		ID:                      id,
-		CreatedAt:               util.DateTimeToRFC3339(auth.CreatedAt),
 		Name:                    util.ValueOrBlank(auth.Name),
 		Version:                 auth.Version,
 		AuthType:                auth.AuthType,

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -9,8 +9,7 @@ import (
 )
 
 type AuthenticationResponse struct {
-	ID        string `json:"id"`
-	CreatedAt string `json:"created_at"`
+	ID string `json:"id"`
 
 	Name                    string                 `json:"name,omitempty"`
 	AuthType                string                 `json:"authtype"`


### PR DESCRIPTION
Also this fixes bug in UI,

when user is trying to submit for with editing authentication:
![L44Uqx0VEk](https://user-images.githubusercontent.com/14937244/165092999-510e452d-5eec-4220-8a88-3a0dd407dc96.gif)

(please ignore part with developer console)


it is because (apparently) UI takes attributes from GET authentication endpoint to define attributes of body for PATCH request and one such attribute is `created_at` which we don't support anymore and thanks to that we refuse it as _unknown_ attribute during update.