### PR TITLE
[RHCLOUD-19378] feature: "NULL" on "external_tenant" and "org_id" columns by default

### DIFF
--- a/model/tenant.go
+++ b/model/tenant.go
@@ -2,10 +2,14 @@ package model
 
 import "time"
 
+// Tenant represents the tenant object we will store on the database. The "external_tenant" and "org_id" columns have a
+// "null" default value, so that Gorm inserts "null" when receiving an empty "AccountNumber" or "OrgId" value from an
+// identity header. Empty values are considered when enforcing the "unique index" on those columns, whilst the "NULL"s
+// are not considered.
 type Tenant struct {
 	Id             int64
-	ExternalTenant string
-	OrgID          string
+	ExternalTenant string `gorm:"default:null"`
+	OrgID          string `gorm:"default:null"`
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }


### PR DESCRIPTION
The unique indexes on Postgres don't count "NULL" values as duplicates,
but empty strings do.

Since our "Tenant" model uses non-pointer values, whenever we receive an
identity header without an "AccountNumber" or an "OrgId" number, we are
inserting empty strings instead of null values.

This change would prevent that by inserting "NULL" values in the
database whenever we receive empty values.

## Links

[[RHCLOUD-19378]](https://issues.redhat.com/browse/RHCLOUD-19378)