### PR TITLE
Add error message when source type is missing in bulkcreate

### DIFF
--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+func TestBulkCreateMissingSourceType(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	nameSource := "test"
+	bulkCreateSource := m.BulkCreateSource{SourceCreateRequest: m.SourceCreateRequest{Name: &nameSource}}
+	requestBody := m.BulkCreateRequest{Sources: []m.BulkCreateSource{bulkCreateSource}}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, _ := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/bulkc_reate",
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+
+	err = BulkCreate(c)
+	if err.Error() != "no source type present, need either [source_type_name] or [source_type_id]" {
+		t.Error(err)
+	}
+}

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -131,6 +131,8 @@ func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant) ([]m.Source
 			}
 
 			source.SourceTypeIDRaw = sourceType.Id
+		default:
+			return nil, fmt.Errorf("no source type present, need either [source_type_name] or [source_type_id]")
 		}
 
 		// set up the source type + id for validation


### PR DESCRIPTION
bulk create request was failing when there is not source type(id or name) in request : 
```
POST http://localhost:{{port}}/api/sources/v3.1/bulk_create


{

  "sources": [
    {
      "name": "SourceName5"
    }
  ],
  "applications": [
    {
      "source_name": "SourceName5",
      "application_type_name": "cost-management"
    },
    {
      "source_name": "SourceName5",
      "application_type_name": "cloud-meter"
    }
  ],
  "authentications": [
    {
      "resource_type": "source",
      "resource_name": "SourceName5",
      "username": "aws::iam::arn::i_cant_remember_the_format",
      "authtype": "arn"
    },
    {
      "resource_type": "application",
      "resource_name": "cost-management",
      "username": "myUser",
      "password": "myPass"
    },
    {
      "resource_type": "application",
      "resource_name": "cloud-meter",
      "username": "cloudUser",
      "password": "cloudPass"
    }
  ]
}
```

but response and log message was improper:

**Before:**

response:
```

{
  "message": "Internal Server Error"
}
```
log message

