### PR TITLE
Create users in bulk create request for user resource ownership application types

### DIFF
--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -33,8 +33,10 @@ func BulkCreate(c echo.Context) error {
 		return fmt.Errorf("failed to pull identity from request")
 	}
 
+	user := &m.User{TenantID: tenantID, UserID: id.Identity.User.UserID}
+
 	// TODO: Pull the identity from the context after the org_id changes are merged.
-	output, err := service.BulkAssembly(req, &m.Tenant{Id: tenantID, ExternalTenant: id.Identity.AccountNumber})
+	output, err := service.BulkAssembly(req, &m.Tenant{Id: tenantID, ExternalTenant: id.Identity.AccountNumber}, user)
 	if err != nil {
 		return err
 	}

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
@@ -39,4 +40,186 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 	if err.Error() != "no source type present, need either [source_type_name] or [source_type_id]" {
 		t.Error(err)
 	}
+}
+
+func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	conf.ResourceOwnership = "user"
+
+	testUserId := "testUser"
+	identityHeader := testutils.IdentityHeaderForUser(testUserId)
+
+	nameSource := "test source"
+	sourceTypeName := "bitbucket"
+	applicationTypeName := "app-studio"
+	authenticationResourceType := "application"
+
+	requestBody := testutils.SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType)
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, _ := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/bulk_create",
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+	c.Set("identity", &identity.XRHID{Identity: identityHeader})
+
+	err = BulkCreate(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var users []m.User
+	err = dao.DB.Model(&m.User{}).Find(&users).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(users) != 1 {
+		t.Errorf("1 user expected instead of %d", len(users))
+	}
+
+	if users[0].UserID != testUserId {
+		t.Errorf("expected userid is %s instead of %s", testUserId, users[0].UserID)
+	}
+
+	err = dao.DB.Model(&m.User{}).Delete(&users).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
+	if err != nil {
+		t.Errorf(`unexpected error received when deleting the source: %s`, err)
+	}
+}
+
+func TestCreateUserWithoutResourceOwnershipApplicationType(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	conf.ResourceOwnership = "user"
+
+	testUserId := "testUser"
+	identityHeader := testutils.IdentityHeaderForUser(testUserId)
+
+	nameSource := "test source"
+	sourceTypeName := "amazon"
+	applicationTypeName := "cost-management"
+	authenticationResourceType := "application"
+
+	requestBody := testutils.SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType)
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, _ := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/bulk_create",
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+	c.Set("identity", &identity.XRHID{Identity: identityHeader})
+
+	err = BulkCreate(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var users []m.User
+	err = dao.DB.Model(&m.User{}).Find(&users).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(users) != 0 {
+		t.Errorf("0 user expected instead of %d", len(users))
+	}
+
+	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
+	if err != nil {
+		t.Errorf(`unexpected error received when deleting the source: %s`, err)
+	}
+}
+
+func TestCreateUserWithoutResourceOwnershipConfig(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	conf.ResourceOwnership = ""
+
+	testUserId := "testUser"
+	identityHeader := testutils.IdentityHeaderForUser(testUserId)
+
+	nameSource := "test source"
+	sourceTypeName := "bitbucket"
+	applicationTypeName := "app-studio"
+	authenticationResourceType := "application"
+
+	requestBody := testutils.SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType)
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, _ := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/bulk_create",
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+	c.Set("identity", &identity.XRHID{Identity: identityHeader})
+
+	err = BulkCreate(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var users []m.User
+	err = dao.DB.Model(&m.User{}).Find(&users).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(users) != 0 {
+		t.Errorf("0 users expected instead of %d", len(users))
+	}
+
+	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
+	if err != nil {
+		t.Errorf(`unexpected error received when deleting the source: %s`, err)
+	}
+}
+
+func cleanSourceForTenant(sourceName string, tenantID *int64) error {
+	sourceDao := dao.GetSourceDao(tenantID)
+
+	source := &m.Source{Name: sourceName}
+	err := dao.DB.Model(&m.Source{}).Where("name = ?", source.Name).Find(&source).Error
+	if err != nil {
+		return err
+	}
+
+	_, _, _, _, _, err = sourceDao.DeleteCascade(source.ID)
+
+	return err
 }

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -80,7 +80,7 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 	}
 
 	var users []m.User
