### PR TITLE
[wip] New pattern for enforcing tenancy

### DIFF
--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -31,16 +31,26 @@ type sourceDaoImpl struct {
 	TenantID *int64
 }
 
+func (s sourceDaoImpl) getDb() *gorm.DB {
+	if s.TenantID == nil {
+		panic("nil tenant found in source db DAO")
+	}
+
+	return DB.Debug().
+		Model(&m.Source{}).
+		Where("tenant_id = ?", s.TenantID)
+}
+
 func (s *sourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	// allocating a slice of source types, initial length of
 	// 0, size of limit (since we will not be returning more than that)
 	sources := make([]m.Source, 0, limit)
 
-	relationObject, err := m.NewRelationObject(primaryCollection, *s.TenantID, DB.Debug())
+	relationObject, err := m.NewRelationObject(primaryCollection, *s.TenantID, s.getDb())
 	if err != nil {
 		return nil, 0, util.NewErrNotFound(relationObject.StringBaseObject())
 	}
-	query := relationObject.HasMany(&m.Source{}, DB.Debug())
+	query := relationObject.HasMany(&m.Source{}, s.getDb())
 
 	query = query.Where("sources.tenant_id = ?", s.TenantID)
 
@@ -64,7 +74,7 @@ func (s *sourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 
 func (s *sourceDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	sources := make([]m.Source, 0, limit)
-	query := DB.Debug().Model(&m.Source{}).
+	query := s.getDb().
 		Where("sources.tenant_id = ?", s.TenantID)
 
 	query, err := applyFilters(query, filters)
@@ -86,8 +96,7 @@ func (s *sourceDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.Sour
 }
 
 func (s *sourceDaoImpl) ListInternal(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
-	query := DB.Debug().
-		Model(&m.Source{}).
+	query := s.getDb().
 		Select(`sources.id, sources.availability_status, "Tenant".external_tenant`)
 
 	query, err := applyFilters(query, filters)
@@ -110,7 +119,7 @@ func (s *sourceDaoImpl) ListInternal(limit, offset int, filters []util.Filter) (
 
 func (s *sourceDaoImpl) GetById(id *int64) (*m.Source, error) {
 	src := &m.Source{ID: *id}
-	result := DB.Debug().First(src)
+	result := s.getDb().First(src)
 	if result.Error != nil {
 		return nil, util.NewErrNotFound("source")
 	}
@@ -121,7 +130,7 @@ func (s *sourceDaoImpl) GetById(id *int64) (*m.Source, error) {
 // Function that searches for a source and preloads any specified relations
 func (s *sourceDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error) {
 	src := &m.Source{ID: *id}
-	q := DB.Debug().Where("tenant_id = ?", s.TenantID)
+	q := s.getDb()
 
 	for _, preload := range preloads {
 		q = q.Preload(preload)
@@ -141,18 +150,16 @@ func (s *sourceDaoImpl) Create(src *m.Source) error {
 }
 
 func (s *sourceDaoImpl) Update(src *m.Source) error {
-	result := DB.Debug().Updates(src)
+	result := s.getDb().Updates(src)
 	return result.Error
 }
 
 func (s *sourceDaoImpl) Delete(id *int64) (*m.Source, error) {
 	var source m.Source
 
-	result := DB.
-		Debug().
+	result := s.getDb().
 		Clauses(clause.Returning{}).
 		Where("id = ?", id).
-		Where("tenant_id = ?", s.TenantID).
 		Delete(&source)
 
 	if result.Error != nil {
@@ -172,7 +179,7 @@ func (s *sourceDaoImpl) Tenant() *int64 {
 
 func (s *sourceDaoImpl) NameExistsInCurrentTenant(name string) bool {
 	src := &m.Source{Name: name}
-	result := DB.Debug().Where("name = ? AND tenant_id = ?", name, s.TenantID).First(src)
+	result := s.getDb().Where("name = ? AND tenant_id = ?", name, s.TenantID).First(src)
 
 	// If the name is found, GORM returns one row and no errors.
 	return result.Error == nil
@@ -180,9 +187,8 @@ func (s *sourceDaoImpl) NameExistsInCurrentTenant(name string) bool {
 
 func (s *sourceDaoImpl) IsSuperkey(id int64) bool {
 	var valid bool
-	result := DB.Model(&m.Source{}).
+	result := s.getDb().
 		Select("app_creation_workflow = ?", m.AccountAuth).
-		Where("tenant_id = ?", s.TenantID).
 		Where("id = ?", id).
 		First(&valid)
 
@@ -195,7 +201,7 @@ func (s *sourceDaoImpl) IsSuperkey(id int64) bool {
 
 func (s *sourceDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
 	src := m.Source{ID: resource.ResourceID}
-	result := DB.Debug().Find(&src)
+	result := s.getDb().Find(&src)
 	if result.Error != nil {
 		return nil, result.Error
 	}
@@ -205,7 +211,7 @@ func (s *sourceDaoImpl) BulkMessage(resource util.Resource) (map[string]interfac
 }
 
 func (s *sourceDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) (interface{}, error) {
-	result := DB.Debug().Model(&m.Source{ID: resource.ResourceID}).Updates(updateAttributes)
+	result := s.getDb().Model(&m.Source{ID: resource.ResourceID}).Updates(updateAttributes)
 
 	if result.RowsAffected == 0 {
 		return nil, fmt.Errorf("source not found %v", resource)
@@ -219,11 +225,9 @@ func (s *sourceDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttribute
 	return source, nil
 }
 
+// TODO: remove?
 func (s *sourceDaoImpl) FindWithTenant(id *int64) (*m.Source, error) {
-	src := &m.Source{ID: *id}
-	result := DB.Debug().Preload("Tenant").Find(&src)
-
-	return src, result.Error
+	return s.GetByIdWithPreload(id, "Tenant")
 }
 
 func (s *sourceDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
@@ -243,8 +247,7 @@ func (s *sourceDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
 func (s *sourceDaoImpl) ListForRhcConnection(rhcConnectionId *int64, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	sources := make([]m.Source, 0)
 
-	query := DB.Debug().
-		Model(&m.Source{}).
+	query := s.getDb().
 		Joins(`INNER JOIN "source_rhc_connections" "sr" ON "sources"."id" = "sr"."source_id"`).
 		Where(`"sr"."rhc_connection_id" = ?`, rhcConnectionId).
 		Where(`"sr"."tenant_id" = ?`, s.TenantID)
@@ -268,7 +271,7 @@ func (s *sourceDaoImpl) ListForRhcConnection(rhcConnectionId *int64, limit, offs
 }
 
 func (s *sourceDaoImpl) Pause(id int64) error {
-	err := DB.Debug().Transaction(func(tx *gorm.DB) error {
+	err := s.getDb().Transaction(func(tx *gorm.DB) error {
 		err := tx.Debug().
 			Model(&m.Source{}).
 			Where("id = ?", id).
@@ -332,8 +335,7 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 	// The "len(objects) != 0" check to delete the resources is necessary to avoid Gorm issuing the "cannot batch
 	// delete without a where condition" error, since there might be times when the resources don't have any related
 	// sub resources.
-	err := DB.
-		Debug().
+	err := s.getDb().
 		Transaction(func(tx *gorm.DB) error {
 			// Fetch and delete the application authentications.
 			err := tx.
@@ -459,10 +461,9 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 func (s *sourceDaoImpl) Exists(sourceId int64) (bool, error) {
 	var sourceExists bool
 
-	err := DB.Model(&m.Source{}).
+	err := s.getDb().
 		Select("1").
 		Where("id = ?", sourceId).
-		Where("tenant_id = ?", s.TenantID).
 		Scan(&sourceExists).
 		Error
 


### PR DESCRIPTION
Hey all - this is about as far as I got today. Basically it abstracts the `dao.DB` `*gorm.DB` instance to a function on the dao struct instance.

The struct(s) will have a private method on them that basically returns a DB from which queries can be ran - BUT also contains the `Where("tenant_id = ?")` clause.

----

As part of this I was hoping to also come up with a pre-commit hook that checks for any `DB.*` statements - and was able to accomplish that with this command line:
`grep DB\. dao/source_dao.go -n | grep -v Create | grep -v tx | grep -v '*gorm.DB'`
Basically it searches for DB. but ignores any create/transaction related lines. This command should only ever return **1** line since we only have that function call in the `getDb()` function.

---

One caveat to this is that we can't really enforce the Where clause when using transactions - so we have to do our diligence there or wherever we're using transactions. Looking forward to this getting implemented! 