### PR TITLE
Refactor: use rxhidentity everywhere

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 func TestSourceApplicationSubcollectionList(t *testing.T) {
@@ -528,7 +529,7 @@ func TestApplicationEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("accountNumber", fixtures.TestTenantData[0].ExternalTenant)
+	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	appEditHandlerWithNotifier := middleware.Notifier(ApplicationEdit)
 	err := appEditHandlerWithNotifier(c)

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/go-cmp/cmp"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 func TestAuthenticationList(t *testing.T) {
@@ -291,7 +292,7 @@ func TestAuthenticationEdit(t *testing.T) {
 		c.SetParamValues(id)
 	}
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("accountNumber", fixtures.TestTenantData[0].ExternalTenant)
+	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	authEditHandlerWithNotifier := middleware.Notifier(AuthenticationEdit)
 	err = authEditHandlerWithNotifier(c)

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 func TestSourceEndpointSubcollectionList(t *testing.T) {
@@ -437,7 +438,7 @@ func TestEndpointEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("accountNumber", fixtures.TestTenantData[0].ExternalTenant)
+	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(EndpointEdit)
 	err := sourceEditHandlerWithNotifier(c)

--- a/internal/testutils/mocks/mock_notification_producer.go
+++ b/internal/testutils/mocks/mock_notification_producer.go
@@ -1,16 +1,21 @@
 package mocks
 
-import m "github.com/RedHatInsights/sources-api-go/model"
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
 
 type MockAvailabilityStatusNotificationProducer struct {
 	EmitAvailabilityStatusCallCounter int
 	AccountNumber                     string
+	OrgId                             string
 	EmailNotificationInfo             *m.EmailNotificationInfo
 }
 
-func (producer *MockAvailabilityStatusNotificationProducer) EmitAvailabilityStatusNotification(accountNumber string, emailNotificationInfo *m.EmailNotificationInfo) error {
+func (producer *MockAvailabilityStatusNotificationProducer) EmitAvailabilityStatusNotification(id *identity.Identity, emailNotificationInfo *m.EmailNotificationInfo) error {
 	producer.EmitAvailabilityStatusCallCounter++
 	producer.EmailNotificationInfo = emailNotificationInfo
-	producer.AccountNumber = accountNumber
+	producer.AccountNumber = id.AccountNumber
+	producer.OrgId = id.OrgID
 	return nil
 }

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -59,8 +59,8 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 	s := mocks.MockSender{}
 	service.Producer = events.EventStreamProducer{Sender: &s}
 	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
-		"psk-account":   "1234",
-		"x-rh-identity": "asdfasdf",
+		"x-rh-sources-psk": "1234",
+		"x-rh-identity":    "asdfasdf",
 	})
 
 	f := raiseMiddleware(func(c echo.Context) error {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -49,8 +49,6 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 
 			// store the parsed header for later usage.
 			c.Set("identity", xRhIdentity)
-			// store the psk to pass along in headers
-			c.Set("psk-account", xRhIdentity.Identity.AccountNumber)
 
 			// store whether or not this a cert-auth based request
 			if xRhIdentity.Identity.System != nil && xRhIdentity.Identity.System["cn"] != nil {

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -25,6 +25,7 @@ func TestParseAll(t *testing.T) {
 
 	c.Request().Header.Set("x-rh-identity", xrhid)
 	c.Request().Header.Set("x-rh-sources-psk", "1234")
+	c.Request().Header.Set("x-rh-sources-account-number", "1a2b3c4d5e")
 	c.Request().Header.Set("x-rh-sources-org-id", "abcde")
 
 	err := parseOrElse204(c)
@@ -40,8 +41,7 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
 	}
 
-	// Gets set from the xrhid's account number.
-	if c.Get("psk-account").(string) != "12345" {
+	if c.Get("psk-account").(string) != "1a2b3c4d5e" {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get("psk-account").(string), "9876")
 	}
 

--- a/middleware/notifier.go
+++ b/middleware/notifier.go
@@ -6,6 +6,7 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
@@ -19,13 +20,13 @@ func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
 			return fmt.Errorf("unable to find emailNotificationInfo instance in middleware")
 		}
 
-		accountNumber, ok := c.Get("accountNumber").(string)
+		xRhIdentity, ok := c.Get("identity").(*identity.XRHID)
 		if !ok {
-			return fmt.Errorf("failed to cast account-number to string")
+			return fmt.Errorf("failed to fetch the identity header")
 		}
 
 		if emailNotificationInfo.PreviousAvailabilityStatus != emailNotificationInfo.CurrentAvailabilityStatus {
-			return service.EmitAvailabilityStatusNotification(accountNumber, emailNotificationInfo)
+			return service.EmitAvailabilityStatusNotification(&xRhIdentity.Identity, emailNotificationInfo)
 		}
 
 		return nil

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -37,13 +37,14 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 
 			c.Logger().Debugf("Looking up Tenant ID for account number %v", accountNumber)
 
+			id := identity.Identity{AccountNumber: accountNumber}
 			tenantDao := dao.GetTenantDao()
-			tenantId, err := tenantDao.GetOrCreateTenantID(&identity.Identity{AccountNumber: accountNumber})
+			tenantId, err := tenantDao.GetOrCreateTenantID(&id)
 			if err != nil {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set("accountNumber", accountNumber)
+			c.Set("identity", &id)
 			c.Set("tenantID", tenantId)
 
 		case c.Get("psk-org-id") != nil:
@@ -54,12 +55,14 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 
 			c.Logger().Debugf(`[org_id: %s] Looking up Tenant ID`, orgId)
 
+			id := identity.Identity{OrgID: orgId}
 			tenantDao := dao.GetTenantDao()
-			tenantId, err := tenantDao.GetOrCreateTenantID(&identity.Identity{OrgID: orgId})
+			tenantId, err := tenantDao.GetOrCreateTenantID(&id)
 			if err != nil {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
+			c.Set("identity", &id)
 			c.Set("tenantID", tenantId)
 
 		case c.Get("identity") != nil:
@@ -88,7 +91,6 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set("accountNumber", identity.Identity.AccountNumber)
 			c.Set("tenantID", tenantId)
 
 		default:

--- a/service/events.go
+++ b/service/events.go
@@ -40,8 +40,15 @@ func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) 
 func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	headers := make([]kafka.Header, 0)
 
-	if c.Get("psk-account") != nil {
-		psk, ok := c.Get("psk-account").(string)
+	if c.Get("x-rh-sources-psk") != nil {
+		psk, ok := c.Get("x-rh-sources-psk").(string)
+		if ok {
+			headers = append(headers, kafka.Header{Key: "x-rh-sources-account-number", Value: []byte(psk)})
+		}
+	}
+
+	if c.Get("x-rh-sources-account-number") != nil {
+		psk, ok := c.Get("x-rh-sources-account-number").(string)
 		if ok {
 			headers = append(headers, kafka.Header{Key: "x-rh-sources-account-number", Value: []byte(psk)})
 		}
@@ -67,7 +74,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 			xRhId.Identity.OrgID = orgId
 		}
 
-		psk, pskOk := c.Get("psk-account").(string)
+		psk, pskOk := c.Get("x-rh-sources-psk").(string)
 		if pskOk {
 			xRhId.Identity.AccountNumber = psk
 		}

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -18,7 +18,7 @@ func TestForwadableHeadersPsk(t *testing.T) {
 	testPskAccountValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set("psk-account", testPskAccountValue)
+	context.Set("x-rh-sources-psk", testPskAccountValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -228,7 +228,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	testOrgIdValue := "12345"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set("psk-account", testPskAccountValue)
+	context.Set("x-rh-sources-psk", testPskAccountValue)
 	context.Set("x-rh-sources-org-id", testOrgIdValue)
 
 	// Call the function under test.

--- a/service/notifications.go
+++ b/service/notifications.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	l "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 var NotificationProducer Notifier
@@ -17,7 +18,7 @@ func init() {
 }
 
 type Notifier interface {
-	EmitAvailabilityStatusNotification(accountNumber string, emailNotificationInfo *m.EmailNotificationInfo) error
+	EmitAvailabilityStatusNotification(xRhIdentity *identity.Identity, emailNotificationInfo *m.EmailNotificationInfo) error
 }
 
 type AvailabilityStatusNotifier struct {
@@ -61,12 +62,13 @@ type notificationMessage struct {
 	EventType   string                   `json:"event_type"`
 	Timestamp   string                   `json:"timestamp"`
 	AccountID   string                   `json:"account_id"`
+	OrgId       string                   `json:"org_id"`
 	Context     string                   `json:"context"`
 	Events      []notificationEvent      `json:"events"`
 	Recipients  []notificationRecipients `json:"recipients"`
 }
 
-func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(accountNumber string, emailNotificationInfo *m.EmailNotificationInfo) error {
+func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(id *identity.Identity, emailNotificationInfo *m.EmailNotificationInfo) error {
 	mgr := &kafka.Manager{Config: kafka.Config{
 		KafkaBrokers:   config.Get().KafkaBrokers,
 		ProducerConfig: kafka.ProducerConfig{Topic: notificationTopic},
@@ -93,7 +95,8 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(a
 		Application: application,
 		EventType:   statusEventType,
 		Timestamp:   time.Now().Format(time.RFC3339),
-		AccountID:   accountNumber,
+		AccountID:   id.AccountNumber,
+		OrgId:       id.OrgID,
 		Events:      []notificationEvent{event},
 		Context:     string(context),
 		Recipients:  []notificationRecipients{},
@@ -113,12 +116,12 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(a
 	return nil
 }
 
-func EmitAvailabilityStatusNotification(accountNumber string, emailNotificationInfo *m.EmailNotificationInfo) error {
+func EmitAvailabilityStatusNotification(id *identity.Identity, emailNotificationInfo *m.EmailNotificationInfo) error {
 	l.Log.Infof("[tenant_id: %s][source_id: %s] Publishing status notification status changed from: %s to %s",
 		emailNotificationInfo.TenantID,
 		emailNotificationInfo.SourceID,
 		emailNotificationInfo.PreviousAvailabilityStatus,
 		emailNotificationInfo.CurrentAvailabilityStatus)
 
-	return NotificationProducer.EmitAvailabilityStatusNotification(accountNumber, emailNotificationInfo)
+	return NotificationProducer.EmitAvailabilityStatusNotification(id, emailNotificationInfo)
 }

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 func TestSourceListAuthentications(t *testing.T) {
@@ -851,7 +852,7 @@ func TestSourceEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("accountNumber", fixtures.TestTenantData[0].ExternalTenant)
+	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
 	err := sourceEditHandlerWithNotifier(c)

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -152,7 +152,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		}
 
 		if emailInfo != nil {
-			err = service.EmitAvailabilityStatusNotification(id.AccountNumber, emailInfo.ToEmail(previousStatus))
+			err = service.EmitAvailabilityStatusNotification(id, emailInfo.ToEmail(previousStatus))
 			if err != nil {
 				l.Log.Errorf("unable to emit notification: %v", err)
 			}


### PR DESCRIPTION
The goal of this PR is to remove all traces of `c.Set("accountNumber")` from the code, so that we end up using the standardized `xRhIdentity.Identity´ struct instead. This allows us to:

* Support both EBS account numbers and OrgIds easily, and be able to pass them using a single struct.
* Open the window for any other data that may identify the user, because if the identity struct gets updated, we won't have to change any of the function's signatures.