### PR TITLE
Improve backtrace in logs for ErrNotFound and ErrBadRequest

### DIFF
--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -18,10 +18,10 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 			switch err.(type) {
 			case util.ErrNotFound:
 				statusCode = http.StatusNotFound
-				message = util.ErrorDoc(err.Error(), "404")
+				message = util.ErrorDocWithoutLogging(err.Error(), "404")
 			case util.ErrBadRequest:
 				statusCode = http.StatusBadRequest
-				message = util.ErrorDoc(err.Error(), "400")
+				message = util.ErrorDocWithoutLogging(err.Error(), "400")
 			default:
 				statusCode = http.StatusInternalServerError
 				message = util.ErrorDoc(fmt.Sprintf("Internal Server Error: %v", err.Error()), "500")

--- a/util/error_document.go
+++ b/util/error_document.go
@@ -21,6 +21,10 @@ type ErrorDocument struct {
 func ErrorDoc(message, status string) *ErrorDocument {
 	l.Log.Error(message)
 
+	return ErrorDocWithoutLogging(message, status)
+}
+
+func ErrorDocWithoutLogging(message, status string) *ErrorDocument {
 	return &ErrorDocument{
 		[]Error{{
 			Detail: message,

--- a/util/error_document.go
+++ b/util/error_document.go
@@ -42,6 +42,10 @@ func (e ErrNotFound) Is(err error) bool {
 }
 
 func NewErrNotFound(t string) error {
+	if l.Log != nil {
+		l.Log.Error(t)
+	}
+
 	return ErrNotFound{Type: t}
 }
 
@@ -58,12 +62,20 @@ func (e ErrBadRequest) Is(err error) bool {
 }
 
 func NewErrBadRequest(t interface{}) error {
+	errorMessage := ""
+
 	switch t := t.(type) {
 	case string:
-		return ErrBadRequest{Message: t}
+		errorMessage = t
 	case error:
-		return ErrBadRequest{Message: t.Error()}
+		errorMessage = t.Error()
 	default:
 		panic("bad interface type for bad request: " + reflect.ValueOf(t).String())
 	}
+
+	if l.Log != nil {
+		l.Log.Error(errorMessage)
+	}
+
+	return ErrBadRequest{Message: errorMessage}
 }


### PR DESCRIPTION
When we had error which was covered by `NewErrNotFound` and `NewErrBadRequest` - logging happened here in ErrorHandling middleware and exactly in ErrorDoc - backtrace was not useful:

```json
{
    "@timestamp": "2022-04-29T11:20:35.147Z",
    "@version": 1,
    "app": "source-api-go",
    "backtrace": [
        "runtime.Callers(/usr/local/opt/go/libexec/src/runtime/extern.go:227)",
        "github.com/RedHatInsights/sources-api-go/logger.backtrace(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:94)",
        "github.com/RedHatInsights/sources-api-go/logger.(*CustomLoggerFormatter).Format(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:156)",
        "github.com/sirupsen/logrus.(*Entry).write(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:279)",
        "github.com/sirupsen/logrus.(*Entry).log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:251)",
        "github.com/sirupsen/logrus.(*Entry).Log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:293)",
        "github.com/sirupsen/logrus.(*Logger).Log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/logger.go:198)",
        "github.com/sirupsen/logrus.(*Logger).Error(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/logger.go:238)",
        "github.com/RedHatInsights/sources-api-go/util.ErrorDoc(/Users/liborpichler/Projects/sources-api-go/util/error_document.go:22)",
        "github.com/RedHatInsights/sources-api-go/middleware.HandleErrors.func1(/Users/liborpichler/Projects/sources-api-go/middleware/error_handling.go:24)",
        "github.com/RedHatInsights/sources-api-go/middleware.Timing.func1(/Users/liborpichler/Projects/sources-api-go/middleware/timings.go:19)",
        "github.com/labstack/echo/v4.(*Echo).add.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:552)",
        "github.com/labstack/echo-contrib/prometheus.(*Prometheus).HandlerFunc.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo-contrib@v0.12.0/prometheus/prometheus.go:382)",
        "github.com/labstack/echo/v4/middleware.LoggerWithConfig.func2.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/logger.go:117)",
        "github.com/labstack/echo/v4/middleware.RecoverWithConfig.func1.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/recover.go:98)",
        "github.com/labstack/echo/v4.(*Echo).ServeHTTP.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:656)",
        "github.com/labstack/echo/v4/middleware.RemoveTrailingSlashWithConfig.func1.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/slash.go:118)",
        "github.com/labstack/echo/v4.(*Echo).ServeHTTP(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:662)",
        "net/http.serverHandler.ServeHTTP(/usr/local/opt/go/libexec/src/net/http/server.go:2879)",
        "net/http.(*conn).serve(/usr/local/opt/go/libexec/src/net/http/server.go:1930)"
    ],
    "caller": "",
    "filename": "/Users/liborpichler/Projects/sources-api-go/util/error_document.go:22",
    "hostname": "lpichler1-mac",
    "labels": {
        "app": "source-api-go"
    },
    "level": "error",
    "message": "bad request: strconv.ParseInt: parsing \"XX\": invalid syntax",
    "tags": [
        "source-api-go"
    ]
}
```

with this change, log looks like:

```json
{
    "@timestamp": "2022-04-29T11:14:34.616Z",
    "@version": 1,
    "app": "source-api-go",
    "backtrace": [
        "runtime.Callers(/usr/local/opt/go/libexec/src/runtime/extern.go:227)",
        "github.com/RedHatInsights/sources-api-go/logger.backtrace(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:94)",
        "github.com/RedHatInsights/sources-api-go/logger.(*CustomLoggerFormatter).Format(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:156)",
        "github.com/sirupsen/logrus.(*Entry).write(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:279)",
        "github.com/sirupsen/logrus.(*Entry).log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:251)",
        "github.com/sirupsen/logrus.(*Entry).Log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:293)",
        "github.com/sirupsen/logrus.(*Logger).Log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/logger.go:198)",
        "github.com/sirupsen/logrus.(*Logger).Error(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/logger.go:238)",
        "github.com/RedHatInsights/sources-api-go/util.NewErrBadRequest(/Users/liborpichler/Projects/sources-api-go/util/error_document.go:81)",
        "main.SourceGet(/Users/liborpichler/Projects/sources-api-go/source_handlers.go:79)",
        "github.com/RedHatInsights/sources-api-go/middleware.Tenancy.func1(/Users/liborpichler/Projects/sources-api-go/middleware/tenancy.go:98)",
        "github.com/RedHatInsights/sources-api-go/middleware.ParseHeaders.func1(/Users/liborpichler/Projects/sources-api-go/middleware/headers.go:73)",
        "github.com/RedHatInsights/sources-api-go/middleware.HandleErrors.func1(/Users/liborpichler/Projects/sources-api-go/middleware/error_handling.go:13)",
        "github.com/RedHatInsights/sources-api-go/middleware.Timing.func1(/Users/liborpichler/Projects/sources-api-go/middleware/timings.go:19)",
        "github.com/labstack/echo/v4.(*Echo).add.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:552)",
        "github.com/labstack/echo-contrib/prometheus.(*Prometheus).HandlerFunc.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo-contrib@v0.12.0/prometheus/prometheus.go:382)",
        "github.com/labstack/echo/v4/middleware.LoggerWithConfig.func2.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/logger.go:117)",
        "github.com/labstack/echo/v4/middleware.RecoverWithConfig.func1.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/recover.go:98)",
        "github.com/labstack/echo/v4.(*Echo).ServeHTTP.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:656)",
        "github.com/labstack/echo/v4/middleware.RemoveTrailingSlashWithConfig.func1.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/slash.go:118)",
        "github.com/labstack/echo/v4.(*Echo).ServeHTTP(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:662)",
        "net/http.serverHandler.ServeHTTP(/usr/local/opt/go/libexec/src/net/http/server.go:2879)",
        "net/http.(*conn).serve(/usr/local/opt/go/libexec/src/net/http/server.go:1930)"
    ],
    "caller": "github.com/RedHatInsights/sources-api-go/util.NewErrBadRequest",
    "filename": "/Users/liborpichler/Projects/sources-api-go/util/error_document.go:81",
    "hostname": "lpichler1-mac",
    "labels": {
        "app": "source-api-go"
    },
    "level": "error",
    "message": "strconv.ParseInt: parsing \"XX\": invalid syntax",
    "tags": [
        "source-api-go"
    ]
}
```

It is not perfect yet, just little improvement.
