### PR TITLE
[RHCLOUD-18283] create special fixtures for TestEndpointDelele()

### DIFF
--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -204,7 +205,7 @@ func TestEndpointList(t *testing.T) {
 		t.Error("offset not set correctly")
 	}
 
-	if len(out.Data) != 2 {
+	if len(out.Data) != len(fixtures.TestEndpointData) {
 		t.Error("not enough objects passed back from DB")
 	}
 
@@ -564,11 +565,12 @@ func TestEndpointEditBadRequest(t *testing.T) {
 }
 
 func TestEndpointDelete(t *testing.T) {
+	endpoint := "300"
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	c, rec := request.CreateTestContext(
 		http.MethodDelete,
-		"/api/sources/v3.1/endpoints/1",
+		fmt.Sprintf("/api/sources/v3.1/endpoints/%s", endpoint),
 		nil,
 		map[string]interface{}{
 			"tenantID": int64(1),
@@ -576,7 +578,7 @@ func TestEndpointDelete(t *testing.T) {
 	)
 
 	c.SetParamNames("id")
-	c.SetParamValues("1")
+	c.SetParamValues(endpoint)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	err := EndpointDelete(c)
@@ -591,7 +593,7 @@ func TestEndpointDelete(t *testing.T) {
 	// Check that endpoint doesn't exist.
 	c, rec = request.CreateTestContext(
 		http.MethodGet,
-		"/api/sources/v3.1/endpoints/1",
+		fmt.Sprintf("/api/sources/v3.1/endpoints/%s", endpoint),
 		nil,
 		map[string]interface{}{
 			"tenantID": int64(1),
@@ -599,7 +601,7 @@ func TestEndpointDelete(t *testing.T) {
 	)
 
 	c.SetParamNames("id")
-	c.SetParamValues("1")
+	c.SetParamValues(endpoint)
 
 	notFoundEndpointGet := ErrorHandlingContext(EndpointGet)
 	err = notFoundEndpointGet(c)

--- a/internal/testutils/fixtures/endpoint.go
+++ b/internal/testutils/fixtures/endpoint.go
@@ -39,4 +39,15 @@ var TestEndpointData = []m.Endpoint{
 		Path:               &path2,
 		AvailabilityStatus: "unavailable",
 	},
+	{
+		ID:                 300,
+		SourceID:           2,
+		TenantID:           1,
+		Port:               &port,
+		Default:            &defaultValueSource2,
+		Scheme:             &scheme2,
+		Host:               &host2,
+		Path:               &path2,
+		AvailabilityStatus: "unavailable",
+	},
 }


### PR DESCRIPTION
In `TestEndpointDelete()` we used as test data the endpoint with id = 1 and in the end of test the test data was deleted. And I decides to create new fixtures with the id = 300 to be more visually highlighted that this test data are special.

And because count of endpoints were changed, I had to fix count of endpoints returned in `TestEndpointList()`.

This change was originally part of https://github.com/RedHatInsights/sources-api-go/pull/278

**LINKS:** [RHCLOUD-18283](https://issues.redhat.com/browse/RHCLOUD-18283)