### PR TITLE
[RHCLOUD-19370] fix: don't panic when feature flags are missing from the Clowdapp JSON

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -87,21 +87,23 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("CachePort", cfg.InMemoryDb.Port)
 		options.SetDefault("CachePassword", cfg.InMemoryDb.Password)
 
-		options.SetDefault("FeatureFlagsHost", cfg.FeatureFlags.Hostname)
-		options.SetDefault("FeatureFlagsPort", cfg.FeatureFlags.Port)
-		options.SetDefault("FeatureFlagsSchema", string(cfg.FeatureFlags.Scheme))
+		if cfg.FeatureFlags != nil {
+			options.SetDefault("FeatureFlagsHost", cfg.FeatureFlags.Hostname)
+			options.SetDefault("FeatureFlagsPort", cfg.FeatureFlags.Port)
+			options.SetDefault("FeatureFlagsSchema", string(cfg.FeatureFlags.Scheme))
 
-		unleashUrl := ""
-		if cfg.FeatureFlags.Hostname != "" {
-			unleashUrl = fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
-		}
-		options.SetDefault("FeatureFlagsUrl", unleashUrl)
+			unleashUrl := ""
+			if cfg.FeatureFlags.Hostname != "" {
+				unleashUrl = fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
+			}
+			options.SetDefault("FeatureFlagsUrl", unleashUrl)
 
-		clientAccessToken := ""
-		if cfg.FeatureFlags.ClientAccessToken != nil {
-			clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
+			clientAccessToken := ""
+			if cfg.FeatureFlags.ClientAccessToken != nil {
+				clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
+			}
+			options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)
 		}
-		options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)
 	} else {
 		options.SetDefault("AwsRegion", "us-east-1")
 		options.SetDefault("AwsAccessKeyId", os.Getenv("CW_AWS_ACCESS_KEY_ID"))


### PR DESCRIPTION
The performance team is having issues deploying sources on their cluster, because Clowder doesn't put the feature flags key on the JSON that the back end reads from. This causes the back end to panic when they try to boot it up, which is blocking them.

## Links

[[RHCLOUD-19370]](https://issues.redhat.com/browse/RHCLOUD-19370)