### PR TITLE
Add log type to logs

### DIFF
--- a/logger/gorm_logger.go
+++ b/logger/gorm_logger.go
@@ -45,6 +45,7 @@ func (l *CustomGORMLogger) Trace(_ context.Context, begin time.Time, fc func() (
 		"rows":     rows,
 		"duration": duration,
 		"filename": fileWithLineNum,
+		"log_type": SQLType,
 	})
 
 	switch {


### PR DESCRIPTION
Currently we have let's say 4 types of log messages:

**default**:
`logging.Log.Warnf("Received %v, exiting", s)`

**echo**:
`c.Logger().Infof("tenant: %v", *sourcesDB.Tenant())`
Typical usage in echo handlers method, `c` is `echo.Context`.

**sql**:
this type is used sql query is being logged.

**request**:
this is also related to echo but it is for logging api requests.

it helps for filtering in kibana.
