### PR TITLE
[RHCLOUD-19374] Migration - added user_id column into related tables

### DIFF
--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -164,6 +164,7 @@ func MigrateSchema() {
 		LastAvailableAt         time.Time      `gorm:"column:last_available_at"`
 		SourceId                int64          `gorm:"column:source_id"`
 		TenantId                int64          `gorm:"column:tenant_id"`
+		UserID                  *int64         `gorm:"column:user_id"`
 		ResourceType            string         `gorm:"column:resource_type"`
 		ResourceId              int64          `gorm:"column:resource_id"`
 		CreatedAt               time.Time      `gorm:"column:created_at"`
@@ -242,6 +243,7 @@ func UpdateTablesSequences(schema string) {
 		"source_types",
 		"rhc_connections",
 		"tenants",
+		"users",
 		"applications",
 		"endpoints",
 		"rhc_connections",

--- a/db/migrations/20220607140800_add_user_id_column.go
+++ b/db/migrations/20220607140800_add_user_id_column.go
@@ -1,0 +1,131 @@
+package migrations
+
+import (
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// AddUserIdColumnIntoTables adds into tables "sources", "applications", "authentications"
+// and "application_authentications" a new column "user_id" and creates in each table
+// a foreign key, e.g. "sources.user_id" -> "users.id".
+func AddUserIdColumnIntoTables() *gormigrate.Migration {
+	type User struct {
+		ID int64
+	}
+
+	type Source struct {
+		UserID *int64
+		User   User
+	}
+
+	type Application struct {
+		UserID *int64
+		User   User
+	}
+
+	type ApplicationAuthentication struct {
+		UserID *int64
+		User   User
+	}
+
+	type Authentication struct {
+		UserID *int64
+		User   User
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220607140800",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "add_user_id_column" started`)
+			defer logging.Log.Info(`Migration "add_user_id_column" ended`)
+
+			err := db.Transaction(func(tx *gorm.DB) error {
+				//Add column "user_id" into "sources" table
+				err := tx.Migrator().AddColumn(&Source{}, "UserID")
+				if err != nil {
+					return err
+				}
+				// Add foreign key between sources.user_id and users_id
+				err = tx.Migrator().CreateConstraint(&Source{}, "User")
+				if err != nil {
+					return err
+				}
+
+				err = tx.Migrator().AddColumn(&Application{}, "UserID")
+				if err != nil {
+					return err
+				}
+				err = tx.Migrator().CreateConstraint(&Application{}, "User")
+				if err != nil {
+					return err
+				}
+
+				err = tx.Migrator().AddColumn(&ApplicationAuthentication{}, "UserID")
+				if err != nil {
+					return err
+				}
+				err = tx.Migrator().CreateConstraint(&ApplicationAuthentication{}, "User")
+				if err != nil {
+					return err
+				}
+
+				err = tx.Migrator().AddColumn(&Authentication{}, "UserID")
+				if err != nil {
+					return err
+				}
+				err = tx.Migrator().CreateConstraint(&Authentication{}, "User")
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Transaction(func(tx *gorm.DB) error {
+				err := tx.Migrator().DropConstraint(&Source{}, "User")
+				if err != nil {
+					return err
+				}
+				err = tx.Migrator().DropColumn(&Source{}, "UserID")
+				if err != nil {
+					return err
+				}
+
+				err = tx.Migrator().DropConstraint(&Application{}, "User")
+				if err != nil {
+					return err
+				}
+				err = tx.Migrator().DropColumn(&Application{}, "UserID")
+				if err != nil {
+					return err
+				}
+
+				err = tx.Migrator().DropConstraint(&ApplicationAuthentication{}, "User")
+				if err != nil {
+					return err
+				}
+				err = tx.Migrator().DropColumn(&ApplicationAuthentication{}, "UserID")
+				if err != nil {
+					return err
+				}
+
+				err = tx.Migrator().DropConstraint(&Authentication{}, "User")
+				if err != nil {
+					return err
+				}
+				err = tx.Migrator().DropColumn(&Authentication{}, "UserID")
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -21,6 +21,7 @@ var migrationsCollection = []*gormigrate.Migration{
 	MakeEmptyExternalTenantsOrgIdsNull(),
 	RemoveDuplicatedTenantIdsOrgIds(),
 	AddTenantsExternalTenantOrgIdUniqueIndex(),
+	AddUserIdColumnIntoTables(),
 }
 
 var ctx = context.Background()

--- a/internal/testutils/database/database.go
+++ b/internal/testutils/database/database.go
@@ -55,6 +55,7 @@ func CreateFixtures() {
 	dao.DB.Create(&fixtures.TestSourceData)
 	dao.DB.Create(&fixtures.TestApplicationData)
 	dao.DB.Create(&fixtures.TestAuthenticationData)
+
 	dao.DB.Create(&fixtures.TestApplicationAuthenticationData)
 
 	dao.DB.Create(&fixtures.TestRhcConnectionData)
@@ -110,6 +111,7 @@ func MigrateSchema() {
 		LastAvailableAt         time.Time      `gorm:"column:last_available_at"`
 		SourceId                int64          `gorm:"column:source_id"`
 		TenantId                int64          `gorm:"column:tenant_id"`
+		UserID                  *int64         `gorm:"column:user_id"`
 		ResourceType            string         `gorm:"column:resource_type"`
 		ResourceId              int64          `gorm:"column:resource_id"`
 		CreatedAt               time.Time      `gorm:"column:created_at"`
@@ -118,6 +120,7 @@ func MigrateSchema() {
 
 	err := dao.DB.AutoMigrate(
 		&m.Tenant{},
+		&m.User{},
 
 		&m.SourceType{},
 		&m.ApplicationType{},
@@ -157,6 +160,7 @@ func UpdateTablesSequences() {
 		"source_rhc_connections",
 		"source_types",
 		"tenants",
+		"users",
 	}
 
 	for _, table := range tables {

--- a/model/application.go
+++ b/model/application.go
@@ -27,6 +27,8 @@ type Application struct {
 
 	TenantID int64
 	Tenant   Tenant
+	UserID   *int64 `json:"user_id"`
+	User     User
 
 	SourceID int64 `json:"source_id"`
 	Source   Source

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -19,6 +19,8 @@ type ApplicationAuthentication struct {
 
 	TenantID int64
 	Tenant   Tenant
+	UserID   *int64
+	User     User
 
 	ApplicationID int64 `json:"application_id"`
 	Application   Application

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -36,6 +36,8 @@ type Authentication struct {
 
 	TenantID int64 `json:"tenant_id"`
 	Tenant   Tenant
+	UserID   *int64 `json:"user_id"`
+	User     User
 
 	ResourceType string `json:"resource_type"`
 	ResourceID   int64  `json:"resource_id"`

--- a/model/source.go
+++ b/model/source.go
@@ -39,6 +39,8 @@ type Source struct {
 
 	Tenant   Tenant
 	TenantID int64 `json:"tenant_id"`
+	User     User
+	UserID   *int64 `json:"user_id"`
 
 	ApplicationTypes     []*ApplicationType `gorm:"many2many:applications"`
 	Applications         []Application


### PR DESCRIPTION
For **Single User based Sources** we need to add column "user_id" into related tables and field "UserID" into related models.

The user_id columns will contain NULL value or some concrete user_id which exists in table users => the type of UserID fields in models have to be pointer (to support NULL values) and there must be foreign key between user_id and id from table "users".

Test DB had to be updated to support new table and new UserID fields.

**JIRA:** [RHCLOUD-19374](https://issues.redhat.com/browse/RHCLOUD-19374)