### PR TITLE
Get feature flag config only from ACG_CONFIG

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -92,17 +92,13 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("FeatureFlagsSchema", string(cfg.FeatureFlags.Scheme))
 
 		unleashUrl := ""
-		if os.Getenv("UNLEASH_URL") != "" {
-			unleashUrl = os.Getenv("UNLEASH_URL")
-		} else if cfg.FeatureFlags.Hostname != "" {
+		if cfg.FeatureFlags.Hostname != "" {
 			unleashUrl = fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
 		}
 		options.SetDefault("FeatureFlagsUrl", unleashUrl)
 
 		clientAccessToken := ""
-		if os.Getenv("UNLEASH_TOKEN") != "" {
-			clientAccessToken = os.Getenv("UNLEASH_TOKEN")
-		} else if cfg.FeatureFlags.ClientAccessToken != nil {
+		if cfg.FeatureFlags.ClientAccessToken != nil {
 			clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
 		}
 		options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -142,13 +142,6 @@ objects:
               optional: true
         - name: FEATURE_FLAGS_SERVICE
           value: ${FEATURE_FLAGS_SERVICE}
-        - name: UNLEASH_URL
-          value: ${UNLEASH_URL}
-        - name: UNLEASH_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: ${UNLEASH_SECRET_NAME}
-              key: CLIENT_ACCESS_TOKEN
         readinessProbe:
           tcpSocket:
             port: 8000
@@ -333,10 +326,4 @@ parameters:
 - description: Specify name of service for Feature Flags
   name: FEATURE_FLAGS_SERVICE
   value: 'unleash'
-- description: Unleash API url
-  name: UNLEASH_URL
-  value: ''
-- description: Unleash secret name
-  name: UNLEASH_SECRET_NAME
-  value: unleash-ephemeral
 


### PR DESCRIPTION
Remove dependency from `UNLEASH_URL` and `UNLEASH_TOKEN`. It is not needed as we confirmed it on stage.

`ACG_CONFIG` contains bearer token and we can use it - as there is benefit - url is nicely parsed already and we don't need to parse it and check if it is http and https and then add port to url.

 