### PR TITLE
Remove pointers from EventModelDao interface usages

### DIFF
--- a/dao/common.go
+++ b/dao/common.go
@@ -13,7 +13,7 @@ const (
 	DEFAULT_OFFSET = 0
 )
 
-func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
+func GetFromResourceType(resourceType string) (m.EventModelDao, error) {
 	var resource m.EventModelDao
 	switch strings.ToLower(resourceType) {
 	case "source":
@@ -28,7 +28,7 @@ func GetFromResourceType(resourceType string) (*m.EventModelDao, error) {
 		return nil, fmt.Errorf("invalid resource_type (%s) to get DAO instance", resourceType)
 	}
 
-	return &resource, nil
+	return resource, nil
 }
 
 func GetAvailabilityStatusFromStatusMessage(tenantID int64, resourceID string, resourceType string) (string, error) {

--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -69,7 +69,7 @@ func (esp *EventStreamProducer) RaiseEventForUpdate(resource util.Resource, upda
 		return err
 	}
 
-	resourceJSON, err := (*eventModelDao).ToEventJSON(resource)
+	resourceJSON, err := eventModelDao.ToEventJSON(resource)
 	if err != nil {
 		return err
 	}

--- a/model/events.go
+++ b/model/events.go
@@ -18,7 +18,7 @@ type EventModelDao interface {
 	ToEventJSON(resource util.Resource) ([]byte, error)
 }
 
-func UpdateMessage(eventObject *EventModelDao, resource util.Resource, attributes []string) ([]byte, error) {
+func UpdateMessage(eventObject EventModelDao, resource util.Resource, attributes []string) ([]byte, error) {
 	updatedAttributes := map[string]interface{}{}
 
 	resourceID := ""
@@ -30,7 +30,7 @@ func UpdateMessage(eventObject *EventModelDao, resource util.Resource, attribute
 
 	updatedAttributes["updated"] = map[string]interface{}{resource.ResourceType: map[string]interface{}{resourceID: attributes}}
 
-	bulkMessage, err := (*eventObject).BulkMessage(resource)
+	bulkMessage, err := eventObject.BulkMessage(resource)
 	if err != nil {
 		return nil, fmt.Errorf("error in BulkMessage: %v", err.Error())
 	}

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -125,7 +125,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 
 	resource.TenantID = tenant.Id
 	resource.AccountNumber = tenant.ExternalTenant
-	resultRecord, err := (*modelEventDao).FetchAndUpdateBy(*resource, updateAttributes)
+	resultRecord, err := modelEventDao.FetchAndUpdateBy(*resource, updateAttributes)
 	if err != nil {
 		l.Log.Errorf("unable to update availability status: %s", err)
 		return


### PR DESCRIPTION
it is not needed because `EventModelDao` interface (without pointer) also satisfies structs with functions on pointer receivers.