### PR TITLE
[RHCLOUD-19378] feature: migration to make empty "external_tenants" and "org_ids" null

### DIFF
--- a/db/migrations/20220608090000_make_empty_external_tenants_org_ids_null.go
+++ b/db/migrations/20220608090000_make_empty_external_tenants_org_ids_null.go
@@ -1,0 +1,64 @@
+package migrations
+
+import (
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// MakeEmptyExternalTenantsOrgIdsNull makes all the empty "external_tenant" and "org_id" values NULL in the database.
+func MakeEmptyExternalTenantsOrgIdsNull() *gormigrate.Migration {
+	return &gormigrate.Migration{
+		ID: "20220608090000",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "make empty external tenants and org ids null" started`)
+			defer logging.Log.Info(`Migration "make empty external tenants and org ids null" ended`)
+
+			err := db.Debug().Transaction(func(tx *gorm.DB) error {
+				err := tx.
+					Model(&model.Tenant{}).
+					Where("external_tenant = ''").
+					Update("external_tenant", nil).
+					Error
+
+				if err != nil {
+					return err
+				}
+
+				err = tx.
+					Model(&model.Tenant{}).
+					Where("org_id = ''").
+					Update("org_id", nil).
+					Error
+
+				return err
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Debug().Transaction(func(tx *gorm.DB) error {
+				err := tx.
+					Model(&model.Tenant{}).
+					Where("external_tenant IS NULL").
+					Update("external_tenant", "").
+					Error
+
+				if err != nil {
+					return err
+				}
+
+				err = tx.
+					Model(&model.Tenant{}).
+					Where("org_id IS NULL").
+					Update("org_id", "").
+					Error
+
+				return err
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -18,6 +18,7 @@ var migrationsCollection = []*gormigrate.Migration{
 	SourceTypesAddCategoryColumn(),
 	AddRetryCounterToApplications(),
 	AddTableUsers(),
+	MakeEmptyExternalTenantsOrgIdsNull(),
 }
 
 var ctx = context.Background()


### PR DESCRIPTION
The empty values on the "external_tenants" and "org_id" columns are
considered when applying a unique index or a unique constraint, so we
need to make sure that the empty values are replaced by "NULL", since
"NULL" is not considered when applying such constraints.

## Links

[[RHCLOUD-19378]](https://issues.redhat.com/browse/RHCLOUD-19378)