### PR TITLE
[RHCLOUD-19374] Migration and related changes for Resource Ownership for App studio application type 

### DIFF
--- a/dao/seeding.go
+++ b/dao/seeding.go
@@ -179,6 +179,7 @@ func seedApplicationTypes() error {
 		at.SupportedAuthenticationTypes = supportedAuthenticationTypes
 		at.DisplayName = values.DisplayName
 		at.Name = name
+		at.ResourceOwnership = values.ResourceOwnership
 
 		var result *gorm.DB
 		// if this is a new record we need to create rather than save.

--- a/dao/seeding_types.go
+++ b/dao/seeding_types.go
@@ -21,6 +21,7 @@ type applicationTypeSeed struct {
 	DependentApplications        interface{} `json:"dependent_applications"`
 	SupportedSourceTypes         interface{} `json:"supported_source_types"`
 	SupportedAuthenticationTypes interface{} `json:"supported_authentication_types"`
+	ResourceOwnership            *string     `json:"resource_ownership"`
 }
 
 const SuperKeyMetaData = "SuperKeyMetaData"

--- a/db/migrations/20220607215900_add_resource_ownership_column.go
+++ b/db/migrations/20220607215900_add_resource_ownership_column.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// AddResouceOwnershipToApplicationTypes adds new column "resource_ownership" into table
+// "application_types".
+func AddResouceOwnershipToApplicationTypes() *gormigrate.Migration {
+	type ApplicationType struct {
+		ResourceOwnership *string `gorm:"type:CHARACTER VARYING"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220607215900",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "add_resource_ownership_column" started`)
+			defer logging.Log.Info(`Migration "add_resource_ownership_column" ended`)
+
+			err := db.Transaction(func(tx *gorm.DB) error {
+				return tx.Migrator().AddColumn(&ApplicationType{}, "ResourceOwnership")
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Transaction(func(tx *gorm.DB) error {
+				return tx.Migrator().DropColumn(&ApplicationType{}, "ResourceOwnership")
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -22,6 +22,7 @@ var migrationsCollection = []*gormigrate.Migration{
 	RemoveDuplicatedTenantIdsOrgIds(),
 	AddTenantsExternalTenantOrgIdUniqueIndex(),
 	AddUserIdColumnIntoTables(),
+	AddResouceOwnershipToApplicationTypes(),
 }
 
 var ctx = context.Background()

--- a/model/application_type.go
+++ b/model/application_type.go
@@ -22,6 +22,7 @@ type ApplicationType struct {
 	DependentApplications        datatypes.JSON `json:"dependent_applications"`
 	SupportedSourceTypes         datatypes.JSON `json:"supported_source_types"`
 	SupportedAuthenticationTypes datatypes.JSON `json:"supported_authentication_types"`
+	ResourceOwnership            *string        `json:"resource_ownership"`
 
 	Applications []Application
 	Sources      []*Source `gorm:"many2many:applications;"`


### PR DESCRIPTION
For **Single User based Sources** we need to distinguish if application type is user based.

This PR:
- adds a migration for new column `resource_ownership` in table `application_types`
- updates the models `Application_Type` and `applicationTypeSeed` - a pointer is used because we want to save NULL values into db in case that the resource ownership is not set for the application type
- updates the function `seedApplicationTypes()` that is responsible for changes from `application_types.yml`