### PR TITLE
Add ENV variables for unleash's token and url

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -93,7 +93,9 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("FeatureFlagsSchema", string(cfg.FeatureFlags.Scheme))
 
 		clientAccessToken := ""
-		if cfg.FeatureFlags.ClientAccessToken != nil {
+		if os.Getenv("UNLEASH_TOKEN") != "" {
+			clientAccessToken = os.Getenv("UNLEASH_TOKEN")
+		} else if cfg.FeatureFlags.ClientAccessToken != nil {
 			clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
 		}
 
@@ -125,7 +127,7 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("FeatureFlagsHost", os.Getenv("FEATURE_FLAGS_HOST"))
 		options.SetDefault("FeatureFlagsPort", os.Getenv("FEATURE_FLAGS_PORT"))
 		options.SetDefault("FeatureFlagsSchema", os.Getenv("FEATURE_FLAGS_SCHEMA"))
-		options.SetDefault("FeatureFlagsAPIToken", os.Getenv("FEATURE_FLAGS_API_TOKEN"))
+		options.SetDefault("FeatureFlagsAPIToken", os.Getenv("UNLEASH_TOKEN"))
 	}
 
 	options.SetDefault("FeatureFlagsService", os.Getenv("FEATURE_FLAGS_SERVICE"))

--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,12 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("FeatureFlagsPort", cfg.FeatureFlags.Port)
 		options.SetDefault("FeatureFlagsSchema", string(cfg.FeatureFlags.Scheme))
 
-		unleashUrl := fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
+		unleashUrl := ""
+		if os.Getenv("UNLEASH_URL") != "" {
+			unleashUrl = os.Getenv("UNLEASH_URL")
+		} else if cfg.FeatureFlags.ClientAccessToken != nil {
+			unleashUrl = fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
+		}
 		options.SetDefault("FeatureFlagsUrl", unleashUrl)
 
 		clientAccessToken := ""
@@ -99,7 +104,6 @@ func Get() *SourcesApiConfig {
 		} else if cfg.FeatureFlags.ClientAccessToken != nil {
 			clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
 		}
-
 		options.SetDefault("FeatureFlagsAPIToken", clientAccessToken)
 	} else {
 		options.SetDefault("AwsRegion", "us-east-1")

--- a/config/config.go
+++ b/config/config.go
@@ -35,9 +35,7 @@ type SourcesApiConfig struct {
 	DatabasePassword          string
 	DatabaseName              string
 	FeatureFlagsEnvironment   string
-	FeatureFlagsHost          string
-	FeatureFlagsPort          string
-	FeatureFlagsSchema        string
+	FeatureFlagsUrl           string
 	FeatureFlagsAPIToken      string
 	FeatureFlagsService       string
 	CacheHost                 string
@@ -92,6 +90,9 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("FeatureFlagsPort", cfg.FeatureFlags.Port)
 		options.SetDefault("FeatureFlagsSchema", string(cfg.FeatureFlags.Scheme))
 
+		unleashUrl := fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
+		options.SetDefault("FeatureFlagsUrl", unleashUrl)
+
 		clientAccessToken := ""
 		if os.Getenv("UNLEASH_TOKEN") != "" {
 			clientAccessToken = os.Getenv("UNLEASH_TOKEN")
@@ -123,10 +124,7 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("CacheHost", os.Getenv("REDIS_CACHE_HOST"))
 		options.SetDefault("CachePort", os.Getenv("REDIS_CACHE_PORT"))
 		options.SetDefault("CachePassword", os.Getenv("REDIS_CACHE_PASSWORD"))
-
-		options.SetDefault("FeatureFlagsHost", os.Getenv("FEATURE_FLAGS_HOST"))
-		options.SetDefault("FeatureFlagsPort", os.Getenv("FEATURE_FLAGS_PORT"))
-		options.SetDefault("FeatureFlagsSchema", os.Getenv("FEATURE_FLAGS_SCHEMA"))
+		options.SetDefault("FeatureFlagsUrl", os.Getenv("FEATURE_FLAGS_URL"))
 		options.SetDefault("FeatureFlagsAPIToken", os.Getenv("UNLEASH_TOKEN"))
 	}
 
@@ -208,11 +206,9 @@ func Get() *SourcesApiConfig {
 		DatabaseUser:              options.GetString("DatabaseUser"),
 		DatabasePassword:          options.GetString("DatabasePassword"),
 		DatabaseName:              options.GetString("DatabaseName"),
-		FeatureFlagsHost:          options.GetString("FeatureFlagsHost"),
 		FeatureFlagsEnvironment:   options.GetString("FeatureFlagsEnvironment"),
-		FeatureFlagsPort:          options.GetString("FeatureFlagsPort"),
+		FeatureFlagsUrl:           options.GetString("FeatureFlagsUrl"),
 		FeatureFlagsAPIToken:      options.GetString("FeatureFlagsAPIToken"),
-		FeatureFlagsSchema:        options.GetString("FeatureFlagsSchema"),
 		FeatureFlagsService:       options.GetString("FeatureFlagsService"),
 		CacheHost:                 options.GetString("CacheHost"),
 		CachePort:                 options.GetInt("CachePort"),

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -29,6 +29,13 @@ objects:
       app: sources-api
   stringData:
     psk: "thisMustBeEphemeralOrMinikube"
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: unleash-ephemeral
+  type: Opaque
+  data:
+    CLIENT_ACCESS_TOKEN: ''
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
@@ -135,6 +142,13 @@ objects:
               optional: true
         - name: FEATURE_FLAGS_SERVICE
           value: ${FEATURE_FLAGS_SERVICE}
+        - name: UNLEASH_URL
+          value: ${UNLEASH_URL}
+        - name: UNLEASH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${UNLEASH_SECRET_NAME}
+              key: CLIENT_ACCESS_TOKEN
         readinessProbe:
           tcpSocket:
             port: 8000
@@ -319,3 +333,10 @@ parameters:
 - description: Specify name of service for Feature Flags
   name: FEATURE_FLAGS_SERVICE
   value: 'unleash'
+- description: Unleash API url
+  name: UNLEASH_URL
+  value: ''
+- description: Unleash secret name
+  name: UNLEASH_SECRET_NAME
+  value: unleash-ephemeral
+

--- a/service/feature_flags.go
+++ b/service/feature_flags.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -55,10 +54,9 @@ func init() {
 			logging.Log.Warnf("FeatureFlagsAPIToken is empty")
 		}
 
-		unleashUrl := fmt.Sprintf("%s://%s:%s/api", conf.FeatureFlagsSchema, conf.FeatureFlagsHost, conf.FeatureFlagsPort)
 		unleashConfig := []unleash.ConfigOption{unleash.WithAppName(appName),
 			unleash.WithListener(&FeatureFlagListener{}),
-			unleash.WithUrl(unleashUrl),
+			unleash.WithUrl(conf.FeatureFlagsUrl),
 			unleash.WithEnvironment(conf.FeatureFlagsEnvironment),
 			unleash.WithRefreshInterval(refreshInterval * time.Second),
 			unleash.WithMetricsInterval(metricsInterval * time.Second),


### PR DESCRIPTION
There are 2 ways to get access token for unleash token.

1. From ENV vars. inspiration here: https://gitlab.cee.redhat.com/automation-analytics/automation-analytics-backend/-/blob/main/saas-templates/clowderapp.yaml#L24-30
2. From clowder loaded config 

Currently as 2. is not working in stage and I set preference for point 2 in code.