### PR TITLE
[RHCLOUD-19160] Vault mock update

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -321,7 +321,7 @@ func TestAuthenticationEdit(t *testing.T) {
 
 	emailNotificationInfo := &m.EmailNotificationInfo{ResourceDisplayName: "Authentication",
 		CurrentAvailabilityStatus:  newAvailabilityStatus,
-		PreviousAvailabilityStatus: "unknown",
+		PreviousAvailabilityStatus: "available",
 		SourceName:                 fixtures.TestSourceData[0].Name,
 		SourceID:                   strconv.FormatInt(fixtures.TestSourceData[0].ID, 10),
 		TenantID:                   strconv.FormatInt(fixtures.TestSourceData[0].TenantID, 10),

--- a/internal/testutils/fixtures/authentication.go
+++ b/internal/testutils/fixtures/authentication.go
@@ -6,30 +6,35 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 )
 
+var availabilityStatus = "available"
+
 var TestAuthenticationData = []m.Authentication{
 	{
-		ID:           "611a8a38-f434-4e62-bda0-78cd45ffae5b",
-		DbID:         1,
-		TenantID:     TestTenantData[0].Id,
-		SourceID:     1,
-		ResourceType: "Application",
-		ResourceID:   1,
+		ID:                 "611a8a38-f434-4e62-bda0-78cd45ffae5b",
+		DbID:               1,
+		TenantID:           TestTenantData[0].Id,
+		SourceID:           1,
+		ResourceType:       "Application",
+		ResourceID:         1,
+		AvailabilityStatus: &availabilityStatus,
 	},
 	{
-		ID:           "82e1a1b6-a136-11ec-b909-0242ac120002",
-		DbID:         2,
-		TenantID:     TestTenantData[0].Id,
-		SourceID:     2,
-		ResourceType: "Endpoint",
-		ResourceID:   1,
+		ID:                 "82e1a1b6-a136-11ec-b909-0242ac120002",
+		DbID:               2,
+		TenantID:           TestTenantData[0].Id,
+		SourceID:           2,
+		ResourceType:       "Endpoint",
+		ResourceID:         1,
+		AvailabilityStatus: &availabilityStatus,
 	},
 	{
-		ID:           "24127a2a-c4db-11ec-9d64-0242ac120002",
-		DbID:         3,
-		TenantID:     TestTenantData[0].Id,
-		SourceID:     2,
-		ResourceType: "Source",
-		ResourceID:   1,
+		ID:                 "24127a2a-c4db-11ec-9d64-0242ac120002",
+		DbID:               3,
+		TenantID:           TestTenantData[0].Id,
+		SourceID:           2,
+		ResourceType:       "Source",
+		ResourceID:         1,
+		AvailabilityStatus: &availabilityStatus,
 	},
 }
 

--- a/internal/testutils/mocks/mock_vault.go
+++ b/internal/testutils/mocks/mock_vault.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/hashicorp/vault/api"
 )
@@ -13,26 +14,22 @@ import (
 type MockVault struct {
 }
 
-var VaultPath = []string{fmt.Sprintf("Application_%d_%v", fixtures.TestTenantData[0].Id, fixtures.TestAuthenticationData[0].ID)}
-
 func (m *MockVault) Read(path string) (*api.Secret, error) {
-	if path != fmt.Sprintf("secret/data/%d/%v", fixtures.TestTenantData[0].Id, VaultPath[0]) {
-		return nil, nil
+	idFromPath := getIdFromVaultPath(path)
+
+	for _, auth := range fixtures.TestAuthenticationData {
+		if auth.ID == idFromPath {
+			return createSecretOutput(auth), nil
+		}
 	}
-
-	secret := &api.Secret{}
-	secret.Data = make(map[string]interface{})
-	secret.Data["data"] = fixtures.TestAuthenticationVaultData
-	secret.Data["metadata"] = fixtures.TestAuthenticationVaultMetaData
-
-	return secret, nil
+	return nil, nil
 }
 
 func (m *MockVault) List(_ string) (*api.Secret, error) {
 	secret := &api.Secret{}
 
 	secret.Data = make(map[string]interface{})
-	secret.Data["keys"] = []interface{}{VaultPath[0]}
+	secret.Data["keys"] = getVaultPathsFromFixtures()
 
 	return secret, nil
 }
@@ -55,4 +52,45 @@ func (m *MockVault) Delete(path string) (*api.Secret, error) {
 		return secret, nil
 	}
 	return nil, util.NewErrNotFound("authentication")
+}
+
+// getVaultPathsFromFixtures creates list of fault paths
+func getVaultPathsFromFixtures() []interface{} {
+	var vaultPaths []interface{}
+
+	for _, auth := range fixtures.TestAuthenticationData {
+		path := fmt.Sprintf("%s_%d_%s", auth.ResourceType, auth.TenantID, auth.ID)
+		vaultPaths = append(vaultPaths, path)
+	}
+	return vaultPaths
+}
+
+// getIdFromVaultPath gets ID from given vault path
+func getIdFromVaultPath(path string) string {
+	paths := strings.Split(path, "_")
+	uid := paths[len(paths)-1]
+
+	return uid
+}
+
+// createSecretOutput creates and returns secret objects from given authentication
+func createSecretOutput(auth m.Authentication) *api.Secret {
+	secret := &api.Secret{}
+	secret.Data = make(map[string]interface{})
+
+	secret.Data["data"] = map[string]interface{}{
+		"id":                  auth.ID,
+		"tenant_id":           fmt.Sprintf("%d", auth.TenantID),
+		"availability_status": *auth.AvailabilityStatus,
+		"resource_type":       auth.ResourceType,
+		"resource_id":         fmt.Sprintf("%d", auth.ResourceID),
+		"source_id":           fmt.Sprintf("%d", auth.SourceID),
+		"authtype":            "test",
+		"name":                "OpenShift",
+		"username":            "testusr",
+		"extra":               map[string]interface{}{},
+	}
+
+	secret.Data["metadata"] = fixtures.TestAuthenticationVaultMetaData
+	return secret
 }


### PR DESCRIPTION
we need to update vault mock methods List() and Read() because we need it for writing tests for these functions (when secret store = vault):
- EndpointListAuthentications() from endpoint handler ([RHCLOUD-18283](https://issues.redhat.com/browse/RHCLOUD-18283)) 
- ApplicationListAuthentications() from app handler ([RHCLOUD-18281](https://issues.redhat.com/browse/RHCLOUD-18281))
- SourceListAuthentications() from source handler (done)
- ApplicationAuthenticationListAuthentications() from app auth handler ([RHCLOUD-18282](https://issues.redhat.com/browse/RHCLOUD-18282))

so basically we need more test data for these tests and Vault mock that is able to handle them

and

after changes in first commit some tests failed, so second commit fixes this

--------------

This change was originally part of https://github.com/RedHatInsights/sources-api-go/pull/278

**LINKS:** [RHCLOUD-19160](https://issues.redhat.com/browse/RHCLOUD-19160)