### PR TITLE
Fix up forwardable headers to always include as many headers as possible

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1174,9 +1174,17 @@ func applicationEventTestHelper(t *testing.T, c echo.Context, expectedEventType 
 	}
 
 	{
+		var h kafka.Header
+		for _, header := range headers {
+			if header.Key == "event_type" {
+				h = header
+				break
+			}
+
+		}
 		// The header should contain the expected event type as well.
 		want := expectedEventType
-		got := string(headers[0].Value)
+		got := string(h.Value)
 		if want != got {
 			t.Errorf(`incorrect header on raise event. Want "%s", got "%s"`, want, got)
 			return errors.New(`incorrect header on raise event`)

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/labstack/echo/v4"
@@ -18,16 +18,16 @@ func BulkCreate(c echo.Context) error {
 		return err
 	}
 
-	tenantID, ok := c.Get(fields.TENANTID).(int64)
+	tenantID, ok := c.Get(h.TENANTID).(int64)
 	if !ok {
 		return fmt.Errorf("failed to pull tenant from request")
 	}
 
-	xrhid, ok := c.Get(fields.XRHID).(string)
+	xrhid, ok := c.Get(h.XRHID).(string)
 	if !ok {
-		c.Logger().Warnf("bad xrhid %v", c.Get(fields.XRHID))
+		c.Logger().Warnf("bad xrhid %v", c.Get(h.XRHID))
 	}
-	id, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
 	if !ok {
 		c.Logger().Warnf("failed to pull identity from request")
 		return fmt.Errorf("failed to pull identity from request")

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/labstack/echo/v4"
@@ -17,16 +18,16 @@ func BulkCreate(c echo.Context) error {
 		return err
 	}
 
-	tenantID, ok := c.Get("tenantID").(int64)
+	tenantID, ok := c.Get(fields.TENANTID).(int64)
 	if !ok {
 		return fmt.Errorf("failed to pull tenant from request")
 	}
 
-	xrhid, ok := c.Get("x-rh-identity").(string)
+	xrhid, ok := c.Get(fields.XRHID).(string)
 	if !ok {
-		c.Logger().Warnf("bad xrhid %v", c.Get("x-rh-identity"))
+		c.Logger().Warnf("bad xrhid %v", c.Get(fields.XRHID))
 	}
-	id, ok := c.Get("identity").(*identity.XRHID)
+	id, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
 	if !ok {
 		c.Logger().Warnf("failed to pull identity from request")
 		return fmt.Errorf("failed to pull identity from request")

--- a/graphql_handlers.go
+++ b/graphql_handlers.go
@@ -21,8 +21,8 @@ import (
 var (
 	// the graphql handler server - initialized in the init() function below
 	srv *handler.Server
-	// the wrapped handler function for graphql
-	h echo.HandlerFunc
+	// the wrapped wrapper function for graphql
+	wrapper echo.HandlerFunc
 
 	// this is the uri to hit "old" sources api, initialized in the init() function
 	legacyUri string
@@ -38,7 +38,7 @@ func init() {
 		srv.Use(extension.Introspection{})
 	}
 
-	h = echo.WrapHandler(srv)
+	wrapper = echo.WrapHandler(srv)
 
 	// set the default host/port to what we'll see in k8s environments. Override
 	// this by setting these values locally
@@ -90,7 +90,7 @@ func GraphQLQuery(c echo.Context) error {
 		)),
 	)
 
-	return h(c)
+	return wrapper(c)
 }
 
 // this handler proxies the graphql request body + headers included over to the

--- a/helpers.go
+++ b/helpers.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
@@ -82,7 +83,7 @@ func setEventStreamResource(c echo.Context, model m.Event) {
 // getTenantFromEchoContext tries to extract the tenant from the echo context. If the "tenantID" is missing from the
 // context, then a default value and nil are returned as the int64 and error values.
 func getTenantFromEchoContext(c echo.Context) (int64, error) {
-	tenantValue := c.Get("tenantID")
+	tenantValue := c.Get(fields.TENANTID)
 
 	// If no tenant is found in the context, that shouldn't imply an error.
 	if tenantValue == nil {
@@ -102,7 +103,7 @@ func getTenantFromEchoContext(c echo.Context) (int64, error) {
 }
 
 func getAccountNumberFromEchoContext(c echo.Context) (string, error) {
-	id, ok := c.Get("identity").(*identity.XRHID)
+	id, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
 	if !ok {
 		return "", fmt.Errorf("failed to pull identity from context")
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
@@ -83,7 +83,7 @@ func setEventStreamResource(c echo.Context, model m.Event) {
 // getTenantFromEchoContext tries to extract the tenant from the echo context. If the "tenantID" is missing from the
 // context, then a default value and nil are returned as the int64 and error values.
 func getTenantFromEchoContext(c echo.Context) (int64, error) {
-	tenantValue := c.Get(fields.TENANTID)
+	tenantValue := c.Get(h.TENANTID)
 
 	// If no tenant is found in the context, that shouldn't imply an error.
 	if tenantValue == nil {
@@ -103,7 +103,7 @@ func getTenantFromEchoContext(c echo.Context) (int64, error) {
 }
 
 func getAccountNumberFromEchoContext(c echo.Context) (string, error) {
-	id, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
 	if !ok {
 		return "", fmt.Errorf("failed to pull identity from context")
 	}

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/RedHatInsights/rbac-client-go"
 	"github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -35,21 +36,21 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 		switch {
 		case bypassRbac:
 			c.Logger().Debugf("Skipping authorization check -- disabled in ENV")
-		case c.Get("psk") != nil:
-			psk, ok := c.Get("psk").(string)
+		case c.Get(fields.PSK) != nil:
+			psk, ok := c.Get(fields.PSK).(string)
 			if !ok {
-				return fmt.Errorf("error casting psk to string: %v", c.Get("psk"))
+				return fmt.Errorf("error casting psk to string: %v", c.Get(fields.PSK))
 			}
 
 			if !pskMatches(psk) {
 				return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Unauthorized Action: Incorrect PSK", "401"))
 			}
 
-		case c.Get("x-rh-identity") != nil:
+		case c.Get(fields.XRHID) != nil:
 			// first check the identity (already parsed) to see if it contains
 			// the system key and if it does do some extra checks to authorize
 			// based on some internal rules (operator + satellite)
-			identity, ok := c.Get("identity").(*identity.XRHID)
+			identity, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("error casting identity to struct: %+v", c.Get("identity"))
 			}
@@ -80,7 +81,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 
 			// otherwise, ship the xrhid off to rbac and check access rights.
-			rhid, ok := c.Get("x-rh-identity").(string)
+			rhid, ok := c.Get(fields.XRHID).(string)
 			if !ok {
 				return fmt.Errorf("error casting x-rh-identity to string: %v", c.Get("x-rh-identity"))
 			}

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -54,7 +54,7 @@ func TestGoodPSK(t *testing.T) {
 		http.MethodPost,
 		"/",
 		nil,
-		map[string]interface{}{fields.PSK: "1234"},
+		map[string]interface{}{h.PSK: "1234"},
 	)
 
 	err := permCheckOrElse204(c)
@@ -73,7 +73,7 @@ func TestBadPSK(t *testing.T) {
 		http.MethodPost,
 		"/",
 		nil,
-		map[string]interface{}{fields.PSK: "1234"},
+		map[string]interface{}{h.PSK: "1234"},
 	)
 
 	err := permCheckOrElse204(c)

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -53,7 +54,7 @@ func TestGoodPSK(t *testing.T) {
 		http.MethodPost,
 		"/",
 		nil,
-		map[string]interface{}{"psk": "1234"},
+		map[string]interface{}{fields.PSK: "1234"},
 	)
 
 	err := permCheckOrElse204(c)
@@ -72,7 +73,7 @@ func TestBadPSK(t *testing.T) {
 		http.MethodPost,
 		"/",
 		nil,
-		map[string]interface{}{"psk": "1234"},
+		map[string]interface{}{fields.PSK: "1234"},
 	)
 
 	err := permCheckOrElse204(c)

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -60,7 +60,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 	service.Producer = events.EventStreamProducer{Sender: &s}
 	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
 		"x-rh-sources-psk": "1234",
-		"x-rh-identity":    "asdfasdf",
+		"x-rh-identity":    util.GeneratedXRhIdentity("1234", "1234"),
 	})
 
 	f := raiseMiddleware(func(c echo.Context) error {
@@ -85,11 +85,11 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Wrong number of Hits to raise event, got %v expected %v", s.Hit, 1)
 	}
 
-	if len(s.Headers) != 3 {
+	if len(s.Headers) != 4 {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", "x-rh-identity", "x-rh-sources-account-number"}
+	expected := []string{"event_type", "x-rh-identity", "x-rh-sources-account-number", "x-rh-sources-org-id"}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/fields/fields.go
+++ b/middleware/fields/fields.go
@@ -1,0 +1,10 @@
+package fields
+
+const (
+	PSK             = "x-rh-sources-psk"
+	ACCOUNT_NUMBER  = "x-rh-sources-account-number"
+	ORGID           = "x-rh-sources-org-id"
+	XRHID           = "x-rh-identity"
+	PARSED_IDENTITY = "identity"
+	TENANTID        = "tenantID"
+)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
@@ -26,30 +26,30 @@ import (
 func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// the PSK related headers - just storing them as raw strings.
-		if c.Request().Header.Get(fields.PSK) != "" {
-			c.Set(fields.PSK, c.Request().Header.Get(fields.PSK))
+		if c.Request().Header.Get(h.PSK) != "" {
+			c.Set(h.PSK, c.Request().Header.Get(h.PSK))
 		}
 
-		if c.Request().Header.Get(fields.ACCOUNT_NUMBER) != "" {
-			c.Set(fields.ACCOUNT_NUMBER, c.Request().Header.Get(fields.ACCOUNT_NUMBER))
+		if c.Request().Header.Get(h.ACCOUNT_NUMBER) != "" {
+			c.Set(h.ACCOUNT_NUMBER, c.Request().Header.Get(h.ACCOUNT_NUMBER))
 		}
 
-		if c.Request().Header.Get(fields.ORGID) != "" {
-			c.Set(fields.ORGID, c.Request().Header.Get(fields.ORGID))
+		if c.Request().Header.Get(h.ORGID) != "" {
+			c.Set(h.ORGID, c.Request().Header.Get(h.ORGID))
 		}
 
 		// parsing the base64-encoded identity header if present
-		if c.Request().Header.Get(fields.XRHID) != "" {
+		if c.Request().Header.Get(h.XRHID) != "" {
 			// store it raw first.
-			c.Set(fields.XRHID, c.Request().Header.Get(fields.XRHID))
+			c.Set(h.XRHID, c.Request().Header.Get(h.XRHID))
 
-			xRhIdentity, err := util.ParseXRHIDHeader(c.Request().Header.Get(fields.XRHID))
+			xRhIdentity, err := util.ParseXRHIDHeader(c.Request().Header.Get(h.XRHID))
 			if err != nil {
 				return fmt.Errorf("could not extract identity from header: %s", err)
 			}
 
 			// store the parsed header for later usage.
-			c.Set(fields.PARSED_IDENTITY, xRhIdentity)
+			c.Set(h.PARSED_IDENTITY, xRhIdentity)
 
 			// store whether or not this a cert-auth based request
 			if xRhIdentity.Identity.System != nil && xRhIdentity.Identity.System["cn"] != nil {
@@ -57,19 +57,19 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 		} else {
 			dummyIdentity := util.GeneratedXRhIdentity(
-				c.Request().Header.Get(fields.ACCOUNT_NUMBER),
-				c.Request().Header.Get(fields.ORGID),
+				c.Request().Header.Get(h.ACCOUNT_NUMBER),
+				c.Request().Header.Get(h.ORGID),
 			)
 
 			// backup xrhid from account number (in case of psk auth)
-			c.Set(fields.XRHID, dummyIdentity)
+			c.Set(h.XRHID, dummyIdentity)
 
 			// store the parsed header for later usage.
 			id, err := util.ParseXRHIDHeader(dummyIdentity)
 			if err != nil {
 				return err
 			}
-			c.Set(fields.PARSED_IDENTITY, id)
+			c.Set(h.PARSED_IDENTITY, id)
 		}
 
 		return next(c)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -55,7 +55,10 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 				c.Set("cert-auth", true)
 			}
 		} else {
-			dummyIdentity := util.XRhIdentityWithAccountNumber(c.Request().Header.Get("x-rh-sources-account-number"))
+			dummyIdentity := util.GeneratedXRhIdentity(
+				c.Request().Header.Get("x-rh-sources-account-number"),
+				c.Request().Header.Get("x-rh-sources-org-id"),
+			)
 
 			// backup xrhid from account number (in case of psk auth)
 			c.Set("x-rh-identity", dummyIdentity)

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -1,4 +1,4 @@
-package fields
+package headers
 
 const (
 	PSK             = "x-rh-sources-psk"

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -24,10 +24,10 @@ func TestParseAll(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(fields.XRHID, xrhid)
-	c.Request().Header.Set(fields.PSK, "1234")
-	c.Request().Header.Set(fields.ACCOUNT_NUMBER, "1a2b3c4d5e")
-	c.Request().Header.Set(fields.ORGID, "abcde")
+	c.Request().Header.Set(h.XRHID, xrhid)
+	c.Request().Header.Set(h.PSK, "1234")
+	c.Request().Header.Set(h.ACCOUNT_NUMBER, "1a2b3c4d5e")
+	c.Request().Header.Set(h.ORGID, "abcde")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -38,19 +38,19 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(fields.PSK).(string) != "1234" {
-		t.Errorf("%v was set as psk instead of %v", c.Get(fields.PSK).(string), "1234")
+	if c.Get(h.PSK).(string) != "1234" {
+		t.Errorf("%v was set as psk instead of %v", c.Get(h.PSK).(string), "1234")
 	}
 
-	if c.Get(fields.ACCOUNT_NUMBER).(string) != "1a2b3c4d5e" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(fields.ACCOUNT_NUMBER).(string), "9876")
+	if c.Get(h.ACCOUNT_NUMBER).(string) != "1a2b3c4d5e" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
 	}
 
-	if c.Get(fields.ORGID).(string) != "abcde" {
-		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(fields.ORGID).(string))
+	if c.Get(h.ORGID).(string) != "abcde" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.ORGID).(string))
 	}
 
-	id, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
 	if !ok {
 		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
 	}
@@ -68,7 +68,7 @@ func TestParseAccountNumber(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(fields.ACCOUNT_NUMBER, "9876")
+	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -79,8 +79,8 @@ func TestParseAccountNumber(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(fields.ACCOUNT_NUMBER).(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(fields.ACCOUNT_NUMBER).(string), "9876")
+	if c.Get(h.ACCOUNT_NUMBER).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
 	}
 }
 
@@ -92,7 +92,7 @@ func TestBadIdentityBase64(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(fields.XRHID, "not valid base64")
+	c.Request().Header.Set(h.XRHID, "not valid base64")
 
 	err := parseOrElse204(c)
 	if err == nil {
@@ -118,7 +118,7 @@ func TestBadIdentityJson(t *testing.T) {
 	)
 
 	// base64 for: {"not a real field": true}
-	c.Request().Header.Set(fields.XRHID, "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
+	c.Request().Header.Set(h.XRHID, "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
 
 	err := parseOrElse204(c)
 	if err == nil {
@@ -143,8 +143,8 @@ func TestOnlyPskHeaders(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(fields.PSK, "1234")
-	c.Request().Header.Set(fields.ACCOUNT_NUMBER, "9876")
+	c.Request().Header.Set(h.PSK, "1234")
+	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -155,11 +155,11 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(fields.PSK).(string) != "1234" {
+	if c.Get(h.PSK).(string) != "1234" {
 		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
 	}
 
-	if c.Get(fields.ACCOUNT_NUMBER).(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(fields.ACCOUNT_NUMBER).(string), "9876")
+	if c.Get(h.ACCOUNT_NUMBER).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
 	}
 }

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -23,10 +24,10 @@ func TestParseAll(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set("x-rh-identity", xrhid)
-	c.Request().Header.Set("x-rh-sources-psk", "1234")
-	c.Request().Header.Set("x-rh-sources-account-number", "1a2b3c4d5e")
-	c.Request().Header.Set("x-rh-sources-org-id", "abcde")
+	c.Request().Header.Set(fields.XRHID, xrhid)
+	c.Request().Header.Set(fields.PSK, "1234")
+	c.Request().Header.Set(fields.ACCOUNT_NUMBER, "1a2b3c4d5e")
+	c.Request().Header.Set(fields.ORGID, "abcde")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -37,19 +38,19 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get("psk").(string) != "1234" {
-		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
+	if c.Get(fields.PSK).(string) != "1234" {
+		t.Errorf("%v was set as psk instead of %v", c.Get(fields.PSK).(string), "1234")
 	}
 
-	if c.Get("psk-account").(string) != "1a2b3c4d5e" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get("psk-account").(string), "9876")
+	if c.Get(fields.ACCOUNT_NUMBER).(string) != "1a2b3c4d5e" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(fields.ACCOUNT_NUMBER).(string), "9876")
 	}
 
-	if c.Get("psk-org-id").(string) != "abcde" {
-		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get("x-rh-sources-org-id").(string))
+	if c.Get(fields.ORGID).(string) != "abcde" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(fields.ORGID).(string))
 	}
 
-	id, ok := c.Get("identity").(*identity.XRHID)
+	id, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
 	if !ok {
 		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
 	}
@@ -67,7 +68,7 @@ func TestParseAccountNumber(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set("x-rh-sources-account-number", "9876")
+	c.Request().Header.Set(fields.ACCOUNT_NUMBER, "9876")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -78,8 +79,8 @@ func TestParseAccountNumber(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get("psk-account").(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get("psk-account").(string), "9876")
+	if c.Get(fields.ACCOUNT_NUMBER).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(fields.ACCOUNT_NUMBER).(string), "9876")
 	}
 }
 
@@ -91,7 +92,7 @@ func TestBadIdentityBase64(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set("x-rh-identity", "not valid base64")
+	c.Request().Header.Set(fields.XRHID, "not valid base64")
 
 	err := parseOrElse204(c)
 	if err == nil {
@@ -117,7 +118,7 @@ func TestBadIdentityJson(t *testing.T) {
 	)
 
 	// base64 for: {"not a real field": true}
-	c.Request().Header.Set("x-rh-identity", "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
+	c.Request().Header.Set(fields.XRHID, "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
 
 	err := parseOrElse204(c)
 	if err == nil {
@@ -142,8 +143,8 @@ func TestOnlyPskHeaders(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set("x-rh-sources-psk", "1234")
-	c.Request().Header.Set("x-rh-sources-account-number", "9876")
+	c.Request().Header.Set(fields.PSK, "1234")
+	c.Request().Header.Set(fields.ACCOUNT_NUMBER, "9876")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -154,11 +155,11 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get("psk").(string) != "1234" {
+	if c.Get(fields.PSK).(string) != "1234" {
 		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
 	}
 
-	if c.Get("psk-account").(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get("psk-account").(string), "9876")
+	if c.Get(fields.ACCOUNT_NUMBER).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(fields.ACCOUNT_NUMBER).(string), "9876")
 	}
 }

--- a/middleware/notifier.go
+++ b/middleware/notifier.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"fmt"
 
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/labstack/echo/v4"
@@ -20,7 +21,7 @@ func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
 			return fmt.Errorf("unable to find emailNotificationInfo instance in middleware")
 		}
 
-		xRhIdentity, ok := c.Get("identity").(*identity.XRHID)
+		xRhIdentity, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
 		if !ok {
 			return fmt.Errorf("failed to fetch the identity header")
 		}

--- a/middleware/notifier.go
+++ b/middleware/notifier.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"fmt"
 
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/labstack/echo/v4"
@@ -21,7 +21,7 @@ func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
 			return fmt.Errorf("unable to find emailNotificationInfo instance in middleware")
 		}
 
-		xRhIdentity, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
+		xRhIdentity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
 		if !ok {
 			return fmt.Errorf("failed to fetch the identity header")
 		}

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/jobs"
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
@@ -23,7 +23,7 @@ import (
 */
 func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(fields.TENANTID).(int64)
+		tenantId, ok := c.Get(h.TENANTID).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
@@ -36,7 +36,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 		s := dao.GetSourceDao(&tenantId)
 
 		if s.IsSuperkey(id) {
-			xrhid, ok := c.Get(fields.XRHID).(string)
+			xrhid, ok := c.Get(h.XRHID).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}
@@ -63,7 +63,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 
 func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(fields.TENANTID).(int64)
+		tenantId, ok := c.Get(h.TENANTID).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
@@ -76,7 +76,7 @@ func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 		a := dao.GetApplicationDao(&tenantId)
 
 		if a.IsSuperkey(id) {
-			xrhid, ok := c.Get(fields.XRHID).(string)
+			xrhid, ok := c.Get(h.XRHID).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/jobs"
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
@@ -22,7 +23,7 @@ import (
 */
 func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get("tenantID").(int64)
+		tenantId, ok := c.Get(fields.TENANTID).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
@@ -35,7 +36,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 		s := dao.GetSourceDao(&tenantId)
 
 		if s.IsSuperkey(id) {
-			xrhid, ok := c.Get("x-rh-identity").(string)
+			xrhid, ok := c.Get(fields.XRHID).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}
@@ -62,7 +63,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 
 func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get("tenantID").(int64)
+		tenantId, ok := c.Get(fields.TENANTID).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
@@ -75,7 +76,7 @@ func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 		a := dao.GetApplicationDao(&tenantId)
 
 		if a.IsSuperkey(id) {
-			xrhid, ok := c.Get("x-rh-identity").(string)
+			xrhid, ok := c.Get(fields.XRHID).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/gommon/log"
@@ -29,8 +30,8 @@ import (
 func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		switch {
-		case c.Get("psk-account") != nil:
-			accountNumber, ok := c.Get("psk-account").(string)
+		case c.Get(fields.ACCOUNT_NUMBER) != nil:
+			accountNumber, ok := c.Get(fields.ACCOUNT_NUMBER).(string)
 			if !ok {
 				return fmt.Errorf("failed to cast account-number to string")
 			}
@@ -51,11 +52,11 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set("identity", id)
-			c.Set("tenantID", tenantId)
+			c.Set(fields.PARSED_IDENTITY, id)
+			c.Set(fields.TENANTID, tenantId)
 
-		case c.Get("psk-org-id") != nil:
-			orgId, ok := c.Get("psk-org-id").(string)
+		case c.Get(fields.ORGID) != nil:
+			orgId, ok := c.Get(fields.ORGID).(string)
 			if !ok {
 				return errors.New("failed to cast orgId to string")
 			}
@@ -76,11 +77,11 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set("identity", id)
-			c.Set("tenantID", tenantId)
+			c.Set(fields.PARSED_IDENTITY, id)
+			c.Set(fields.TENANTID, tenantId)
 
-		case c.Get("identity") != nil:
-			identity, ok := c.Get("identity").(*identity.XRHID)
+		case c.Get(fields.PARSED_IDENTITY) != nil:
+			identity, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("invalid identity structure received")
 			}
@@ -105,7 +106,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set("tenantID", tenantId)
+			c.Set(fields.TENANTID, tenantId)
 
 		default:
 			return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Authentication required by either [x-rh-identity] or [x-rh-sources-psk]", "401"))

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/gommon/log"
@@ -30,8 +30,8 @@ import (
 func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		switch {
-		case c.Get(fields.ACCOUNT_NUMBER) != nil:
-			accountNumber, ok := c.Get(fields.ACCOUNT_NUMBER).(string)
+		case c.Get(h.ACCOUNT_NUMBER) != nil:
+			accountNumber, ok := c.Get(h.ACCOUNT_NUMBER).(string)
 			if !ok {
 				return fmt.Errorf("failed to cast account-number to string")
 			}
@@ -52,11 +52,11 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set(fields.PARSED_IDENTITY, id)
-			c.Set(fields.TENANTID, tenantId)
+			c.Set(h.PARSED_IDENTITY, id)
+			c.Set(h.TENANTID, tenantId)
 
-		case c.Get(fields.ORGID) != nil:
-			orgId, ok := c.Get(fields.ORGID).(string)
+		case c.Get(h.ORGID) != nil:
+			orgId, ok := c.Get(h.ORGID).(string)
 			if !ok {
 				return errors.New("failed to cast orgId to string")
 			}
@@ -77,11 +77,11 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set(fields.PARSED_IDENTITY, id)
-			c.Set(fields.TENANTID, tenantId)
+			c.Set(h.PARSED_IDENTITY, id)
+			c.Set(h.TENANTID, tenantId)
 
-		case c.Get(fields.PARSED_IDENTITY) != nil:
-			identity, ok := c.Get(fields.PARSED_IDENTITY).(*identity.XRHID)
+		case c.Get(h.PARSED_IDENTITY) != nil:
+			identity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("invalid identity structure received")
 			}
@@ -106,7 +106,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to get or create tenant for request: %s", err)
 			}
 
-			c.Set(fields.TENANTID, tenantId)
+			c.Set(h.TENANTID, tenantId)
 
 		default:
 			return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Authentication required by either [x-rh-identity] or [x-rh-sources-psk]", "401"))

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -98,7 +98,7 @@ func httpAvailabilityRequest(source *m.Source, app *m.Application, uri *url.URL)
 	}
 
 	req.Header.Add("x-rh-sources-account-number", source.Tenant.ExternalTenant)
-	req.Header.Add("x-rh-identity", util.XRhIdentityWithAccountNumber(source.Tenant.ExternalTenant))
+	req.Header.Add("x-rh-identity", util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -164,7 +164,7 @@ func publishSatelliteMessage(mgr *kafka.Manager, source *m.Source, endpoint *m.E
 	msg.AddHeaders([]kafka.Header{
 		{Key: "event_type", Value: []byte("Source.availability_check")},
 		{Key: "encoding", Value: []byte("json")},
-		{Key: "x-rh-identity", Value: []byte(util.XRhIdentityWithAccountNumber(endpoint.Tenant.ExternalTenant))},
+		{Key: "x-rh-identity", Value: []byte(util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))},
 		{Key: "x-rh-sources-account-number", Value: []byte(endpoint.Tenant.ExternalTenant)},
 	})
 

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -97,6 +97,7 @@ func httpAvailabilityRequest(source *m.Source, app *m.Application, uri *url.URL)
 		return
 	}
 
+	req.Header.Add("x-rh-sources-org-id", source.Tenant.OrgID)
 	req.Header.Add("x-rh-sources-account-number", source.Tenant.ExternalTenant)
 	req.Header.Add("x-rh-identity", util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")

--- a/service/events.go
+++ b/service/events.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/internal/events"
 	"github.com/RedHatInsights/sources-api-go/kafka"
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
@@ -41,24 +41,24 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	var ok bool
 
 	// pulling the specified account if it exists
-	if c.Get(fields.ACCOUNT_NUMBER) != nil {
-		account, ok = c.Get(fields.ACCOUNT_NUMBER).(string)
+	if c.Get(h.ACCOUNT_NUMBER) != nil {
+		account, ok = c.Get(h.ACCOUNT_NUMBER).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
 	}
 
 	// pulling the specified orgId if it exists
-	if c.Get(fields.ORGID) != nil {
-		orgId, ok = c.Get(fields.ORGID).(string)
+	if c.Get(h.ORGID) != nil {
+		orgId, ok = c.Get(h.ORGID).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
 	}
 
 	// pull the xrhid OR generate one using the information from the PSK information.
-	if c.Get(fields.XRHID) != nil {
-		rhid, ok := c.Get(fields.XRHID).(string)
+	if c.Get(h.XRHID) != nil {
+		rhid, ok := c.Get(h.XRHID).(string)
 		if ok {
 			// set the xrhid to be passed on
 			xrhid = rhid
@@ -83,13 +83,13 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 
 	// need to check org_id + account since one or the other might not be there.
 	if account != "" {
-		headers = append(headers, kafka.Header{Key: fields.ACCOUNT_NUMBER, Value: []byte(account)})
+		headers = append(headers, kafka.Header{Key: h.ACCOUNT_NUMBER, Value: []byte(account)})
 	}
 	if orgId != "" {
-		headers = append(headers, kafka.Header{Key: fields.ORGID, Value: []byte(orgId)})
+		headers = append(headers, kafka.Header{Key: h.ORGID, Value: []byte(orgId)})
 	}
 
-	headers = append(headers, kafka.Header{Key: fields.XRHID, Value: []byte(xrhid)})
+	headers = append(headers, kafka.Header{Key: h.XRHID, Value: []byte(xrhid)})
 
 	return headers, nil
 }

--- a/service/events.go
+++ b/service/events.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/internal/events"
 	"github.com/RedHatInsights/sources-api-go/kafka"
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
@@ -40,24 +41,24 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	var ok bool
 
 	// pulling the specified account if it exists
-	if c.Get("psk-account") != nil {
-		account, ok = c.Get("psk-account").(string)
+	if c.Get(fields.ACCOUNT_NUMBER) != nil {
+		account, ok = c.Get(fields.ACCOUNT_NUMBER).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
 	}
 
 	// pulling the specified orgId if it exists
-	if c.Get("psk-org-id") != nil {
-		orgId, ok = c.Get("psk-org-id").(string)
+	if c.Get(fields.ORGID) != nil {
+		orgId, ok = c.Get(fields.ORGID).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
 	}
 
 	// pull the xrhid OR generate one using the information from the PSK information.
-	if c.Get("x-rh-identity") != nil {
-		rhid, ok := c.Get("x-rh-identity").(string)
+	if c.Get(fields.XRHID) != nil {
+		rhid, ok := c.Get(fields.XRHID).(string)
 		if ok {
 			// set the xrhid to be passed on
 			xrhid = rhid
@@ -82,13 +83,13 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 
 	// need to check org_id + account since one or the other might not be there.
 	if account != "" {
-		headers = append(headers, kafka.Header{Key: "x-rh-sources-account-number", Value: []byte(account)})
+		headers = append(headers, kafka.Header{Key: fields.ACCOUNT_NUMBER, Value: []byte(account)})
 	}
 	if orgId != "" {
-		headers = append(headers, kafka.Header{Key: "x-rh-sources-org-id", Value: []byte(orgId)})
+		headers = append(headers, kafka.Header{Key: fields.ORGID, Value: []byte(orgId)})
 	}
 
-	headers = append(headers, kafka.Header{Key: "x-rh-identity", Value: []byte(xrhid)})
+	headers = append(headers, kafka.Header{Key: fields.XRHID, Value: []byte(xrhid)})
 
 	return headers, nil
 }

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/kafka"
-	"github.com/RedHatInsights/sources-api-go/middleware/fields"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -19,7 +19,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 	testPskAccountValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(fields.ACCOUNT_NUMBER, testPskAccountValue)
+	context.Set(h.ACCOUNT_NUMBER, testPskAccountValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -87,7 +87,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	testOrgIdValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(fields.ORGID, testOrgIdValue)
+	context.Set(h.ORGID, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -270,7 +270,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	testOrgIdValue := "12345"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(fields.ORGID, testOrgIdValue)
+	context.Set(h.ORGID, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/kafka"
+	"github.com/RedHatInsights/sources-api-go/middleware/fields"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -18,7 +19,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 	testPskAccountValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set("psk-account", testPskAccountValue)
+	context.Set(fields.ACCOUNT_NUMBER, testPskAccountValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -86,7 +87,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	testOrgIdValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set("psk-org-id", testOrgIdValue)
+	context.Set(fields.ORGID, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -269,7 +270,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	testOrgIdValue := "12345"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set("psk-org-id", testOrgIdValue)
+	context.Set(fields.ORGID, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-// TestForwadableHeadersPsk tests that when the "psk-account" context value is present, two headers are returned from
+// TestForwadableHeadersPskAccountNumber tests that when the "psk-account" context value is present, two headers are returned from
 // the function under test: "x-rh-sources-account-number" and "x-rh-identity".
-func TestForwadableHeadersPsk(t *testing.T) {
+func TestForwadableHeadersAccountNumber(t *testing.T) {
 	testPskAccountValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set("x-rh-sources-psk", testPskAccountValue)
+	context.Set("psk-account", testPskAccountValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -86,7 +86,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	testOrgIdValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set("x-rh-sources-org-id", testOrgIdValue)
+	context.Set("psk-org-id", testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -148,8 +148,9 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	}
 }
 
-// TestForwadableHeadersXrhId tests that when the "x-rh-identity" context value is present, only one header is returned
-// from the function under test: "x-rh-identity".
+// TestForwadableHeadersXrhId tests that when the "x-rh-identity" context value
+// is present, it passes it along as well as adding the psk-account + psk-org-id
+// related headers.
 func TestForwadableHeadersXrhId(t *testing.T) {
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
 
@@ -176,7 +177,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	}
 
 	{
-		want := 1
+		want := 3
 		got := len(headers)
 
 		if want != got {
@@ -185,7 +186,49 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	}
 
 	{
-		xRhIdentityHeader := headers[0]
+		accountHeader := headers[0]
+		{
+			want := "x-rh-sources-account-number"
+			got := accountHeader.Key
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			{
+				want := testAccountNumber
+				got := string(accountHeader.Value)
+
+				if want != got {
+					t.Errorf(`incorrect account number on xRhId struct. Want "%s", got "%s"`, want, got)
+				}
+			}
+		}
+	}
+
+	{
+		orgIdHeader := headers[1]
+		{
+			want := "x-rh-sources-org-id"
+			got := orgIdHeader.Key
+
+			if want != got {
+				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
+			}
+		}
+		{
+			want := testOrgId
+			got := string(orgIdHeader.Value)
+
+			if want != got {
+				t.Errorf(`incorrect orgId on xRhId struct. Want "%s", got "%s"`, want, got)
+			}
+		}
+	}
+
+	{
+		xRhIdentityHeader := headers[2]
 
 		{
 			want := "x-rh-identity"
@@ -220,16 +263,13 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	}
 }
 
-// TestForwadableHeadersOrgId tests that when the "psk-account" and "x-rh-sources-org-id" context values are present,
-// three headers are returned from the function under test: "x-rh-sources-account-number", "x-rh-sources-org-id" and
-// "x-rh-identity"
+// TestForwadableHeadersOrgId tests that when the and "x-rh-sources-org-id" context value is present,
+// two headers are returned from the function under test: "x-rh-sources-org-id" and "x-rh-identity"
 func TestForwadableHeadersPskOrgId(t *testing.T) {
-	testPskAccountValue := "abcde"
 	testOrgIdValue := "12345"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set("x-rh-sources-psk", testPskAccountValue)
-	context.Set("x-rh-sources-org-id", testOrgIdValue)
+	context.Set("psk-org-id", testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -238,7 +278,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	}
 
 	{
-		want := 3
+		want := 2
 		got := len(headers)
 
 		if want != got {
@@ -247,28 +287,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	}
 
 	{
-		pskHeader := headers[0]
-
-		{
-			want := "x-rh-sources-account-number"
-			got := pskHeader.Key
-
-			if want != got {
-				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
-			}
-		}
-		{
-			want := []byte(testPskAccountValue)
-			got := pskHeader.Value
-
-			if !bytes.Equal(want, got) {
-				t.Errorf(`incorrect Kafka header value generated. Want "%s", got "%s"`, want, got)
-			}
-		}
-	}
-
-	{
-		orgIdHeader := headers[1]
+		orgIdHeader := headers[0]
 
 		{
 			want := "x-rh-sources-org-id"
@@ -289,7 +308,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	}
 
 	{
-		xRhIdentityHeader := headers[2]
+		xRhIdentityHeader := headers[1]
 
 		{
 			want := "x-rh-identity"
@@ -303,14 +322,6 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 			xRhId, err := util.ParseXRHIDHeader(string(xRhIdentityHeader.Value))
 			if err != nil {
 				t.Errorf(`unexpected error when parsing the xRhIdentity base64 string: %s`, err)
-			}
-			{
-				want := testPskAccountValue
-				got := xRhId.Identity.AccountNumber
-
-				if want != got {
-					t.Errorf(`incorrect account number on xRhId struct. Want "%s", got "%s"`, want, got)
-				}
 			}
 			{
 				want := testOrgIdValue

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1256,7 +1256,8 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 		"/api/sources/v3.1/sources/1/pause",
 		nil,
 		map[string]interface{}{
-			"tenantID": int64(1),
+			"tenantID":      int64(1),
+			"x-rh-identity": util.GeneratedXRhIdentity("1234", "1234"),
 		},
 	)
 
@@ -1283,7 +1284,8 @@ func TestResumeSourceAndItsApplications(t *testing.T) {
 		"/api/sources/v3.1/sources/1/unpause",
 		nil,
 		map[string]interface{}{
-			"tenantID": int64(1),
+			"tenantID":      int64(1),
+			"x-rh-identity": util.GeneratedXRhIdentity("1234", "1234"),
 		},
 	)
 
@@ -1322,7 +1324,8 @@ func TestSourcePauseRaiseEventCheck(t *testing.T) {
 		"/api/sources/v3.1/sources/1/unpause",
 		nil,
 		map[string]interface{}{
-			"tenantID": int64(1),
+			"tenantID":      int64(1),
+			"x-rh-identity": util.GeneratedXRhIdentity("1234", "1234"),
 		},
 	)
 
@@ -1399,7 +1402,8 @@ func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
 		"/api/sources/v3.1/sources/1/unpause",
 		nil,
 		map[string]interface{}{
-			"tenantID": int64(1),
+			"tenantID":      int64(1),
+			"x-rh-identity": util.GeneratedXRhIdentity("1234", "1234"),
 		},
 	)
 
@@ -1499,9 +1503,16 @@ func sourceEventTestHelper(t *testing.T, c echo.Context, expectedEventType strin
 	}
 
 	{
+		var h kafka.Header
+		for _, header := range headers {
+			if header.Key == "event_type" {
+				h = header
+				break
+			}
+		}
 		// The header should contain the expected event type as well.
 		want := expectedEventType
-		got := string(headers[0].Value)
+		got := string(h.Value)
 		if want != got {
 			t.Errorf(`incorrect header on raise event. Want "%s", got "%s"`, want, got)
 			return errors.New(`incorrect header on raise event`)

--- a/util/identity_header.go
+++ b/util/identity_header.go
@@ -7,9 +7,13 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-// XRhIdentityWithAccountNumber returns a base64 encoded header to use as x-rh-identity when one is not provided
-func XRhIdentityWithAccountNumber(account string) string {
-	bytes, err := json.Marshal(identity.XRHID{Identity: identity.Identity{AccountNumber: account}})
+// GeneratedXRhIdentity returns a base64 encoded header to use as x-rh-identity when one is not provided
+func GeneratedXRhIdentity(account, orgId string) string {
+	id := identity.XRHID{Identity: identity.Identity{
+		AccountNumber: account,
+		OrgID:         orgId},
+	}
+	bytes, err := json.Marshal(id)
 	if err != nil {
 		return ""
 	}

--- a/util/identity_header_test.go
+++ b/util/identity_header_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCreateIdentityHeader(t *testing.T) {
-	out := XRhIdentityWithAccountNumber("1234")
+	out := GeneratedXRhIdentity("1234", "2345")
 
 	bytes, err := base64.StdEncoding.DecodeString(out)
 	if err != nil {
@@ -23,6 +23,10 @@ func TestCreateIdentityHeader(t *testing.T) {
 	}
 
 	if identity.Identity.AccountNumber != "1234" {
-		t.Errorf("did not marshal correctly, got %v wanted %v", identity.Identity.AccountNumber, "1234")
+		t.Errorf("did not marshal account correctly, got %v wanted %v", identity.Identity.AccountNumber, "1234")
+	}
+
+	if identity.Identity.OrgID != "2345" {
+		t.Errorf("did not marshal org_id correctly, got %v wanted %v", identity.Identity.OrgID, "2345")
 	}
 }


### PR DESCRIPTION
Upon inspection it appears that when we don't pass in account/org-id those headers wouldn't be forwarded along, we actually need to include them even if they're just parsed from the xrhid specifically so our sub-apps can use them internally.

The biggest changes in this PR are probably in `service/events.go` where basically I try to parse what we have this way:
1. Pull the specified org-id + account-number from the request
2. If the xrhid is there from an earlier request -> set the org+acct if they aren't set
3. ...Otherwise just generate one from what we pulled before. 
4. Add all the headers we have to the forwardable list

This basically ensures no matter what we will _generally_ have all headers passed on:
| What is included in the request | What we forward along |
| ------------- | ------------- |
| `x-rh-identity`  |  `xrhid` + `org-id` + `account` |
| `x-rh-sources-account-number`  | `xrhid` + `account`  |
|`x-rh-sources-org-id` | `xrhid` + `org-id` |
| `x-rh-sources-account-number` + `x-rh-sources-org-id` | `xrhid` + `account` + `org-id` |


\# TODO: 
- [x] update forwardable headers function to always include account/org-id even if they aren't passed
- [x] fix eventing tests
- [x] fix handler tests


---

Another thing I added is a new package `middleware/headers/` that constantizes our header/context names. That way we don't run into the problem we had before this where things were stored on the context with key `foo` instead of `x-rh-sources-foo`.