### PR TITLE
[RHCLOUD-19207] Refactor migrations improve redis connection error message

### DIFF
--- a/dao/db.go
+++ b/dao/db.go
@@ -94,10 +94,7 @@ func Init() {
 	rawDB.SetMaxOpenConns(20)
 
 	// Perform database migrations.
-	err = migrations.Migrate(DB)
-	if err != nil {
-		logging.Log.Fatalf(`Error migrating database "%s": %s`, conf.DatabaseName, err)
-	}
+	migrations.Migrate(DB)
 
 	// Open up the conn to Vault
 	cfg := vault.DefaultConfig()

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -2,9 +2,9 @@ package migrations
 
 import (
 	"context"
-	"fmt"
 	"time"
 
+	logging "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/redis"
 	"github.com/go-gormigrate/gormigrate/v2"
 	uuidpkg "github.com/google/uuid"
@@ -32,17 +32,17 @@ const redisLockExpirationTime = 30 * time.Second
 
 // Migrate migrates the database schema to the latest version. Implements the single instance lock algorithm detailed
 // in https://redis.io/topics/distlock#correct-implementation-with-a-single-instance.
-func Migrate(db *gorm.DB) error {
+func Migrate(db *gorm.DB) {
 	// Using UUID as the lock value since it's a safe way of obtaining a unique string among all the clients.
 	uuid, err := uuidpkg.NewUUID()
 	if err != nil {
-		return err
+		logging.Log.Fatalf(`could not generate a UUID for the Redis lock: %s`, err)
 	}
 
 	// Before doing anything, check for the existence of the lock.
 	exists, err := redis.Client.Exists(ctx, redisLockKey).Result()
 	if err != nil {
-		return err
+		logging.Log.Fatalf(`error when fetching the Redis lock: %s`, err)
 	}
 
 	// If the lock is present, we must wait in order to be able to obtain it ourselves.
@@ -52,7 +52,7 @@ func Migrate(db *gorm.DB) error {
 
 		exists, err = redis.Client.Exists(ctx, redisLockKey).Result()
 		if err != nil {
-			return err
+			logging.Log.Fatalf(`error when checking if the Redis lock exists: %s`, err)
 		}
 
 		lockExists = exists != 0
@@ -61,29 +61,29 @@ func Migrate(db *gorm.DB) error {
 	// Set the migrations lock.
 	err = redis.Client.Set(ctx, redisLockKey, uuid.String(), redisLockExpirationTime).Err()
 	if err != nil {
-		return err
+		logging.Log.Fatalf(`error when setting the Redis lock: %s`, err)
 	}
 
 	// Perform the migrations and store the error for a proper return.
 	migrateTool := gormigrate.New(db, gormigrate.DefaultOptions, migrationsCollection)
-	migrationErr := migrateTool.Migrate()
+	err = migrateTool.Migrate()
+	if err != nil {
+		logging.Log.Fatalf(`error when performing the database migrations: %s. The Redis lock is going to try to be released...`, err)
+	}
 
 	// Once the migrations have finished, get the lock's value to attempt to release it.
 	value, err := redis.Client.Get(ctx, redisLockKey).Result()
 	if err != nil {
-		return err
+		logging.Log.Fatalf(`error when getting the Redis lock after the migrations have run: %s`, err)
 	}
 
 	// The lock's value should coincide with the one we set above. If it doesn't something very wrong happened.
 	if value == uuid.String() {
 		err = redis.Client.Del(ctx, redisLockKey).Err()
 		if err != nil {
-			return err
+			logging.Log.Fatalf(`error when deleting the Redis lock after the migrations have run: %s`, err)
 		}
 	} else {
-		return fmt.Errorf(`migrations lock release failed. Expecting lock with value "%s", got "%s"`, uuid.String(), value)
+		logging.Log.Fatalf(`migrations lock release failed. Expecting lock with value "%s", got "%s"`, uuid.String(), value)
 	}
-
-	// Return the result of the migration process, in case something went wrong.
-	return migrationErr
 }

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -31,7 +31,8 @@ const redisSleepTime = 3 * time.Second
 const redisLockExpirationTime = 30 * time.Second
 
 // Migrate migrates the database schema to the latest version. Implements the single instance lock algorithm detailed
-// in https://redis.io/topics/distlock#correct-implementation-with-a-single-instance.
+// in https://redis.io/topics/distlock#correct-implementation-with-a-single-instance. On error, it tries deleting the
+// lock before exiting the program.
 func Migrate(db *gorm.DB) {
 	// Using UUID as the lock value since it's a safe way of obtaining a unique string among all the clients.
 	uuid, err := uuidpkg.NewUUID()


### PR DESCRIPTION
Changes the signature of the migration function, since we were only returning the error to log it afterwards. I thought that, in that case, it would be better to spare that return and to log the error directly.

The PR also improves the error messages, so that it is clearer why migrations are failing. For example, when Redis was not present, the error message would look like as if the database were not running, when in reality the "connection error" came from the Redis client.

## Links

[[RHCLOUD-19207]](https://issues.redhat.com/browse/RHCLOUD-19207)