### PR TITLE
Use shutdown channel for all worker pods

### DIFF
--- a/jobs/worker.go
+++ b/jobs/worker.go
@@ -13,47 +13,52 @@ import (
 const workQueue = "sources_api_jobs"
 
 // Runs the worker just consuming off of a redis list
-func Run() {
+func Run(shutdown chan struct{}) {
 	l.Log.Infof("Starting up Background worker listening to redis queue [%v]", workQueue)
 
-	runScheduledJobs()
+	go func() {
+		runScheduledJobs()
 
-	for {
-		// This is a BLocking Pop that will effectively wait forever until
-		// something gets queued.
-		//
-		// Once it does succeed - we check to see if the error is just
-		// `redis.Nil`, in which case things are fine and we continue.
-		val, err := redis.Client.BLPop(context.Background(), 0, workQueue).Result()
-		if err != nil {
-			if !errors.Is(err, redis.Nil) {
-				l.Log.Warnf("Failed to pop job from queue: %v", err)
+		for {
+			// This is a BLocking Pop that will effectively wait forever until
+			// something gets queued.
+			//
+			// Once it does succeed - we check to see if the error is just
+			// `redis.Nil`, in which case things are fine and we continue.
+			val, err := redis.Client.BLPop(context.Background(), 0, workQueue).Result()
+			if err != nil {
+				if !errors.Is(err, redis.Nil) {
+					l.Log.Warnf("Failed to pop job from queue: %v", err)
+				}
+
+				continue
 			}
 
-			continue
-		}
+			jr := JobRequest{}
+			// the val that is returned is a slice in the form [listname, value]
+			// where val[0] is the name of the list (e.g. workQueue above) and
+			// val[1] is the string value, e.g. the output from
+			// jobRequest.MarshalBinary. So we need to unmarshal it.
+			err = jr.UnmarshalBinary([]byte(val[1]))
+			if err != nil {
+				l.Log.Warnf("Failed to unmarshal job from redis: %v", err)
+				continue
+			}
 
-		jr := JobRequest{}
-		// the val that is returned is a slice in the form [listname, value]
-		// where val[0] is the name of the list (e.g. workQueue above) and
-		// val[1] is the string value, e.g. the output from
-		// jobRequest.MarshalBinary. So we need to unmarshal it.
-		err = jr.UnmarshalBinary([]byte(val[1]))
-		if err != nil {
-			l.Log.Warnf("Failed to unmarshal job from redis: %v", err)
-			continue
-		}
+			// Parse is the _very_ important method that looks at the job name and
+			// figures out what kind of job to unmarshal
+			err = jr.Parse()
+			if err != nil {
+				l.Log.Warnf("Failed to unmarshal job from redis: %v", err)
+				continue
+			}
 
-		// Parse is the _very_ important method that looks at the job name and
-		// figures out what kind of job to unmarshal
-		err = jr.Parse()
-		if err != nil {
-			l.Log.Warnf("Failed to unmarshal job from redis: %v", err)
-			continue
+			RunJobAsync(jr.Job)
 		}
+	}()
 
-		RunJobAsync(jr.Job)
-	}
+	<-shutdown
+	shutdown <- struct{}{}
 }
 
 // Run a Job with a delay but in the background so it does _not_ block the

--- a/main.go
+++ b/main.go
@@ -36,9 +36,9 @@ func main() {
 
 	switch {
 	case conf.StatusListener:
-		go statuslistener.Run()
+		go statuslistener.Run(shutdown)
 	case conf.BackgroundWorker:
-		go jobs.Run()
+		go jobs.Run(shutdown)
 	default:
 		// launch 2 listeners - one for metrics and one for the actual application,
 		// one on 8000 and one on 9000 (per clowder)

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -28,9 +28,12 @@ type AvailabilityStatusListener struct {
 	*events.EventStreamProducer
 }
 
-func Run() {
+func Run(shutdown chan struct{}) {
 	avs := AvailabilityStatusListener{EventStreamProducer: NewEventStreamProducer()}
-	avs.subscribeToAvailabilityStatus()
+	go avs.subscribeToAvailabilityStatus()
+
+	<-shutdown
+	shutdown <- struct{}{}
 }
 
 func NewEventStreamProducer() *events.EventStreamProducer {


### PR DESCRIPTION
Noticed this today when doing the promotion. The background + availability status listener pods will sit and wait until killed since they never send a message back on the shutdown channel, this fixes that. 