### PR TITLE
[RHCLOUD-18283] added tests for EndpointListAuthentications()

### DIFF
--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -775,8 +775,29 @@ func (m MockAuthenticationDao) ListForApplicationAuthentication(appAuthID int64,
 	panic("implement me")
 }
 
-func (m MockAuthenticationDao) ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
-	panic("implement me")
+func (mAuth MockAuthenticationDao) ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	endpointExists := false
+
+	for _, e := range fixtures.TestEndpointData {
+		if e.ID == endpointID {
+			endpointExists = true
+			break
+		}
+	}
+
+	if !endpointExists {
+		return nil, 0, util.NewErrNotFound("endpoint")
+	}
+
+	out := make([]m.Authentication, 0)
+
+	for _, auth := range mAuth.Authentications {
+		if auth.ResourceType == "Endpoint" && auth.ResourceID == endpointID {
+			out = append(out, auth)
+		}
+	}
+
+	return out, int64(len(out)), nil
 }
 
 func (m MockAuthenticationDao) Create(auth *m.Authentication) error {

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -274,7 +274,7 @@ func EndpointListAuthentications(c echo.Context) error {
 
 	auths, count, err := authDB.ListForEndpoint(id, limit, offset, filters)
 	if err != nil {
-		return c.JSON(http.StatusNotFound, util.ErrorDoc(err.Error(), "404"))
+		return err
 	}
 
 	tenantId := authDB.Tenant()

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -793,3 +793,137 @@ func TestEndpointEditPausedInvalidFields(t *testing.T) {
 	// Restore the binder to not affect any other tests.
 	c.Echo().Binder = backupBinder
 }
+
+func TestEndpointListAuthentications(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/endpoints/1/authentications",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("endpoint_id")
+	c.SetParamValues("1")
+
+	err := EndpointListAuthentications(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 200 {
+		t.Error("Did not return 200")
+	}
+
+	var out util.Collection
+	err = json.Unmarshal(rec.Body.Bytes(), &out)
+	if err != nil {
+		t.Error("Failed unmarshaling output")
+	}
+
+	if out.Meta.Limit != 100 {
+		t.Error("limit not set correctly")
+	}
+
+	if out.Meta.Offset != 0 {
+		t.Error("offset not set correctly")
+	}
+
+	auth1, ok := out.Data[0].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if auth1["resource_type"] != "Endpoint" {
+		t.Error("ghosts infected the return")
+	}
+
+	if auth1["resource_id"] != "1" {
+		t.Error("ghosts infected the return")
+	}
+
+	AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
+}
+
+func TestEndpointListAuthenticationsBadRequestInvalidEndpointId(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/endpoints/xxx/authentications",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("endpoint_id")
+	c.SetParamValues("xxx")
+
+	badRequestEndpointListAuthentications := ErrorHandlingContext(EndpointListAuthentications)
+	err := badRequestEndpointListAuthentications(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.BadRequestTest(t, rec)
+}
+
+func TestEndpointListAuthenticationsBadRequestInvalidFilter(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/endpoints/xxx/authentications",
+		nil,
+		map[string]interface{}{
+			"limit":  100,
+			"offset": 0,
+			"filters": []util.Filter{
+				{Name: "wrongName", Value: []string{"wrongValue"}},
+			},
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("endpoint_id")
+	c.SetParamValues("xxx")
+
+	badRequestEndpointListAuthentications := ErrorHandlingContext(EndpointListAuthentications)
+	err := badRequestEndpointListAuthentications(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.BadRequestTest(t, rec)
+}
+
+func TestEndpointListAuthenticationsNotFound(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/endpoints/09834098349/authentications",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("endpoint_id")
+	c.SetParamValues("09834098349")
+
+	notFoundEndpointListAuthentications := ErrorHandlingContext(EndpointListAuthentications)
+	err := notFoundEndpointListAuthentications(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}


### PR DESCRIPTION
Tests for EndpointListAuthentications()


------------
This change was originally part of https://github.com/RedHatInsights/sources-api-go/pull/278

**LINKS:** [RHCLOUD-18283](https://issues.redhat.com/browse/RHCLOUD-18283)