### PR TITLE
[RHCLOUD-17971] Add RetryCounter field to Application model to track retries

### DIFF
--- a/db/migrations/20220428124100_add_retry_counter_to_applications.go
+++ b/db/migrations/20220428124100_add_retry_counter_to_applications.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+func AddRetryCounterToApplications() *gormigrate.Migration {
+	type Application struct {
+		// using a smallint here, goes up to 32,000 which should be plenty.
+		RetryCounter *int8 `gorm:"default:0"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220428124100",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "add retry counter to applications" started`)
+			defer logging.Log.Info(`Migration "add retry counter to applications" ended`)
+
+			// Perform the migration.
+			err := db.Transaction(func(tx *gorm.DB) error {
+				return tx.Migrator().AddColumn(&Application{}, "RetryCounter")
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Transaction(func(tx *gorm.DB) error {
+				return tx.Migrator().DropColumn(&Application{}, "RetryCounter")
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -16,6 +16,7 @@ var migrationsCollection = []*gormigrate.Migration{
 	AddOrgIdToTenants(),
 	TranslateEbsAccountNumbersToOrgIds(),
 	SourceTypesAddCategoryColumn(),
+	AddRetryCounterToApplications(),
 }
 
 var ctx = context.Background()

--- a/model/application.go
+++ b/model/application.go
@@ -21,6 +21,7 @@ type Application struct {
 	AvailabilityStatusError string     `json:"availability_status_error,omitempty"`
 
 	Extra             datatypes.JSON `json:"extra,omitempty"`
+	RetryCounter      *int8          `json:"-" gorm:"default:0"`
 	SuperkeyData      datatypes.JSON `json:"-"`
 	GotSuperkeyUpdate bool           `json:"-" gorm:"-"`
 


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-17971

Simple migration adding the `retry_counter` column to applications. This will be for the auto-retry job eventually.

---

cc @petracihalova this is how you create a migration :) after #284 is merged you should be able to create a migration with `make migration NAME="..."` and then from there we can work on adding that constraint to the DB where we only want one application of each type per source. 

The SQL for that is this: 
```sql
CREATE UNIQUE INDEX applications_unique_application_types_per_source_per_tenant ON applications (application_type_id, source_id, tenant_id);
```