### PR TITLE
Support Bearer Token for unleash

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ func Get() *SourcesApiConfig {
 		unleashUrl := ""
 		if os.Getenv("UNLEASH_URL") != "" {
 			unleashUrl = os.Getenv("UNLEASH_URL")
-		} else if cfg.FeatureFlags.ClientAccessToken != nil {
+		} else if cfg.FeatureFlags.Hostname != "" {
 			unleashUrl = fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
 		}
 		options.SetDefault("FeatureFlagsUrl", unleashUrl)

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type SourcesApiConfig struct {
 	FeatureFlagsUrl           string
 	FeatureFlagsAPIToken      string
 	FeatureFlagsService       string
+	FeatureFlagsBearerToken   string
 	CacheHost                 string
 	CachePort                 int
 	CachePassword             string
@@ -104,7 +105,7 @@ func Get() *SourcesApiConfig {
 		} else if cfg.FeatureFlags.ClientAccessToken != nil {
 			clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
 		}
-		options.SetDefault("FeatureFlagsAPIToken", clientAccessToken)
+		options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)
 	} else {
 		options.SetDefault("AwsRegion", "us-east-1")
 		options.SetDefault("AwsAccessKeyId", os.Getenv("CW_AWS_ACCESS_KEY_ID"))
@@ -128,7 +129,8 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("CacheHost", os.Getenv("REDIS_CACHE_HOST"))
 		options.SetDefault("CachePort", os.Getenv("REDIS_CACHE_PORT"))
 		options.SetDefault("CachePassword", os.Getenv("REDIS_CACHE_PASSWORD"))
-		options.SetDefault("FeatureFlagsUrl", os.Getenv("FEATURE_FLAGS_URL"))
+
+		options.SetDefault("FeatureFlagsUrl", os.Getenv("UNLEASH_URL"))
 		options.SetDefault("FeatureFlagsAPIToken", os.Getenv("UNLEASH_TOKEN"))
 	}
 
@@ -213,6 +215,7 @@ func Get() *SourcesApiConfig {
 		FeatureFlagsEnvironment:   options.GetString("FeatureFlagsEnvironment"),
 		FeatureFlagsUrl:           options.GetString("FeatureFlagsUrl"),
 		FeatureFlagsAPIToken:      options.GetString("FeatureFlagsAPIToken"),
+		FeatureFlagsBearerToken:   options.GetString("FeatureFlagsBearerToken"),
 		FeatureFlagsService:       options.GetString("FeatureFlagsService"),
 		CacheHost:                 options.GetString("CacheHost"),
 		CachePort:                 options.GetInt("CachePort"),

--- a/service/feature_flags.go
+++ b/service/feature_flags.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -54,6 +55,13 @@ func init() {
 			logging.Log.Warnf("FeatureFlagsAPIToken is empty")
 		}
 
+		authorizationHeader := ""
+		if conf.FeatureFlagsBearerToken != "" {
+			authorizationHeader = fmt.Sprintf("Bearer %s", conf.FeatureFlagsAPIToken)
+		} else {
+			authorizationHeader = conf.FeatureFlagsAPIToken
+		}
+
 		unleashConfig := []unleash.ConfigOption{unleash.WithAppName(appName),
 			unleash.WithListener(&FeatureFlagListener{}),
 			unleash.WithUrl(conf.FeatureFlagsUrl),
@@ -61,7 +69,7 @@ func init() {
 			unleash.WithRefreshInterval(refreshInterval * time.Second),
 			unleash.WithMetricsInterval(metricsInterval * time.Second),
 			unleash.WithProjectName(projectName),
-			unleash.WithCustomHeaders(http.Header{"Authorization": {conf.FeatureFlagsAPIToken}})}
+			unleash.WithCustomHeaders(http.Header{"Authorization": {authorizationHeader}})}
 
 		err := unleash.Initialize(unleashConfig...)
 		if err != nil {


### PR DESCRIPTION
Tokens for authentication are bearer tokens for stage and prod - so we need to specify `Bearer` type in authorisation header for stage and prod:

`Authorization: Bearer <token>`

Authentication  for **ephemeral/minikube** is without any tokens.

To run and use unleash instance locally is API Token needed which needs to better created in UI. Token has to be used like this in authorization header:
`Authorization: <token>`


Note: I added here fix about unleash url.
