### PR TITLE
fix: XRHID cannot be correctly cast

### DIFF
--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -26,7 +26,7 @@ func BulkCreate(c echo.Context) error {
 	if !ok {
 		c.Logger().Warnf("bad xrhid %v", c.Get("x-rh-identity"))
 	}
-	id, ok := c.Get("identity").(identity.XRHID)
+	id, ok := c.Get("identity").(*identity.XRHID)
 	if !ok {
 		c.Logger().Warnf("failed to pull identity from request")
 		return fmt.Errorf("failed to pull identity from request")

--- a/helpers.go
+++ b/helpers.go
@@ -102,7 +102,7 @@ func getTenantFromEchoContext(c echo.Context) (int64, error) {
 }
 
 func getAccountNumberFromEchoContext(c echo.Context) (string, error) {
-	id, ok := c.Get("identity").(identity.XRHID)
+	id, ok := c.Get("identity").(*identity.XRHID)
 	if !ok {
 		return "", fmt.Errorf("failed to pull identity from context")
 	}

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -49,7 +49,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			// first check the identity (already parsed) to see if it contains
 			// the system key and if it does do some extra checks to authorize
 			// based on some internal rules (operator + satellite)
-			identity, ok := c.Get("identity").(identity.XRHID)
+			identity, ok := c.Get("identity").(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("error casting identity to struct: %+v", c.Get("identity"))
 			}

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -111,7 +111,7 @@ func TestSystemClusterID(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			"x-rh-identity": "dummy",
-			"identity": identity.XRHID{
+			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: map[string]interface{}{"cluster_id": "test_cluster"},
 				},
@@ -136,7 +136,7 @@ func TestSystemCN(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			"x-rh-identity": "dummy",
-			"identity": identity.XRHID{
+			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: map[string]interface{}{"cn": "test_cert"},
 				},
@@ -161,7 +161,7 @@ func TestSystemPatch(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			"x-rh-identity": "dummy",
-			"identity": identity.XRHID{
+			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: map[string]interface{}{"cn": "test_cert"},
 				},
@@ -186,7 +186,7 @@ func TestSystemDelete(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			"x-rh-identity": "dummy",
-			"identity": identity.XRHID{
+			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: map[string]interface{}{"cn": "test_cert"},
 				},
@@ -227,7 +227,7 @@ func TestRbacWithAccess(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			"x-rh-identity": "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":      identity.XRHID{Identity: identity.Identity{}},
+			"identity":      &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -250,7 +250,7 @@ func TestRbacWithoutAccess(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			"x-rh-identity": "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":      identity.XRHID{Identity: identity.Identity{}},
+			"identity":      &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -273,7 +273,7 @@ func TestRbacNoConnection(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			"x-rh-identity": "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":      identity.XRHID{Identity: identity.Identity{}},
+			"identity":      &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -67,7 +67,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			if err != nil {
 				return err
 			}
-			c.Set("identity", *id)
+			c.Set("identity", id)
 		}
 
 		return next(c)

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -63,7 +63,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set("tenantID", tenantId)
 
 		case c.Get("identity") != nil:
-			identity, ok := c.Get("identity").(identity.XRHID)
+			identity, ok := c.Get("identity").(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("invalid identity structure received")
 			}


### PR DESCRIPTION
There were places were we had stored the XRHID struct by value, and some
others by reference. We are turning all of them to pointers for
consistency.