### PR TITLE
[RHCLOUD-19248] Added missing tests for ApplicationAuthenticationDelete()

### DIFF
--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -309,11 +309,32 @@ func TestApplicationAuthenticationDeleteNotFound(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("1234523452542")
 
-	notFoundApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationDelete)
-	err := notFoundApplicationAuthenticationGet(c)
+	notFoundApplicationAuthenticationDelete := ErrorHandlingContext(ApplicationAuthenticationDelete)
+	err := notFoundApplicationAuthenticationDelete(c)
 	if err != nil {
 		t.Error(err)
 	}
 
 	templates.NotFoundTest(t, rec)
+}
+
+func TestApplicationAuthenticationDeleteBadRequest(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodDelete,
+		"/api/sources/v3.1/application_authentications/xxx",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+	c.SetParamNames("id")
+	c.SetParamValues("xxx")
+
+	badRequestApplicationAuthenticationDelete := ErrorHandlingContext(ApplicationAuthenticationDelete)
+	err := badRequestApplicationAuthenticationDelete(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.BadRequestTest(t, rec)
 }

--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -52,7 +52,7 @@ func TestApplicationAuthenticationList(t *testing.T) {
 		t.Error("offset not set correctly")
 	}
 
-	if len(out.Data) != 1 {
+	if len(out.Data) != len(fixtures.TestApplicationAuthenticationData) {
 		t.Error("not enough objects passed back from DB")
 	}
 
@@ -268,6 +268,33 @@ func TestApplicationAuthenticationCreateBadAuthId(t *testing.T) {
 	}
 
 	templates.BadRequestTest(t, rec)
+}
+
+func TestApplicationAuthenticationDelete(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodDelete,
+		"/api/sources/v3.1/application_authentications/300",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+	c.SetParamNames("id")
+	c.SetParamValues("300")
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	err := ApplicationAuthenticationDelete(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("Did not return 204. Body: %s", rec.Body.String())
+	}
+
+	if rec.Body.Len() != 0 {
+		t.Errorf("Response body is not nil")
+	}
 }
 
 func TestApplicationAuthenticationDeleteNotFound(t *testing.T) {

--- a/internal/testutils/fixtures/application_authentication.go
+++ b/internal/testutils/fixtures/application_authentication.go
@@ -15,4 +15,12 @@ var TestApplicationAuthenticationData = []m.ApplicationAuthentication{
 		AuthenticationID:  1,
 		AuthenticationUID: TestAuthenticationData[0].ID,
 	},
+	{
+		ID:                300,
+		VaultPath:         fmt.Sprintf("Application_%d_%v", TestTenantData[0].Id, TestAuthenticationData[3].ID),
+		TenantID:          TestTenantData[0].Id,
+		ApplicationID:     4,
+		AuthenticationID:  5,
+		AuthenticationUID: TestAuthenticationData[3].ID,
+	},
 }

--- a/internal/testutils/fixtures/authentication.go
+++ b/internal/testutils/fixtures/authentication.go
@@ -36,6 +36,15 @@ var TestAuthenticationData = []m.Authentication{
 		ResourceID:         1,
 		AvailabilityStatus: &availabilityStatus,
 	},
+	{
+		ID:                 "1683629d-b830-4542-8842-308525cb7004",
+		DbID:               5,
+		TenantID:           TestTenantData[0].Id,
+		SourceID:           2,
+		ResourceType:       "Application",
+		ResourceID:         4,
+		AvailabilityStatus: &availabilityStatus,
+	},
 }
 
 var TestAuthenticationVaultData = map[string]interface{}{


### PR DESCRIPTION
Added missing tests for ApplicationAuthenticationDelete()

**LINKS:** [RHCLOUD-19248](https://issues.redhat.com/browse/RHCLOUD-19248)