### PR TITLE
Skip feature flags when its ACG config is missing 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -87,21 +87,21 @@ func Get() *SourcesApiConfig {
 		options.SetDefault("CachePort", cfg.InMemoryDb.Port)
 		options.SetDefault("CachePassword", cfg.InMemoryDb.Password)
 
-		options.SetDefault("FeatureFlagsHost", cfg.FeatureFlags.Hostname)
-		options.SetDefault("FeatureFlagsPort", cfg.FeatureFlags.Port)
-		options.SetDefault("FeatureFlagsSchema", string(cfg.FeatureFlags.Scheme))
+		if cfg.FeatureFlags != nil {
+			unleashUrl := ""
+			if cfg.FeatureFlags.Hostname != "" && cfg.FeatureFlags.Port != 0 && cfg.FeatureFlags.Scheme != "" {
+				unleashUrl = fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
+			}
 
-		unleashUrl := ""
-		if cfg.FeatureFlags.Hostname != "" {
-			unleashUrl = fmt.Sprintf("%s://%s:%d/api", cfg.FeatureFlags.Scheme, cfg.FeatureFlags.Hostname, cfg.FeatureFlags.Port)
-		}
-		options.SetDefault("FeatureFlagsUrl", unleashUrl)
+			options.SetDefault("FeatureFlagsUrl", unleashUrl)
 
-		clientAccessToken := ""
-		if cfg.FeatureFlags.ClientAccessToken != nil {
-			clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
+			clientAccessToken := ""
+			if cfg.FeatureFlags.ClientAccessToken != nil {
+				clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
+			}
+			options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)
 		}
-		options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)
+
 	} else {
 		options.SetDefault("AwsRegion", "us-east-1")
 		options.SetDefault("AwsAccessKeyId", os.Getenv("CW_AWS_ACCESS_KEY_ID"))

--- a/service/feature_flags.go
+++ b/service/feature_flags.go
@@ -19,6 +19,10 @@ var conf = config.Get()
 
 var ready = false
 
+func featureFlagsConfigPresent() bool {
+	return conf.FeatureFlagsUrl != ""
+}
+
 func featureFlagsServiceUnleash() bool {
 	return conf.FeatureFlagsService == "unleash"
 }
@@ -48,7 +52,7 @@ func (l FeatureFlagListener) OnRegistered(_ unleash.ClientData) {
 }
 
 func init() {
-	if featureFlagsServiceUnleash() {
+	if featureFlagsServiceUnleash() && featureFlagsConfigPresent() {
 		logging.InitLogger(conf)
 
 		if conf.FeatureFlagsAPIToken == "" {
@@ -80,6 +84,10 @@ func init() {
 
 func FeatureEnabled(feature string) bool {
 	if !featureFlagsServiceUnleash() {
+		return false
+	}
+
+	if !featureFlagsConfigPresent() {
 		return false
 	}
 


### PR DESCRIPTION
1. If config of feature flags is not present in `ACG_CONFIG` file the feature flags addition is skipped and all calls of `FeatureEnabled` returns `false`.
2. If config of feature flags is present in order to build unleash url we need all parts(scheme, hostname and port) of feature flag endpoint when any of them is missing feature flags are skipped as well.
3. Leftovers of `FeatureFlagsHost`, `FeatureFlagsPort`, `FeatureFlagsSchema`  removed from config