### PR TITLE
[RHCLOUD-19742] remove tenant from tests for source type, app type and meta data handlers

### DIFF
--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -232,7 +232,7 @@ func TestApplicationTypeGet(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/application_types/1",
 		nil,
-		map[string]interface{}{},
+		nil,
 	)
 
 	c.SetParamNames("id")
@@ -263,7 +263,7 @@ func TestApplicationTypeGetNotFound(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/application_types/12362095",
 		nil,
-		map[string]interface{}{},
+		nil,
 	)
 
 	c.SetParamNames("id")
@@ -283,7 +283,7 @@ func TestApplicationTypeGetBadRequest(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/application_types/xxx",
 		nil,
-		map[string]interface{}{},
+		nil,
 	)
 
 	c.SetParamNames("id")

--- a/meta_data_handlers_test.go
+++ b/meta_data_handlers_test.go
@@ -163,10 +163,9 @@ func TestMetaDataList(t *testing.T) {
 		"/api/sources/v3.1/app_meta_data",
 		nil,
 		map[string]interface{}{
-			"limit":    100,
-			"offset":   0,
-			"filters":  []util.Filter{},
-			"tenantID": int64(1),
+			"limit":   100,
+			"offset":  0,
+			"filters": []util.Filter{},
 		},
 	)
 
@@ -220,7 +219,6 @@ func TestMetaDataListBadRequestInvalidFilter(t *testing.T) {
 			"filters": []util.Filter{
 				{Name: "wrongName", Value: []string{"wrongValue"}},
 			},
-			"tenantID": int64(1),
 		},
 	)
 
@@ -238,9 +236,7 @@ func TestMetaDataGet(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/app_meta_data/1",
 		nil,
-		map[string]interface{}{
-			"tenantID": int64(1),
-		},
+		nil,
 	)
 
 	c.SetParamNames("id")
@@ -267,9 +263,7 @@ func TestMetaDataGetNotFound(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/app_meta_data/13984739874",
 		nil,
-		map[string]interface{}{
-			"tenantID": int64(1),
-		},
+		nil,
 	)
 
 	c.SetParamNames("id")
@@ -289,9 +283,7 @@ func TestMetaDataGetBadRequest(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/app_meta_data/xxx",
 		nil,
-		map[string]interface{}{
-			"tenantID": int64(1),
-		},
+		nil,
 	)
 
 	c.SetParamNames("id")

--- a/source_type_handlers_test.go
+++ b/source_type_handlers_test.go
@@ -97,9 +97,8 @@ func TestSourceTypeGet(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/source_types/1",
 		nil,
-		map[string]interface{}{
-			"tenantID": int64(1),
-		})
+		nil,
+	)
 
 	c.SetParamNames("id")
 	c.SetParamValues("1")
@@ -129,9 +128,7 @@ func TestSourceTypeGetNotFound(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/source_types/3098539345",
 		nil,
-		map[string]interface{}{
-			"tenantID": int64(1),
-		},
+		nil,
 	)
 
 	c.SetParamNames("id")
@@ -151,9 +148,7 @@ func TestSourceTypeGetBadRequest(t *testing.T) {
 		http.MethodGet,
 		"/api/sources/v3.1/source_types/xxx",
 		nil,
-		map[string]interface{}{
-			"tenantID": int64(1),
-		},
+		nil,
 	)
 
 	c.SetParamNames("id")


### PR DESCRIPTION
Some tests for source type handler, application type handler and meta data handler don't need tenant id in echo Context.

**JIRA:** [RHCLOUD-19742](https://issues.redhat.com/browse/RHCLOUD-19742)