### PR TITLE
[RHCLOUD-19336] fix: "failed to pull identity from request" when using PSK and EBS

### DIFF
--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -37,14 +37,21 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 
 			c.Logger().Debugf("Looking up Tenant ID for account number %v", accountNumber)
 
-			id := identity.Identity{AccountNumber: accountNumber}
+			// Use the whole "XRHID" struct for consistency, since many other parts in the code are expecting the
+			// "identity" context variable to have this struct.
+			id := &identity.XRHID{
+				Identity: identity.Identity{
+					AccountNumber: accountNumber,
+				},
+			}
+
 			tenantDao := dao.GetTenantDao()
-			tenantId, err := tenantDao.GetOrCreateTenantID(&id)
+			tenantId, err := tenantDao.GetOrCreateTenantID(&id.Identity)
 			if err != nil {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set("identity", &id)
+			c.Set("identity", id)
 			c.Set("tenantID", tenantId)
 
 		case c.Get("psk-org-id") != nil:
@@ -55,14 +62,21 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 
 			c.Logger().Debugf(`[org_id: %s] Looking up Tenant ID`, orgId)
 
-			id := identity.Identity{OrgID: orgId}
+			// Use the whole "XRHID" struct for consistency, since many other parts in the code are expecting the
+			// "identity" context variable to have this struct.
+			id := &identity.XRHID{
+				Identity: identity.Identity{
+					OrgID: orgId,
+				},
+			}
+
 			tenantDao := dao.GetTenantDao()
-			tenantId, err := tenantDao.GetOrCreateTenantID(&id)
+			tenantId, err := tenantDao.GetOrCreateTenantID(&id.Identity)
 			if err != nil {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set("identity", &id)
+			c.Set("identity", id)
 			c.Set("tenantID", tenantId)
 
 		case c.Get("identity") != nil:

--- a/util/identity_header.go
+++ b/util/identity_header.go
@@ -3,24 +3,13 @@ package util
 import (
 	"encoding/base64"
 	"encoding/json"
+
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-type minimalIdentityHeader struct {
-	Identity id `json:"identity"`
-}
-
-type id struct {
-	Account string `json:"account_number"`
-}
-
-func newMinimalIdentity(account string) *minimalIdentityHeader {
-	return &minimalIdentityHeader{Identity: id{Account: account}}
-}
-
-// returns a base64 encoded header to use as x-rh-identity when one is not
-// provided
+// XRhIdentityWithAccountNumber returns a base64 encoded header to use as x-rh-identity when one is not provided
 func XRhIdentityWithAccountNumber(account string) string {
-	bytes, err := json.Marshal(newMinimalIdentity(account))
+	bytes, err := json.Marshal(identity.XRHID{Identity: identity.Identity{AccountNumber: account}})
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
When using the PSK and the EBS account number headers, the tenancy middleware overwrote the "identity" context value with an "Identity" struct, instead of an "XHRID" one. That caused the "bulk create" operation to not be able to pull the expected "XHRID" struct from the context, and therefore return the aforementioned error.

## Links

[[RHCLOUD-19336]](https://issues.redhat.com/browse/RHCLOUD-19336)