### PR TITLE
refactor: log the request and responses for RHC connection av check

### DIFF
--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -248,6 +248,12 @@ func pingRHC(source *m.Source, rhcConnection *m.RhcConnection, headers []kafka.H
 		return
 	}
 
+	// Log everything from the response
+	l.Log.Debugf(`RHC connection status sent request: %#v`, req)
+	l.Log.Debugf(`RHC connection status received response: %#v`, resp)
+	l.Log.Debugf(`RHC connection status response status code: %d`, resp.StatusCode)
+	l.Log.Debugf(`RHC connection status response body: %s`, b)
+
 	var status rhcConnectionStatusResponse
 	err = json.Unmarshal(b, &status)
 	if err != nil {


### PR DESCRIPTION
In order to better debug the problem, I would like to have the exact request we're sending and the exact response we're receiving to try to debug what's going on.