-	err = dao.DB.Model(&m.User{}).Find(&users).Error
+	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).Find(&users).Error
 	if err != nil {
 		t.Error(err)
 	}
@@ -93,14 +93,14 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Errorf("expected userid is %s instead of %s", testUserId, users[0].UserID)
 	}
 
-	err = dao.DB.Model(&m.User{}).Delete(&users).Error
-	if err != nil {
-		t.Error(err)
-	}
-
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
 	if err != nil {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)
+	}
+
+	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).Delete(&users).Error
+	if err != nil {
+		t.Error(err)
 	}
 }
 
@@ -142,7 +142,7 @@ func TestCreateUserWithoutResourceOwnershipApplicationType(t *testing.T) {
 	}
 
 	var users []m.User
-	err = dao.DB.Model(&m.User{}).Find(&users).Error
+	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).Find(&users).Error
 	if err != nil {
 		t.Error(err)
 	}
@@ -195,7 +195,7 @@ func TestCreateUserWithoutResourceOwnershipConfig(t *testing.T) {
 	}
 
 	var users []m.User
-	err = dao.DB.Model(&m.User{}).Find(&users).Error
+	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).Find(&users).Error
 	if err != nil {
 		t.Error(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -51,6 +51,7 @@ type SourcesApiConfig struct {
 	MigrationsReset           bool
 	SecretStore               string
 	TenantTranslatorUrl       string
+	ResourceOwnership         string
 }
 
 // Get - returns the config parsed from runtime vars
@@ -155,6 +156,7 @@ func Get() *SourcesApiConfig {
 	}
 	options.SetDefault("SecretStore", secretStore)
 	options.SetDefault("TenantTranslatorUrl", os.Getenv("TENANT_TRANSLATOR_URL"))
+	options.SetDefault("ResourceOwnership", os.Getenv("RESOURCE_OWNERSHIP"))
 
 	// Parse any Flags (using our own flag set to not conflict with the global flag)
 	fs := flag.NewFlagSet("runtime", flag.ContinueOnError)
@@ -224,6 +226,7 @@ func Get() *SourcesApiConfig {
 		MigrationsReset:           options.GetBool("MigrationsReset"),
 		SecretStore:               options.GetString("SecretStore"),
 		TenantTranslatorUrl:       options.GetString("TenantTranslatorUrl"),
+		ResourceOwnership:         options.GetString("ResourceOwnership"),
 	}
 
 	return parsedConfig

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -171,3 +171,7 @@ type TenantDao interface {
 	// and if it is not preset, by its EBS account number.
 	TenantByIdentity(identity *identity.Identity) (*m.Tenant, error)
 }
+
+type UserDao interface {
+	CreateIfResourceOwnershipActive(userResource *m.UserResource) error
+}

--- a/dao/user_dao.go
+++ b/dao/user_dao.go
@@ -1,0 +1,57 @@
+package dao
+
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
+
+var GetUserDao func(*int64) UserDao
+
+// getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
+func getDefaultUserDao(tenantId *int64) UserDao {
+	return &userDaoImpl{
+		TenantID: tenantId,
+	}
+}
+
+// init sets the default DAO implementation so that other packages can request it easily.
+func init() {
+	GetUserDao = getDefaultUserDao
+}
+
+type userDaoImpl struct {
+	TenantID *int64
+}
+
+func (u *userDaoImpl) create(user *m.User) error {
+	var userExists bool
+
+	err := DB.Model(&m.User{}).
+		Select("1").
+		Where("user_id = ?", user.UserID).
+		Where("tenant_id = ?", *u.TenantID).
+		Scan(&userExists).
+		Error
+
+	if err != nil {
+		return err
+	}
+
+	if !userExists {
+		user.TenantID = *u.TenantID
+		result := DB.Debug().Create(user)
+		return result.Error
+	} else {
+		return nil
+	}
+}
+
+func (u *userDaoImpl) CreateIfResourceOwnershipActive(userResource *m.UserResource) error {
+	if userResource.UserOwnershipActive() {
+		err := u.create(userResource.User)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/dao/user_dao.go
+++ b/dao/user_dao.go
@@ -6,7 +6,7 @@ import (
 
 var GetUserDao func(*int64) UserDao
 
-// getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
+// getDefaultUserDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultUserDao(tenantId *int64) UserDao {
 	return &userDaoImpl{
 		TenantID: tenantId,

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -142,6 +142,8 @@ objects:
               optional: true
         - name: FEATURE_FLAGS_SERVICE
           value: ${FEATURE_FLAGS_SERVICE}
+        - name: RESOURCE_OWNERSHIP
+          value: ${RESOURCE_OWNERSHIP}
         readinessProbe:
           tcpSocket:
             port: 8000
@@ -326,4 +328,7 @@ parameters:
 - description: Specify name of service for Feature Flags
   name: FEATURE_FLAGS_SERVICE
   value: 'unleash'
+- description: Specify name to select strategy to ensure resource ownership
+  name: RESOURCE_OWNERSHIP
+  value: ''
 

--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -1,6 +1,10 @@
 package fixtures
 
-import m "github.com/RedHatInsights/sources-api-go/model"
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
+
+var userOwnership = "user"
 
 var TestApplicationTypeData = []m.ApplicationType{
 	{
@@ -16,5 +20,18 @@ var TestApplicationTypeData = []m.ApplicationType{
 	{
 		Id:          100,
 		DisplayName: "app type without related sources",
+	},
+	{
+		Id:                   3,
+		DisplayName:          "app-studio",
+		Name:                 "/insights/platform/app-studio",
+		ResourceOwnership:    &userOwnership,
+		SupportedSourceTypes: []byte(`["bitbucket", "dockerhub", "github", "gitlab", "quay"]`),
+	},
+	{
+		Id:                   4,
+		DisplayName:          "Cost Management",
+		Name:                 "/insights/platform/cost-management",
+		SupportedSourceTypes: []byte(`["amazon", "azure", "google", "oracle-cloud-infrastructure", "openshift", "ibm"]`),
 	},
 }

--- a/internal/testutils/fixtures/source_type.go
+++ b/internal/testutils/fixtures/source_type.go
@@ -12,6 +12,10 @@ var TestSourceTypeData = []m.SourceType{
 		Name: "google",
 	},
 	{
+		Id:   3,
+		Name: "bitbucket",
+	},
+	{
 		Id:   100,
 		Name: "source type without sources in fixtures",
 	},

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 var conf = config.Get()
@@ -65,4 +66,23 @@ func AssertLinks(t *testing.T, path string, links util.Links, limit int, offset 
 	if links.Last != expectedLastLink {
 		t.Error("last link is not correct for " + path)
 	}
+}
+
+func IdentityHeaderForUser(testUserId string) identity.Identity {
+	accountNumber := fixtures.TestTenantData[0].ExternalTenant
+	return identity.Identity{AccountNumber: accountNumber, User: identity.User{UserID: testUserId}}
+}
+
+func SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType string) *model.BulkCreateRequest {
+	sourceCreateRequest := model.SourceCreateRequest{Name: &nameSource}
+	bulkCreateSource := model.BulkCreateSource{SourceCreateRequest: sourceCreateRequest, SourceTypeName: sourceTypeName}
+
+	bulkCreateApplication := model.BulkCreateApplication{SourceName: nameSource, ApplicationTypeName: applicationTypeName}
+
+	authenticationCreateRequest := model.AuthenticationCreateRequest{ResourceType: authenticationResourceType}
+	bulkCreateAuthentication := model.BulkCreateAuthentication{AuthenticationCreateRequest: authenticationCreateRequest, ResourceName: applicationTypeName}
+
+	return &model.BulkCreateRequest{Sources: []model.BulkCreateSource{bulkCreateSource},
+		Applications:    []model.BulkCreateApplication{bulkCreateApplication},
+		Authentications: []model.BulkCreateAuthentication{bulkCreateAuthentication}}
 }

--- a/model/application_type.go
+++ b/model/application_type.go
@@ -11,8 +11,6 @@ import (
 	"gorm.io/datatypes"
 )
 
-const UserOwnership = "user"
-
 type ApplicationType struct {
 	//fields for gorm
 	Id        int64     `gorm:"primarykey" json:"id"`

--- a/model/application_type.go
+++ b/model/application_type.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/datatypes"
 )
 
+const UserOwnership = "user"
+
 type ApplicationType struct {
 	//fields for gorm
 	Id        int64     `gorm:"primarykey" json:"id"`
@@ -66,4 +68,11 @@ func (at *ApplicationType) AvailabilityCheckURL() *url.URL {
 	}
 
 	return url
+}
+
+func (at *ApplicationType) UserResourceOwnership() bool {
+	if at.ResourceOwnership == nil {
+		return false
+	}
+	return *at.ResourceOwnership == UserOwnership
 }

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -1,0 +1,7 @@
+package model
+
+type UserResource struct {
+	SourceNames           []string
+	ApplicationTypesNames []string
+	User                  *User
+}

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -4,17 +4,27 @@ type UserResource struct {
 	SourceNames           []string
 	ApplicationTypesNames []string
 	User                  *User
+	ResourceOwnership     string
 }
 
 func (ur *UserResource) AddSourceAndApplicationTypeNames(sourceName, applicationTypeName string) {
-	ur.SourceNames = append(ur.SourceNames, sourceName)
-	ur.ApplicationTypesNames = append(ur.ApplicationTypesNames, applicationTypeName)
+	if ur.userResourceOwnership() {
+		ur.SourceNames = append(ur.SourceNames, sourceName)
+		ur.ApplicationTypesNames = append(ur.ApplicationTypesNames, applicationTypeName)
+	}
 }
 
 func (ur *UserResource) UserOwnershipActive() bool {
-	return len(ur.SourceNames) > 0 && len(ur.ApplicationTypesNames) > 0 && ur.userIDPresent()
+	return len(ur.SourceNames) > 0 &&
+		len(ur.ApplicationTypesNames) > 0 &&
+		ur.userIDPresent() &&
+		ur.userResourceOwnership()
 }
 
 func (ur *UserResource) userIDPresent() bool {
 	return ur.User.UserID != "" && ur.User != nil
+}
+
+func (ur *UserResource) userResourceOwnership() bool {
+	return ur.ResourceOwnership == "user"
 }

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -22,7 +22,7 @@ func (ur *UserResource) UserOwnershipActive() bool {
 }
 
 func (ur *UserResource) userIDPresent() bool {
-	return ur.User.UserID != "" && ur.User != nil
+	return ur.User != nil && ur.User.UserID != ""
 }
 
 func (ur *UserResource) userResourceOwnership() bool {

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -26,5 +26,5 @@ func (ur *UserResource) userIDPresent() bool {
 }
 
 func (ur *UserResource) userResourceOwnership() bool {
-	return ur.ResourceOwnership == "user"
+	return ur.ResourceOwnership == UserOwnership
 }

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -1,5 +1,7 @@
 package model
 
+const UserOwnership = "user"
+
 type UserResource struct {
 	SourceNames           []string
 	ApplicationTypesNames []string

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -5,3 +5,16 @@ type UserResource struct {
 	ApplicationTypesNames []string
 	User                  *User
 }
+
+func (ur *UserResource) AddSourceAndApplicationTypeNames(sourceName, applicationTypeName string) {
+	ur.SourceNames = append(ur.SourceNames, sourceName)
+	ur.ApplicationTypesNames = append(ur.ApplicationTypesNames, applicationTypeName)
+}
+
+func (ur *UserResource) UserOwnershipActive() bool {
+	return len(ur.SourceNames) > 0 && len(ur.ApplicationTypesNames) > 0 && ur.userIDPresent()
+}
+
+func (ur *UserResource) userIDPresent() bool {
+	return ur.User.UserID != "" && ur.User != nil
+}

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -31,7 +31,7 @@ import (
 	3. Saving the Authentications
 	4. Saving the ApplicationAuthentications if necessary
 */
-func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant) (*m.BulkCreateOutput, error) {
+func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, _ *m.User) (*m.BulkCreateOutput, error) {
 	// the output from this request.
 	var output m.BulkCreateOutput
 

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	l "github.com/RedHatInsights/sources-api-go/logger"
@@ -480,7 +481,7 @@ func loadUserResourceSettingFromBulkCreateApplication(userResource *m.UserResour
 }
 
 func userResourceFromBulkCreateApplications(user *m.User, applications []m.BulkCreateApplication, tenant *m.Tenant) (*m.UserResource, error) {
-	userResource := &m.UserResource{User: user}
+	userResource := &m.UserResource{User: user, ResourceOwnership: config.Get().ResourceOwnership}
 
 	for _, reqApp := range applications {
 		err := loadUserResourceSettingFromBulkCreateApplication(userResource, &reqApp, tenant)

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -31,13 +31,24 @@ import (
 	3. Saving the Authentications
 	4. Saving the ApplicationAuthentications if necessary
 */
-func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, _ *m.User) (*m.BulkCreateOutput, error) {
+func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.BulkCreateOutput, error) {
 	// the output from this request.
 	var output m.BulkCreateOutput
 
 	// initiate a transaction that we'll rollback if anything bad happens.
 	err := dao.DB.Transaction(func(tx *gorm.DB) error {
 		var err error
+
+		userResource, err := userResourceFromBulkCreateApplications(user, req.Applications, tenant)
+		if err != nil {
+			return err
+		}
+
+		userDao := dao.GetUserDao(&tenant.Id)
+		err = userDao.CreateIfResourceOwnershipActive(userResource)
+		if err != nil {
+			return err
+		}
 
 		// parse the sources, then save them in the transaction.
 		output.Sources, err = parseSources(req.Sources, tenant)
@@ -455,4 +466,28 @@ func applicationFromBulkCreateApplication(reqApplication *m.BulkCreateApplicatio
 	}
 
 	return &a, nil
+}
+
+func loadUserResourceSettingFromBulkCreateApplication(userResource *m.UserResource, bulkCreateApplication *m.BulkCreateApplication, tenant *m.Tenant) error {
+	app, err := applicationFromBulkCreateApplication(bulkCreateApplication, tenant)
+	if err != nil {
+		return err
+	} else if app.ApplicationType.UserResourceOwnership() {
+		userResource.AddSourceAndApplicationTypeNames(bulkCreateApplication.SourceName, bulkCreateApplication.ApplicationTypeName)
+	}
+
+	return nil
+}
+
+func userResourceFromBulkCreateApplications(user *m.User, applications []m.BulkCreateApplication, tenant *m.Tenant) (*m.UserResource, error) {
+	userResource := &m.UserResource{User: user}
+
+	for _, reqApp := range applications {
+		err := loadUserResourceSettingFromBulkCreateApplication(userResource, &reqApp, tenant)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return userResource, nil
 }


### PR DESCRIPTION
### What ?
When you create source (+related objects) with `/bulk_create` - it adds record (`user_id`, `tenant_id`) to table `users`.

### Required conditions in bulk create request
- application type for the sources has `ApplicationType#ResourceOwnership` column set to `user`.(URO Application Type = User Resource Ownership Application Type)
- env. variable `RESOURCE_OWNERSHIP` is set to `user`. (set to empty string now to disable this feature)
- user_id of user has to be in header

### How ?

We need to determine from request and headers previously mentioned points. 
There is used new struct + its function to handle it:

```go
type UserResource struct {
 	SourceNames           []string
 	ApplicationTypesNames []string
 	User                  *User
        ResourceOwnership     string
 }
```

`ApplicationTypesNames` -  array to gather URO application types names from request  
`SourceNames` - array to gather source names from request which are tied with  "URO Application Type" through application.
`User` - user from header
`ResourceOwnership ` - it is for enabling/disabling this feature (value `user` means enabled)

There are couple function with ensures correct populating this struct or also functions like `UserOwnershipActive` to ask whether all required conditions are active so we can create users.


### Test
x-rh-identity:


```json
{
   "identity":{
      "account_number":"${ACCOUNT_NUMBER}",
      "user":{
         "is_active":true,
         "locale":"en_US",
         "is_org_admin":true,
         "username":"Test",
         "email":"test@test.com",
         "first_name":"Test",
         "user_id":"55555555",
         "last_name":"User",
         "is_internal":true
      }
   },
   "internal":{
      "org_id":"000001"
   }
}
```

```
POST http://localhost:{{port}}/api/sources/v3.1/bulk_create
Content-Type: application/json; charset=UTF-8
x-rh-identity: {{x-rh-identity}}

{
  "sources": [
    {
      "name": "A10",
      "source_type_name": "bitbucket"
    }
  ],
  "applications": [
    {
      "source_name": "A10",
      "application_type_name": "app-studio"
    }
  ],
  "authentications": [
    {
      "resource_type": "application",
      "resource_name": "app-studio",
      "username": "myUser",
      "password": "myPass"
    }
  ]
}
```

### Links
part of https://issues.redhat.com/browse/RHCLOUD-19196