### PR TITLE
add docker-compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .scannerwork/
 sources-api-go
+tmp/

--- a/Makefile
+++ b/Makefile
@@ -59,4 +59,12 @@ generate:
 migration:
 	@sh db/migrations/new_migration.sh
 
+docker-up:
+	@docker-compose up -d sources-db sources-kafka
+	@sleep 7
+	@mkdir -p tmp/db
+	@docker-compose up sources-api-db-setup
+	@docker-compose up init-kafka
+	@docker-compose up -d
+
 .PHONY: setup tidy build clean run container remotedebug debug test lint gci vault listener alltest generate

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,116 @@
+version: '3'
+
+services:
+  sources-api-db-setup:
+    container_name: sources-api-db-setup
+    image: sources-api
+    build:
+      context: .
+    entrypoint: /sources-api-go -setup
+    environment:
+      # db:
+      - DATABASE_HOST=sources-db
+      - DATABASE_PORT=5432
+      - DATABASE_USER=postgres
+      - DATABASE_PASSWORD=postgres
+
+      - ENCRYPTION_KEY=YWFhYWFhYWFhYWFhYWFhYQ
+    depends_on:
+      - sources-db
+
+  sources:
+    container_name: sources-api-server
+    image: sources-api
+    build:
+      context: .
+    environment:
+      # db:
+      - DATABASE_HOST=sources-db
+      - DATABASE_PORT=5432
+      - DATABASE_USER=postgres
+      - DATABASE_PASSWORD=postgres
+      # redis:
+      - REDIS_CACHE_HOST=sources-redis
+      - REDIS_CACHE_PORT=6379
+      # kafka:
+      - QUEUE_HOST=sources-kafka
+      - QUEUE_PORT=29092
+
+      - SOURCES_PSKS=thisMustBeEphemeralOrMinikube
+      - BYPASS_RBAC=true
+      - ENCRYPTION_KEY=YWFhYWFhYWFhYWFhYWFhYQ
+    ports:
+      - 3000:8000
+      - 9394:9394
+    depends_on:
+      - sources-db
+      - sources-redis
+      - sources-kafka
+
+  sources-db:
+    container_name: sources-db
+    image: postgres:14
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    privileged: true
+    ports:
+      - 15434:5432
+    volumes:
+      - ./tmp/db:/var/lib/postgresql/data
+    command:
+      - postgres
+      - -c
+      - log_statement=all
+
+  sources-zookeeper:
+    container_name: sources-zookeeper
+    image: confluentinc/cp-zookeeper
+    environment:
+      - ZOOKEEPER_CLIENT_PORT=32181
+      - ZOOKEEPER_SERVER_ID=1
+
+  sources-kafka:
+    container_name: sources-kafka
+    image: confluentinc/cp-kafka
+    environment:
+      - KAFKA_ADVERTISED_LISTENERS=DOCKER://sources-kafka:29092,LOCALHOST://localhost:9092
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=DOCKER:PLAINTEXT,LOCALHOST:PLAINTEXT
+      - KAFKA_INTER_BROKER_LISTENER_NAME=DOCKER
+      - KAFKA_BROKER_ID=1
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_ZOOKEEPER_CONNECT=sources-zookeeper:32181
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+    ports:
+      - 9092:9092
+      - 29092:29092
+    depends_on:
+      - sources-zookeeper
+
+  init-kafka:
+    image: confluentinc/cp-kafka
+    entrypoint: [ '/bin/sh', '-c' ]
+    command: |
+      "
+      # blocks until kafka is reachable
+      kafka-topics --bootstrap-server sources-kafka:29092 --list
+
+      echo -e 'Creating kafka topics'
+      kafka-topics --bootstrap-server sources-kafka:29092 --create --if-not-exists --topic platform.sources.event-stream --replication-factor 1 --partitions 1
+      kafka-topics --bootstrap-server sources-kafka:29092 --create --if-not-exists --topic platform.sources.status --replication-factor 1 --partitions 1
+
+      echo -e 'Successfully created the following topics:'
+      kafka-topics --bootstrap-server sources-kafka:29092 --list
+      "
+    depends_on:
+      - sources-kafka
+
+  sources-redis:
+    container_name: sources-redis
+    image: redis:5.0.4
+    ports:
+      - 6378:6379
+
+networks:
+  default:
+    name: ${DOCKER_NETWORK_NAME-sources-api_default}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,11 +2,11 @@ version: '3'
 
 services:
   sources-api-db-setup:
-    container_name: sources-api-db-setup
-    image: sources-api
-    build:
-      context: .
-    entrypoint: /sources-api-go -setup
+    image: golang:1.17
+    entrypoint: "bash"
+    command:
+      - -c
+      - "go build && ./sources-api-go -setup"
     environment:
       # db:
       - DATABASE_HOST=sources-db
@@ -15,6 +15,9 @@ services:
       - DATABASE_PASSWORD=postgres
 
       - ENCRYPTION_KEY=YWFhYWFhYWFhYWFhYWFhYQ
+    working_dir: /work
+    volumes:
+      - ./:/work
     depends_on:
       - sources-db
 


### PR DESCRIPTION
To use this compose file and get the service running:
```
$ docker-compose up -d db
---- check that the db is ready ----
sources-db              | 2022-06-03 18:01:24.989 UTC [1] LOG:  database system is ready to accept connections
------------------------------------
$ docker-compose up sources-api-db-setup (this step only needs to be run for a fresh db)
...:"Database \"sources_api_development\" created","tags":["source-api-go"]}
sources-api-db-setup exited with code 0
$ docker-compose up -d sources-kafka
$ docker-compose up init-kafka
...
init-kafka_1            | Successfully created the following topics:
init-kafka_1            | platform.sources.event-stream
init-kafka_1            | platform.sources.status
sources-api-go_init-kafka_1 exited with code 0
$ docker-compose up sources
```

OR, use the make command:
```
make docker-up
```
