### PR TITLE
Close Kafka Producer after producing in order to not leak memory

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1032,7 +1032,7 @@ func TestPauseApplicationPauseRaiseEventCheck(t *testing.T) {
 	// We back up the producer so that we can restore it once the test has finished. This way we don't mess up with
 	// other tests that may need to raise events.
 	backupProducer := service.Producer
-	service.Producer = events.EventStreamProducer{Sender: MockSender{}}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: MockSender{}} }
 
 	var applicationRaiseEventCallCount int
 	raiseEventFunc = func(eventType string, payload []byte, headers []kafka.Header) error {
@@ -1086,7 +1086,7 @@ func TestPauseApplicationUnpauseRaiseEventCheck(t *testing.T) {
 	// We back up the producer so that we can restore it once the test has finished. This way we don't mess up with
 	// other tests that may need to raise events.
 	backupProducer := service.Producer
-	service.Producer = events.EventStreamProducer{Sender: MockSender{}}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: MockSender{}} }
 
 	var applicationRaiseEventCallCount int
 	raiseEventFunc = func(eventType string, payload []byte, headers []kafka.Header) error {

--- a/binder.go
+++ b/binder.go
@@ -23,6 +23,7 @@ func (binder *NoUnknownFieldsBinder) Bind(i interface{}, c echo.Context) error {
 	if c.Request().Body == http.NoBody || c.Request().Body == nil {
 		return util.NewErrBadRequest("no body")
 	}
+	defer c.Request().Body.Close()
 
 	// create a new decoder for the request body
 	dec := json.NewDecoder(c.Request().Body)

--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -51,7 +51,7 @@ func (esp *EventStreamSender) RaiseEvent(eventType string, payload []byte, heade
 
 	logging.Log.Debugf("publishing message %v to topic %q...Complete", eventType, EventStreamTopic)
 
-	return nil
+	return kf.Producer().Close()
 }
 
 func (esp *EventStreamProducer) RaiseEventIf(allowed bool, eventType string, payload []byte, headers []kafka.Header) error {

--- a/main.go
+++ b/main.go
@@ -18,8 +18,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-
-	_ "net/http/pprof"
 )
 
 var conf = config.Get()
@@ -105,10 +103,6 @@ func runServer(shutdown chan struct{}) {
 		if err := e.Start(":8000"); err != nil && err != http.ErrServerClosed {
 			e.Logger.Warn(err)
 		}
-	}()
-
-	go func() {
-		e.Logger.Fatal(http.ListenAndServe("localhost:6060", nil))
 	}()
 
 	// wait for the shutdown signal to come

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	_ "net/http/pprof"
 )
 
 var conf = config.Get()
@@ -103,6 +105,10 @@ func runServer(shutdown chan struct{}) {
 		if err := e.Start(":8000"); err != nil && err != http.ErrServerClosed {
 			e.Logger.Warn(err)
 		}
+	}()
+
+	go func() {
+		e.Logger.Fatal(http.ListenAndServe("localhost:6060", nil))
 	}()
 
 	// wait for the shutdown signal to come

--- a/main_test.go
+++ b/main_test.go
@@ -53,7 +53,7 @@ func TestMain(t *testing.M) {
 
 		dao.Vault = &mocks.MockVault{}
 
-		service.Producer = events.EventStreamProducer{Sender: &mocks.MockSender{}}
+		service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &mocks.MockSender{}} }
 
 		database.CreateFixtures()
 		err := dao.PopulateStaticTypeCache()

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -29,7 +29,7 @@ func (f *fakeEvent) ToEvent() interface{} {
 
 func TestRaiseEvent(t *testing.T) {
 	s := mocks.MockSender{}
-	service.Producer = events.EventStreamProducer{Sender: &s}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.EmptyTestContext()
 
 	f := raiseMiddleware(func(c echo.Context) error {
@@ -57,7 +57,7 @@ func TestRaiseEvent(t *testing.T) {
 
 func TestRaiseEventWithHeaders(t *testing.T) {
 	s := mocks.MockSender{}
-	service.Producer = events.EventStreamProducer{Sender: &s}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
 		"x-rh-sources-psk": "1234",
 		"x-rh-identity":    "asdfasdf",
@@ -99,7 +99,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 
 func TestRaiseEventBody(t *testing.T) {
 	s := mocks.MockSender{}
-	service.Producer = events.EventStreamProducer{Sender: &s}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.EmptyTestContext()
 
 	f := raiseMiddleware(func(c echo.Context) error {
@@ -131,7 +131,7 @@ func TestRaiseEventBody(t *testing.T) {
 
 func TestNoRaiseEvent(t *testing.T) {
 	s := mocks.MockSender{}
-	service.Producer = events.EventStreamProducer{Sender: &s}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.EmptyTestContext()
 
 	f := raiseMiddleware(func(c echo.Context) error {
@@ -157,7 +157,7 @@ func TestNoRaiseEvent(t *testing.T) {
 
 func TestSkipOnContext(t *testing.T) {
 	s := mocks.MockSender{}
-	service.Producer = events.EventStreamProducer{Sender: &s}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.EmptyTestContext()
 
 	f := raiseMiddleware(func(c echo.Context) error {

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -172,6 +172,11 @@ func publishSatelliteMessage(mgr *kafka.Manager, source *m.Source, endpoint *m.E
 	if err != nil {
 		l.Log.Warnf("Failed to produce kafka message for Source %v, error: %v", source.ID, err)
 	}
+
+	err = mgr.Producer().Close()
+	if err != nil {
+		l.Log.Warnf("Failed to close kafka producer: %v", err)
+	}
 }
 
 type rhcConnectionStatusResponse struct {

--- a/service/events.go
+++ b/service/events.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Producer instance used to send messages - default just an empty instance of the struct.
-var Producer = events.EventStreamProducer{Sender: &events.EventStreamSender{}}
+var Producer = func() events.Sender { return events.EventStreamProducer{Sender: &events.EventStreamSender{}} }
 
 // RaiseEvent raises an event with the provided resource.
 func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) error {
@@ -25,7 +25,7 @@ func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) 
 	}
 
 	headers = append(headers, kafka.Header{Key: "event_type", Value: []byte(eventType)})
-	err = Producer.RaiseEvent(eventType, msg, headers)
+	err = Producer().RaiseEvent(eventType, msg, headers)
 	if err != nil {
 		return fmt.Errorf("failed to raise event to kafka: %v", err)
 	}

--- a/service/notifications.go
+++ b/service/notifications.go
@@ -113,7 +113,7 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(i
 		return err
 	}
 
-	return nil
+	return mgr.Producer().Close()
 }
 
 func EmitAvailabilityStatusNotification(id *identity.Identity, emailNotificationInfo *m.EmailNotificationInfo) error {

--- a/service/superkey.go
+++ b/service/superkey.go
@@ -133,5 +133,11 @@ func produceSuperkeyRequest(m *kafka.Message) error {
 			KafkaBrokers:   config.Get().KafkaBrokers,
 			ProducerConfig: kafka.ProducerConfig{Topic: config.Get().KafkaTopic(SUPERKEY_REQUEST_QUEUE)}}}
 
-	return mgr.Produce(m)
+	err := mgr.Produce(m)
+	if err != nil {
+		mgr.Producer().Close()
+		return err
+	}
+
+	return mgr.Producer().Close()
 }

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1332,7 +1332,7 @@ func TestSourcePauseRaiseEventCheck(t *testing.T) {
 	// We back up the producer so that we can restore it once the test has finished. This way we don't mess up with
 	// other tests that may need to raise events.
 	backupProducer := service.Producer
-	service.Producer = events.EventStreamProducer{Sender: MockSender{}}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: MockSender{}} }
 
 	var sourceRaiseEventCallCount int
 	var applicationRaiseEventCallCount int
@@ -1409,7 +1409,7 @@ func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
 	// We back up the producer so that we can restore it once the test has finished. This way we don't mess up with
 	// other tests that may need to raise events.
 	backupProducer := service.Producer
-	service.Producer = events.EventStreamProducer{Sender: MockSender{}}
+	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: MockSender{}} }
 
 	var sourceRaiseEventCallCount int
 	var applicationRaiseEventCallCount int


### PR DESCRIPTION
:zap: *promoting to prod exposed a memory leak!*

After letting the pods marinate in prod for a while we approached over 500MB ram usage, which is kind of nuts considering we only ever hit ~50MB on stage. After watching the graphs for a while it looked like a memory leak. So I took some time to profile it and deduce where it is.

----

In order to profile, first thing you need to do is set up the profiling exporter, with this teeny diff: 

<details>
<summary>Profiling Diff</summary>


```diff
diff --git a/main.go b/main.go
index e654195..100b703 100644
--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	_ "net/http/pprof"
 )
 
 var conf = config.Get()
@@ -105,6 +107,10 @@ func runServer(shutdown chan struct{}) {
 		}
 	}()
 
+	go func() {
+		e.Logger.Fatal(http.ListenAndServe("localhost:6060", nil))
+	}()
+
 	// wait for the shutdown signal to come
 	<-shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)

```
</details>

From here just load the app somehow. I have a [little tool](https://gist.github.com/lindgrenj6/51c40e82d5a58f2e1327886a7f4330e4) that basically spams bulk create a bunch - and from here it was really easy to see the memory leakage happening. 

---

But loading is useless without being able to actually see the results! I followed this guide: https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/

the tl;dr: is you add the code above, then run this command to generate the report after loading the server: 
`go tool pprof -web http://localhost:6060/debug/pprof/heap`
which will open the SVG in your browser. You can also generate pngs by changing `-web` to `-png`.

Here are the results....
**BEFORE:**
![before](https://user-images.githubusercontent.com/5856504/168394328-5a1d169e-cf3d-4b64-ab14-8bc58ec564ed.png)

**AFTER:**
![after](https://user-images.githubusercontent.com/5856504/168394350-7e31b59a-e144-49f9-bcac-ec77517cc9ef.png)


After loading them both for ~2-3 minutes with that program...before we were using 150+mb, with most of that living in the kafka producer. Afterwards we're at a whopping 15M-30M depending when the GC runs.

This change should bubble out to the availability status listener too since that pod was leaking too albeit slower. 

\# TODO:
- [x] fix tests