### PR TITLE
Reduce backtrace in logs

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -27,6 +27,7 @@ const (
 	SQLType     = "sql"
 )
 
+var whiteListForFunctionsInBacktrace = []string{"RedHatInsights", "redhatinsights", "main"}
 var Log *logrus.Logger
 
 var cloudWatchHook *lc.Hook
@@ -94,6 +95,16 @@ func LogrusLogLevelFrom(configLogLevel string) logrus.Level {
 	return logLevel
 }
 
+// StringContainAnySubString - TODO: Move this function to util package
+func stringContainAnySubString(stringToSearch string, subStrings []string) bool {
+	for _, subString := range subStrings {
+		if strings.Contains(stringToSearch, subString) {
+			return true
+		}
+	}
+	return false
+}
+
 func backtrace() []string {
 	var filenames []string
 
@@ -102,7 +113,9 @@ func backtrace() []string {
 	frames := runtime.CallersFrames(pc[:n])
 
 	for frame, isNextFrameValid := frames.Next(); isNextFrameValid; frame, isNextFrameValid = frames.Next() {
-		filenames = append(filenames, fmt.Sprintf("%s(%s:%d)", frame.Function, frame.File, frame.Line))
+		if stringContainAnySubString(frame.Function, whiteListForFunctionsInBacktrace) {
+			filenames = append(filenames, fmt.Sprintf("%s(%s:%d)", frame.Function, frame.File, frame.Line))
+		}
 	}
 
 	return filenames

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -105,6 +105,21 @@ func stringContainAnySubString(stringToSearch string, subStrings []string) bool 
 	return false
 }
 
+/*
+  example:
+	functionNameFromPath("github.com/RedHatInsights/sources-api-go/middleware.Timing.func1")
+	=> "middleware.Timing.func1"
+*/
+func functionNameFromPath(functionWithPath string) string {
+	functionPathParts := strings.Split(functionWithPath, "/")
+	partsLength := len(functionPathParts)
+	if partsLength == 0 {
+		return ""
+	}
+
+	return functionPathParts[partsLength-1]
+}
+
 func backtrace() []string {
 	var filenames []string
 
@@ -114,7 +129,7 @@ func backtrace() []string {
 
 	for frame, isNextFrameValid := frames.Next(); isNextFrameValid; frame, isNextFrameValid = frames.Next() {
 		if stringContainAnySubString(frame.Function, whiteListForFunctionsInBacktrace) {
-			filenames = append(filenames, fmt.Sprintf("%s(%s:%d)", frame.Function, frame.File, frame.Line))
+			filenames = append(filenames, fmt.Sprintf("%s(%s:%d)", functionNameFromPath(frame.Function), frame.File, frame.Line))
 		}
 	}
 


### PR DESCRIPTION
This changes `backtrace` field in log messages:
1. As @lindgrenj6 pointed out [here](https://github.com/RedHatInsights/sources-api-go/pull/240#issuecomment-1111362796)  we don't need to list backtrace from other packages then ours.
2. We display function name with whole package path - I removed the beginning and I left here only package name + function name (it is done by function `functionNameFromPath`):
```go
functionNameFromPath("github.com/RedHatInsights/sources-api-go/middleware.Timing.func1")
	=> "middleware.Timing.func1"
```



Before:

```json
{
    "@timestamp": "2022-05-03T10:59:54.581Z",
    "@version": 1,
    "app": "source-api-go",
    "backtrace": [
        "runtime.Callers(/usr/local/opt/go/libexec/src/runtime/extern.go:227)",
        "github.com/RedHatInsights/sources-api-go/logger.backtrace(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:101)",
        "github.com/RedHatInsights/sources-api-go/logger.(*CustomLoggerFormatter).Format(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:164)",
        "github.com/sirupsen/logrus.(*Entry).write(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:279)",
        "github.com/sirupsen/logrus.(*Entry).log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:251)",
        "github.com/sirupsen/logrus.(*Entry).Log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/entry.go:293)",
        "github.com/sirupsen/logrus.(*Logger).Log(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/logger.go:198)",
        "github.com/sirupsen/logrus.(*Logger).Error(/Users/liborpichler/go/pkg/mod/github.com/sirupsen/logrus@v1.8.1/logger.go:238)",
        "github.com/RedHatInsights/sources-api-go/util.NewErrBadRequest(/Users/liborpichler/Projects/sources-api-go/util/error_document.go:81)",
        "main.SourceGet(/Users/liborpichler/Projects/sources-api-go/source_handlers.go:80)",
        "github.com/RedHatInsights/sources-api-go/middleware.Tenancy.func1(/Users/liborpichler/Projects/sources-api-go/middleware/tenancy.go:98)",
        "github.com/RedHatInsights/sources-api-go/middleware.ParseHeaders.func1(/Users/liborpichler/Projects/sources-api-go/middleware/headers.go:73)",
        "github.com/RedHatInsights/sources-api-go/middleware.HandleErrors.func1(/Users/liborpichler/Projects/sources-api-go/middleware/error_handling.go:13)",
        "github.com/RedHatInsights/sources-api-go/middleware.Timing.func1(/Users/liborpichler/Projects/sources-api-go/middleware/timings.go:19)",
        "github.com/labstack/echo/v4.(*Echo).add.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:552)",
        "github.com/labstack/echo-contrib/prometheus.(*Prometheus).HandlerFunc.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo-contrib@v0.12.0/prometheus/prometheus.go:382)",
        "github.com/labstack/echo/v4/middleware.LoggerWithConfig.func2.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/logger.go:117)",
        "github.com/labstack/echo/v4/middleware.RecoverWithConfig.func1.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/recover.go:98)",
        "github.com/labstack/echo/v4.(*Echo).ServeHTTP.func1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:656)",
        "github.com/labstack/echo/v4/middleware.RemoveTrailingSlashWithConfig.func1.1(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/slash.go:118)",
        "github.com/labstack/echo/v4.(*Echo).ServeHTTP(/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:662)",
        "net/http.serverHandler.ServeHTTP(/usr/local/opt/go/libexec/src/net/http/server.go:2879)",
        "net/http.(*conn).serve(/usr/local/opt/go/libexec/src/net/http/server.go:1930)"
    ],
    "caller": "github.com/RedHatInsights/sources-api-go/util.NewErrBadRequest",
    "filename": "/Users/liborpichler/Projects/sources-api-go/util/error_document.go:81",
    "hostname": "lpichler1-mac",
    "labels": {
        "app": "source-api-go"
    },
    "level": "error",
    "log_type": "default",
    "message": "strconv.ParseInt: parsing \"XX\": invalid syntax",
    "tags": [
        "source-api-go"
    ]
}
```


After:
```json
{
    "@timestamp": "2022-05-03T11:03:48.722Z",
    "@version": 1,
    "app": "source-api-go",
    "backtrace": [
        "logger.backtrace(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:127)",
        "logger.(*CustomLoggerFormatter).Format(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:192)",
        "util.NewErrBadRequest(/Users/liborpichler/Projects/sources-api-go/util/error_document.go:81)",
        "main.SourceGet(/Users/liborpichler/Projects/sources-api-go/source_handlers.go:80)",
        "middleware.Tenancy.func1(/Users/liborpichler/Projects/sources-api-go/middleware/tenancy.go:98)",
        "middleware.ParseHeaders.func1(/Users/liborpichler/Projects/sources-api-go/middleware/headers.go:73)",
        "middleware.HandleErrors.func1(/Users/liborpichler/Projects/sources-api-go/middleware/error_handling.go:13)",
        "middleware.Timing.func1(/Users/liborpichler/Projects/sources-api-go/middleware/timings.go:19)"
    ],
    "caller": "github.com/RedHatInsights/sources-api-go/util.NewErrBadRequest",
    "filename": "/Users/liborpichler/Projects/sources-api-go/util/error_document.go:81",
    "hostname": "lpichler1-mac",
    "labels": {
        "app": "source-api-go"
    },
    "level": "error",
    "log_type": "default",
    "message": "strconv.ParseInt: parsing \"XX\": invalid syntax",
    "tags": [
        "source-api-go"
    ]
}
```