```
{"@timestamp":"2022-05-18T15:37:55.922Z","@version":1,"app":"source-api-go","hostname":"lpichler1-mac","labels":{"app":"source-api-go"},"level":"info","log_type":"echo","message":"[PANIC RECOVER] runtime error: invalid memory address or nil pointer dereference goroutine 165 [running]:\ngithub.com/labstack/echo/v4/middleware.RecoverWithConfig.func1.1.1()\n\t/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/recover.go:77 +0x10d\npanic({0x1c38360, 0x28aad70})\n\t/usr/local/opt/go/libexec/src/runtime/panic.go:1038 +0x215\ngithub.com/RedHatInsights/sources-api-go/service.parseSources({0xc0000cea80, 0x1, 0x19e5d8a}, 0xc000651bc0)\n\t/Users/liborpichler/Projects/sources-api-go/service/bulk_create.go:137 +0x1d6\ngithub.com/RedHatInsights/sources-api-go/service.BulkAssembly.func1(0xc000437800)\n\t/Users/liborpichler/Projects/sources-api-go/service/bulk_create.go:43 +0x65\ngorm.io/gorm.(*DB).Transaction(0xc000437800, 0xc00009ef80, {0x0, 0x0, 0x0})\n\t/Users/liborpichler/go/pkg/mod/gorm.io/gorm@v1.23.2/finisher_api.go:580 +0x29e\ngithub.com/RedHatInsights/sources-api-go/service.BulkAssembly({{0xc0000cea80, 0x1, 0x4}, {0xc000683ba0, 0x2, 0x4}, {0x0, 0x0, 0x0}, {0xc0000cec40, ...}}, ...)\n\t/Users/liborpichler/Projects/sources-api-go/service/bulk_create.go:39 +0xe5\nmain.BulkCreate({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/Projects/sources-api-go/bulk_handlers.go:36 +0x278\ngithub.com/RedHatInsights/sources-api-go/middleware.RaiseEvent.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/Projects/sources-api-go/middleware/event_stream.go:15 +0x3f\ngithub.com/RedHatInsights/sources-api-go/middleware.PermissionCheck.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/Projects/sources-api-go/middleware/authorization.go:101 +0x544\ngithub.com/RedHatInsights/sources-api-go/middleware.Tenancy.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/Projects/sources-api-go/middleware/tenancy.go:114 +0x7c3\ngithub.com/RedHatInsights/sources-api-go/middleware.ParseHeaders.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/Projects/sources-api-go/middleware/headers.go:71 +0x403\ngithub.com/RedHatInsights/sources-api-go/middleware.HandleErrors.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/Projects/sources-api-go/middleware/error_handling.go:13 +0x2e\ngithub.com/RedHatInsights/sources-api-go/middleware.Timing.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/Projects/sources-api-go/middleware/timings.go:19 +0x17f\ngithub.com/labstack/echo/v4.(*Echo).add.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:552 +0x51\ngithub.com/labstack/echo-contrib/prometheus.(*Prometheus).HandlerFunc.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/go/pkg/mod/github.com/labstack/echo-contrib@v0.12.0/prometheus/prometheus.go:382 +0xff\ngithub.com/labstack/echo/v4/middleware.LoggerWithConfig.func2.1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/logger.go:117 +0xe2\ngithub.com/labstack/echo/v4/middleware.RecoverWithConfig.func1.1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/recover.go:98 +0xfc\ngithub.com/labstack/echo/v4.(*Echo).ServeHTTP.func1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:656 +0x132\ngithub.com/labstack/echo/v4/middleware.RemoveTrailingSlashWithConfig.func1.1({0x20cd2d0, 0xc000467cc0})\n\t/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/middleware/slash.go:118 +0x211\ngithub.com/labstack/echo/v4.(*Echo).ServeHTTP(0xc0009fb200, {0x2098e10, 0xc0005e76c0}, 0xc00001cc00)\n\t/Users/liborpichler/go/pkg/mod/github.com/labstack/echo/v4@v4.6.1/echo.go:662 +0x3bc\nnet/http.serverHandler.ServeHTTP({0x2095a00}, {0x2098e10, 0xc0005e76c0}, 0xc00001cc00)\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2879 +0x43b\nnet/http.(*conn).serve(0xc000467b80, {0x20a3f58, 0xc0004e2060})\n\t/usr/local/opt/go/libexec/src/net/http/server.go:1930 +0xb08\ncreated by net/http.(*Server).Serve\n\t/usr/local/opt/go/libexec/src/net/http/server.go:3034 +0x4e8\n\ngoroutine 1 [chan receive]:\nmain.main()\n\t/Users/liborpichler/Projects/sources-api-go/main.go:60 +0x1e5\n\ngoroutine 24 [select]:\ngithub.com/Unleash/unleash-client-go/v3.(*repository).sync(0xc000216300)\n\t/Users/liborpichler/go/pk\n","tags":["source-api-go"
```
**After**

```
{
  "errors": [
    {
      "detail": "Internal Server Error: no source type present, need either [source_type_name] or [source_type_id]",
      "status": "500"
    }
  ]
}
```

log message
```
{"@timestamp":"2022-05-18T15:40:48.242Z","@version":1,"app":"source-api-go","backtrace":["logger.backtrace(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:127)","logger.(*CustomLoggerFormatter).Format(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:192)","util.ErrorDoc(/Users/liborpichler/Projects/sources-api-go/util/error_document.go:22)","middleware.HandleErrors.func1(/Users/liborpichler/Projects/sources-api-go/middleware/error_handling.go:27)","middleware.Timing.func1(/Users/liborpichler/Projects/sources-api-go/middleware/timings.go:19)"],"caller":"github.com/RedHatInsights/sources-api-go/util.ErrorDoc","filename":"/Users/liborpichler/Projects/sources-api-go/util/error_document.go:22","hostname":"lpichler1-mac","labels":{"app":"source-api-go"},"level":"error","log_type":"default","message":"Internal Server Error: no source type present, need either [source_type_name] or [source_type_id]","tags":["source-api-go"]}

```
