### PR TITLE
[RHCLOUD-19271] feature: remove the "Catalog" application from sources

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -20,14 +20,6 @@
     quay:
       - quay-encrypted-password
 
-"/insights/platform/catalog":
-  display_name: Automation Services Catalog
-  dependent_applications: []
-  supported_source_types:
-  - ansible-tower
-  supported_authentication_types:
-    ansible-tower:
-    - username_password
 "/insights/platform/cost-management":
   display_name: Cost Management
   dependent_applications: []

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -76,56 +76,6 @@ amazon:
         initialValue: aws
   vendor: Amazon
   icon_url: "/apps/frontend-assets/partners-icons/aws-long.svg"
-ansible-tower:
-  product_name: Red Hat Ansible Automation Platform
-  category: Red Hat
-  vendor: Red Hat
-  icon_url: "/apps/frontend-assets/platform-logos/ansible-automation-platform.svg"
-  schema:
-    authentication:
-    - type: username_password
-      name: Username and password
-      fields:
-      - component: text-field
-        name: authentication.authtype
-        hideField: true
-        initializeOnMount: true
-        initialValue: username_password
-      - component: text-field
-        name: authentication.username
-        label: User name
-        isRequired: true
-        validate:
-        - type: required
-      - component: text-field
-        name: authentication.password
-        label: Secret key
-        type: password
-        isRequired: true
-        validate:
-        - type: required
-    endpoint:
-      title: Ansible Tower endpoint
-      fields:
-      - component: text-field
-        name: endpoint.role
-        hideField: true
-        initializeOnMount: true
-        initialValue: ansible
-      - component: text-field
-        name: url
-        label: URL
-        validate:
-        - type: url
-      - component: switch
-        name: endpoint.verify_ssl
-        label: Verify SSL
-      - component: text-field
-        name: endpoint.certificate_authority
-        label: Certificate Authority
-        condition:
-          when: endpoint.verify_ssl
-          is: true
 google:
   product_name: Google Cloud
   category: Cloud


### PR DESCRIPTION
It seems like this application will no longer be used, so we've been asked to remove it. The related "ansible-tower" source can be removed as well, since there are no other applications compatible with that source.

## Links

[[RHCLOUD-19271]](https://issues.redhat.com/browse/RHCLOUD-19271)