### PR TITLE
Add Makefile target to create a new DB Migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,4 +56,7 @@ vault:
 generate:
 	go generate ./...
 
+migration:
+	@sh db/migrations/new_migration.sh
+
 .PHONY: setup tidy build clean run container remotedebug debug test lint gci vault listener alltest generate

--- a/db/migrations/new_migration.sh
+++ b/db/migrations/new_migration.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ -z $NAME ]]; then
+    echo "NAME must be set, run like \`make migration NAME='new name here'\`"
+    exit 1
+fi
+
+DATE=$(date +"%Y%m%d%H%M00")
+SANITIZED_NAME=$(echo $NAME | sed 's/ /_/g')
+FILENAME="db/migrations/${DATE}_${SANITIZED_NAME}.go"
+
+cp db/migrations/x_migration_template.go.template $FILENAME
+sed -i"" "s/DATE/${DATE}/g" $FILENAME
+sed -i"" "s/NAME/${NAME}/g" $FILENAME

--- a/db/migrations/x_migration_template.go.template
+++ b/db/migrations/x_migration_template.go.template
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	_ "embed"
+
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// TODO: Implement Migration
+func NewMigration() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "DATE",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "NAME" started`)
+			defer logging.Log.Info(`Migration "NAME" ended`)
+
+			// Perform the migration.
+			err := db.Transaction(func(tx *gorm.DB) error {
+				// TODO: do the thing
+				return nil
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Transaction(func(tx *gorm.DB) error {
+				// TODO: reverse the thing
+				return nil
+			})
+
+			return err
+		},
+	}
+}


### PR DESCRIPTION
This adds a make target so its easy to create a migration.

Just run `make migration NAME="my cool new migration"` and it will copy the template out and set up the date/name like so:
```
[ add_migrations_make_target ~m~ ] ~/cloud/git/crc/sources/go-rewrite 
$> git st
?? db/migrations/20220428123900_my_cool_new_migration.go
```

```go
package migrations

import (
	_ "embed"

	logging "github.com/RedHatInsights/sources-api-go/logger"
	"github.com/go-gormigrate/gormigrate/v2"
	"gorm.io/gorm"
)

// TODO: Implement Migration
func NewMigration() *gormigrate.Migration {
	return &gormigrate.Migration{
		ID: "20220428123900",
		Migrate: func(db *gorm.DB) error {
			logging.Log.Info(`Migration "my cool new migration" started`)
			defer logging.Log.Info(`Migration "my cool new migration" ended`)

			// Perform the migration.
			err := db.Transaction(func(tx *gorm.DB) error {
				// TODO: do the thing
				return nil
			})

			return err
		},
		Rollback: func(db *gorm.DB) error {
			err := db.Transaction(func(tx *gorm.DB) error {
				// TODO: reverse the thing
				return nil
			})

			return err
		},
	}
}

```