### PR TITLE
[RHCLOUD-17973] Add re-queuing job engine for scheduled jobs

### DIFF
--- a/jobs/scheduled_jobs.go
+++ b/jobs/scheduled_jobs.go
@@ -1,0 +1,47 @@
+package jobs
+
+import (
+	"time"
+
+	l "github.com/RedHatInsights/sources-api-go/logger"
+)
+
+// ScheduledJob is a struct which stores any jobs we want ran on a consistent
+// schedule.
+//
+// it has 2 fields:
+// 		Interval: how often to run the job
+// 		Job: self-explanatory.
+type ScheduledJob struct {
+	Interval time.Duration
+	Job      Job
+}
+
+// runForever is a method on the scheduled job that basically runs a sleep + run
+// loop forever. This way one can just call `runForever()` on a job and it will
+// do as the name implies
+func (sj *ScheduledJob) runForever() {
+	go func() {
+		for {
+			time.Sleep(sj.Interval)
+
+			RunJobNow(sj.Job)
+		}
+	}()
+}
+
+// schedule is a slice of scheduled jobs that will then get ran forever, if we
+// are adding a new job that we want run on a schedule, add it here.
+//
+// example: var schedule = []ScheduledJob{{Interval: 5 * time.Second, Job: &AsyncDestroyJob{}}}
+var schedule = []ScheduledJob{}
+
+// runScheduledJobs runs all of the jobs on a schedule forever.
+func runScheduledJobs() {
+	l.Log.Infof("Running [%v] Background Job goroutines", len(schedule))
+
+	for _, sj := range schedule {
+		l.Log.Infof("Running Job [%v] on Interval [%v]", sj.Job.Name(), sj.Interval)
+		sj.runForever()
+	}
+}

--- a/jobs/worker.go
+++ b/jobs/worker.go
@@ -14,7 +14,9 @@ const workQueue = "sources_api_jobs"
 
 // Runs the worker just consuming off of a redis list
 func Run() {
-	l.Log.Infof("Starting up Background worker listening to redis queue %q", workQueue)
+	l.Log.Infof("Starting up Background worker listening to redis queue [%v]", workQueue)
+
+	runScheduledJobs()
 
 	for {
 		// This is a BLocking Pop that will effectively wait forever until


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-17973

Basically this adds a feature to the job engine to have scheduled jobs. 

---

In order to add a job to be ran just add it to the `schedule` slice, from there it'll get ran by the background worker consistently on a schedule.

If you want to play here is an example:
```
[ requeuing_job_engine ~m~ ] ~/cloud/git/crc/sources/go-rewrite 
$> make backgroundworker 
go run `ls *.go | grep -v test` -background-worker
Clowder is not enabled, skipping init...
{"@timestamp":"2022-04-27T13:22:16.475Z"...,"caller":"github.com/RedHatInsights/sources-api-go/logger.AddHooksTo"...,"level":"warning","message":"Key or Secret are missing for logging to Cloud Watch.","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:16.488Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.Run"...,"level":"info","message":"Starting up Background worker listening to redis queue [sources_api_jobs]","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:16.488Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.runScheduledJobs"...,"level":"info","message":"Running [1] Background Job goroutines","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:16.488Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.runScheduledJobs"...,"level":"info","message":"Running Job [DemoJob] on Interval [5s]","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:21.489Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.RunJobNow"...,"level":"info","message":"Running Job DemoJob with map[hello:world]","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:21.489Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.(*DemoJob).Run"...,"level":"error","message":"Beep Boop!","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:26.494Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.RunJobNow"...,"level":"info","message":"Running Job DemoJob with map[hello:world]","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:26.494Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.(*DemoJob).Run"...,"level":"error","message":"Beep Boop!","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:31.498Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.RunJobNow"...,"level":"info","message":"Running Job DemoJob with map[hello:world]","tags":["source-api-go"]}
{"@timestamp":"2022-04-27T13:22:31.498Z"...,"caller":"github.com/RedHatInsights/sources-api-go/jobs.(*DemoJob).Run"...,"level":"error","message":"Beep Boop!","tags":["source-api-go"]}
^C{"@timestamp":"2022-04-27T13:22:32.277Z"...,"caller":"main.main"...,"level":"warning","message":"Received interrupt, exiting","tags":["source-api-go"]}
```

After applying this diff.

<details>
<summary>Diff</summary>

```
diff --git a/jobs/scheduled_jobs.go b/jobs/scheduled_jobs.go
index 4ee83cf..c286cb6 100644
--- a/jobs/scheduled_jobs.go
+++ b/jobs/scheduled_jobs.go
@@ -34,7 +34,7 @@ func (sj *ScheduledJob) runForever() {
 // are adding a new job that we want run on a schedule, add it here.
 //
 // example: var schedule = []ScheduledJob{{Interval: 5 * time.Second, Job: &AsyncDestroyJob{}}}
-var schedule = []ScheduledJob{}
+var schedule = []ScheduledJob{{Interval: 5 * time.Second, Job: &DemoJob{}}}
 
 // runScheduledJobs runs all of the jobs on a schedule forever.
 func runScheduledJobs() {
@@ -45,3 +45,30 @@ func runScheduledJobs() {
 		sj.runForever()
 	}
 }
+
+type DemoJob struct{}
+
+// how long to wait until performing (just do a sleep)
+func (dj *DemoJob) Delay() time.Duration {
+	return 5 * time.Second
+}
+
+// any arguments for said job
+func (dj *DemoJob) Arguments() map[string]interface{} {
+	return map[string]interface{}{"hello": "world"}
+}
+
+// pretty name to print
+func (dj *DemoJob) Name() string {
+	return "DemoJob"
+}
+
+// run the job, using any args on the struct
+func (dj *DemoJob) Run() error {
+	l.Log.Errorf("Beep Boop!")
+	return nil
+}
+
+func (dj *DemoJob) ToJSON() []byte {
+	return nil
+}
```

</details>