### PR TITLE
Change authentication DB DAO to list all authentications for a source…

### DIFF
--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -92,8 +92,7 @@ func (add *authenticationDaoDbImpl) ListForSource(sourceID int64, limit, offset 
 	// getting the total count (filters included) for pagination
 	count := int64(0)
 	query.
-		Where("resource_id = ?", sourceID).
-		Where("resource_type = 'Source'").
+		Where("source_id = ?", sourceID).
 		Where("tenant_id = ?", add.TenantID).
 		Count(&count)
 

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -288,6 +288,7 @@ func TestListForSource(t *testing.T) {
 			ResourceID:   source.ID,
 			ResourceType: "Source",
 			TenantID:     fixtures.TestTenantData[1].Id,
+			SourceID:     source.ID,
 		}
 
 		// Using bulk create so we don't check to see if the resource is there first

--- a/internal/testutils/fixtures/authentication.go
+++ b/internal/testutils/fixtures/authentication.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 var availabilityStatus = "available"
@@ -14,6 +15,7 @@ var TestAuthenticationData = []m.Authentication{
 		DbID:               1,
 		TenantID:           TestTenantData[0].Id,
 		SourceID:           1,
+		Username:           util.StringRef("first"),
 		ResourceType:       "Application",
 		ResourceID:         1,
 		AvailabilityStatus: &availabilityStatus,
@@ -23,6 +25,7 @@ var TestAuthenticationData = []m.Authentication{
 		DbID:               2,
 		TenantID:           TestTenantData[0].Id,
 		SourceID:           2,
+		Username:           util.StringRef("second"),
 		ResourceType:       "Endpoint",
 		ResourceID:         1,
 		AvailabilityStatus: &availabilityStatus,
@@ -31,6 +34,7 @@ var TestAuthenticationData = []m.Authentication{
 		ID:                 "24127a2a-c4db-11ec-9d64-0242ac120002",
 		DbID:               3,
 		TenantID:           TestTenantData[0].Id,
+		Username:           util.StringRef("third"),
 		SourceID:           2,
 		ResourceType:       "Source",
 		ResourceID:         1,

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -100,20 +99,8 @@ func TestSourceListAuthentications(t *testing.T) {
 			t.Errorf(`the IDs from the authentication don't match. Want "%s", got "%s"'`, want, got)
 		}
 	} else {
-		want := fixtures.TestAuthenticationData[2].DbID
-
-		outputId, ok := auth1["id"].(string)
-		if !ok {
-			t.Errorf(`invalid ID received from authentication. Want "%s", got "%s"`, "string", reflect.TypeOf(auth1["id"]))
-		}
-
-		got, err := strconv.ParseInt(outputId, 10, 64)
-		if err != nil {
-			t.Errorf(`could not parse ID from authentication: %s`, err)
-		}
-
-		if want != got {
-			t.Errorf(`the IDs from the authentication don't match. Want "%d", got "%d"'`, want, got)
+		if !util.SliceContainsString([]string{"testUser", "first", "second", "third"}, auth1["username"].(string)) {
+			t.Errorf("invalid username returned, not found in test tenant data.")
 		}
 	}
 


### PR DESCRIPTION
… rather than the directly attached authentications

So this was something I must have missed in the code review for the auth DB DAO. For `/sources/:id/authentications` we want to fetch all of the authentications related to that source not just the ones that are directly attached. We have a nice field `source_id` which we set on create so the relation is there. 