### PR TITLE
Remove version from authentication_response struct

### DIFF
--- a/model/authentication.go
+++ b/model/authentication.go
@@ -61,7 +61,6 @@ func (auth *Authentication) ToResponse() *AuthenticationResponse {
 	return &AuthenticationResponse{
 		ID:                      id,
 		Name:                    util.ValueOrBlank(auth.Name),
-		Version:                 auth.Version,
 		AuthType:                auth.AuthType,
 		Username:                util.ValueOrBlank(auth.Username),
 		Extra:                   extra,

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -15,7 +15,6 @@ type AuthenticationResponse struct {
 	AuthType                string                 `json:"authtype"`
 	Username                string                 `json:"username"`
 	Extra                   map[string]interface{} `json:"extra,omitempty"`
-	Version                 string                 `json:"version"`
 	AvailabilityStatus      string                 `json:"availability_status,omitempty"`
 	AvailabilityStatusError string                 `json:"availability_status_error,omitempty"`
 


### PR DESCRIPTION
There is similar [PR](https://github.com/RedHatInsights/sources-api-go/pull/274) as version doesn't exist in DB and as it looks it was intended for vault. 
 