### PR TITLE
Refactor param of getDefaultSourceDao and GetSourceDao

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -722,7 +722,7 @@ func TestApplicationDelete(t *testing.T) {
 
 	// Create a source
 	tenantID := fixtures.TestTenantData[0].Id
-	sourceDao := dao.GetSourceDao(&tenantID)
+	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantID})
 
 	src := m.Source{
 		Name:         "Source for TestApplicationDelete()",

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -176,7 +176,7 @@ func AuthenticationEdit(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
-	sourceDao := dao.GetSourceDao(authDao.Tenant())
+	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: authDao.Tenant()})
 	source, err := sourceDao.GetById(&auth.SourceID)
 	if err != nil {
 		return err

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -211,7 +211,7 @@ func TestCreateUserWithoutResourceOwnershipConfig(t *testing.T) {
 }
 
 func cleanSourceForTenant(sourceName string, tenantID *int64) error {
-	sourceDao := dao.GetSourceDao(tenantID)
+	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantID})
 
 	source := &m.Source{Name: sourceName}
 	err := dao.DB.Model(&m.Source{}).Where("name = ?", source.Name).Find(&source).Error

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -92,7 +92,7 @@ func (a *authenticationDaoImpl) List(limit int, offset int, filters []util.Filte
 
 func (a *authenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	// Check if sourceID exists
-	_, err := GetSourceDao(a.TenantID).GetById(&sourceID)
+	_, err := GetSourceDao(&SourceDaoParams{TenantID: a.TenantID}).GetById(&sourceID)
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("source")
 	}
@@ -566,7 +566,7 @@ func (a *authenticationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateA
 		return nil, err
 	}
 
-	sourceDao := GetSourceDao(a.TenantID)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: a.TenantID})
 	source, err := sourceDao.GetById(&authentication.SourceID)
 	if err != nil {
 		return nil, err

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -390,7 +390,7 @@ func (add *authenticationDaoDbImpl) FetchAndUpdateBy(resource util.Resource, upd
 		return nil, err
 	}
 
-	sourceDao := GetSourceDao(add.TenantID)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: add.TenantID})
 	source, err := sourceDao.GetById(&authentication.SourceID)
 	if err != nil {
 		return nil, err

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -266,7 +266,7 @@ func TestListForSource(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
-	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 	source := model.Source{
 		Name:         "new source in new tenant",
 		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
@@ -351,7 +351,7 @@ func TestListForApplication(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
-	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 	source := model.Source{
 		Name:         "new source in new tenant",
 		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
@@ -447,7 +447,7 @@ func TestListForApplicationAuthentication(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
-	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 	source := model.Source{
 		Name:         "new source in new tenant",
 		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
@@ -550,7 +550,7 @@ func TestListForEndpoint(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
-	sourceDao := GetSourceDao(&fixtures.TestTenantData[1].Id)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 	source := model.Source{
 		Name:         "new source in new tenant",
 		SourceTypeID: fixtures.TestSourceTypeData[0].Id,
@@ -797,7 +797,7 @@ func TestBulkMessage(t *testing.T) {
 	if err != nil {
 		t.Errorf(`could not fetch the authentication from the database: %s`, err)
 	}
-	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	source, err := sourceDao.GetById(&authFixture.SourceID)
 	if err != nil {
 		t.Errorf(`could not fetch source: %s`, err)

--- a/dao/common.go
+++ b/dao/common.go
@@ -38,7 +38,7 @@ func GetAvailabilityStatusFromStatusMessage(tenantID int64, resourceID string, r
 		if err != nil {
 			return "", err
 		}
-		resource, err := GetSourceDao(&tenantID).GetById(&recordID)
+		resource, err := GetSourceDao(&SourceDaoParams{TenantID: &tenantID}).GetById(&recordID)
 		if err != nil {
 			return "", err
 		}

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -13,18 +13,27 @@ import (
 
 // GetSourceDao is a function definition that can be replaced in runtime in case some other DAO provider is
 // needed.
-var GetSourceDao func(*int64) SourceDao
+var GetSourceDao func(*SourceDaoParams) SourceDao
 
 // getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
-func getDefaultSourceDao(tenantId *int64) SourceDao {
+func getDefaultSourceDao(daoParams *SourceDaoParams) SourceDao {
+	var tenantID *int64
+	if daoParams != nil {
+		tenantID = daoParams.TenantID
+	}
+
 	return &sourceDaoImpl{
-		TenantID: tenantId,
+		TenantID: tenantID,
 	}
 }
 
 // init sets the default DAO implementation so that other packages can request it easily.
 func init() {
 	GetSourceDao = getDefaultSourceDao
+}
+
+type SourceDaoParams struct {
+	TenantID *int64
 }
 
 type sourceDaoImpl struct {
@@ -64,8 +73,7 @@ func (s *sourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 
 func (s *sourceDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	sources := make([]m.Source, 0, limit)
-	query := DB.Debug().Model(&m.Source{}).
-		Where("sources.tenant_id = ?", s.TenantID)
+	query := DB.Debug().Model(&m.Source{}).Where("sources.tenant_id = ?", s.TenantID)
 
 	query, err := applyFilters(query, filters)
 	if err != nil {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -18,7 +18,7 @@ var GetSourceDao func(*SourceDaoParams) SourceDao
 // getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultSourceDao(daoParams *SourceDaoParams) SourceDao {
 	var tenantID *int64
-	if daoParams != nil {
+	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
 	}
 

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -68,7 +68,7 @@ func TestPausingSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("pause_unpause")
 
-	sourceDao := GetSourceDao(&testSource.TenantID)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &testSource.TenantID})
 	err := sourceDao.Pause(testSource.ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -98,7 +98,7 @@ func TestResumingSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("pause_unpause")
 
-	sourceDao := GetSourceDao(&testSource.TenantID)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &testSource.TenantID})
 	err := sourceDao.Unpause(fixtures.TestSourceData[0].ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -128,7 +128,7 @@ func TestDeleteSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	sourceDao := GetSourceDao(&fixtures.TestSourceData[0].TenantID)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestSourceData[0].TenantID})
 
 	source := fixtures.TestSourceData[0]
 	// Set the ID to 0 to let GORM know it should insert a new source and not update an existing one.
@@ -173,7 +173,7 @@ func TestDeleteSourceNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	sourceDao := GetSourceDao(&fixtures.TestSourceData[0].TenantID)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestSourceData[0].TenantID})
 
 	nonExistentId := int64(12345)
 	_, err := sourceDao.Delete(&nonExistentId)
@@ -204,7 +204,7 @@ func TestDeleteSourceNotExists(t *testing.T) {
 // 	}
 
 // 	// Try inserting the source in the database.
-// 	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
+// 	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 // 	err := sourceDao.Create(&fixtureSource)
 // 	if err != nil {
 // 		t.Errorf(`error creating a fixture source: %s`, err)
@@ -634,7 +634,7 @@ func TestSourceExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("exists")
 
-	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	got, err := sourceDao.Exists(fixtures.TestSourceData[0].ID)
 	if err != nil {
@@ -653,7 +653,7 @@ func TestSourceNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("exists")
 
-	sourceDao := GetSourceDao(&fixtures.TestTenantData[0].Id)
+	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	got, err := sourceDao.Exists(12345)
 	if err != nil {

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -576,7 +576,7 @@ func TestEndpointDelete(t *testing.T) {
 
 	// Create a source
 	tenantID := fixtures.TestTenantData[0].Id
-	sourceDao := dao.GetSourceDao(&tenantID)
+	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantID})
 
 	src := m.Source{
 		Name:         "Source for TestApplicationDelete()",

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -69,7 +69,7 @@ func (r *applicationTypeResolver) SupportedAuthenticationTypes(ctx context.Conte
 }
 
 func (r *applicationTypeResolver) Sources(ctx context.Context, obj *model.ApplicationType) ([]*model.Source, error) {
-	srces, _, err := dao.GetSourceDao(tenantIdFromCtx(ctx)).SubCollectionList(model.ApplicationType{Id: obj.Id}, 500, 0, []util.Filter{})
+	srces, _, err := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantIdFromCtx(ctx)}).SubCollectionList(model.ApplicationType{Id: obj.Id}, 500, 0, []util.Filter{})
 	out := make([]*model.Source, len(srces))
 	for i := range srces {
 		out[i] = &srces[i]
@@ -131,7 +131,7 @@ func (r *queryResolver) Sources(ctx context.Context, limit *int, offset *int, so
 	f := parseArgs(sortBy, filter)
 
 	// list the sources with filters en tote!
-	srces, count, err := dao.GetSourceDao(tenantIdFromCtx(ctx)).List(*limit, *offset, f)
+	srces, count, err := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantIdFromCtx(ctx)}).List(*limit, *offset, f)
 	sendCount(ctx, count)
 
 	// storing the IDs of relevant sources on the request context for later subresources

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -33,7 +33,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 			return util.NewErrBadRequest(err)
 		}
 
-		s := dao.GetSourceDao(&tenantId)
+		s := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantId})
 
 		if s.IsSuperkey(id) {
 			xrhid, ok := c.Get(h.XRHID).(string)

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -298,7 +298,7 @@ func updateRhcStatus(source *m.Source, status string, errstr string, rhcConnecti
 		rhcConnection.AvailabilityStatusError = errstr
 	}
 
-	err := dao.GetSourceDao(&source.TenantID).Update(source)
+	err := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &source.TenantID}).Update(source)
 	if err != nil {
 		l.Log.Warnf("failed to update source availability status: %v", err)
 		return

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -151,7 +151,7 @@ func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant) ([]m.Source
 		s.SourceType = *sourceType
 
 		// validate the source request
-		err = ValidateSourceCreationRequest(dao.GetSourceDao(&tenant.Id), &source.SourceCreateRequest)
+		err = ValidateSourceCreationRequest(dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenant.Id}), &source.SourceCreateRequest)
 		if err != nil {
 			return nil, err
 		}
@@ -287,7 +287,7 @@ func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput,
 			var err error
 			switch strings.ToLower(auth.ResourceType) {
 			case "source":
-				_, err = dao.GetSourceDao(&tenant.Id).GetById(&id)
+				_, err = dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenant.Id}).GetById(&id)
 				if err == nil {
 					l.Log.Debugf("Found existing Source with id %v, adding to list and continuing", id)
 					a.ResourceID = id

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -28,7 +28,7 @@ func TestMain(t *testing.M) {
 		database.ConnectAndMigrateDB("service")
 
 		endpointDao = dao.GetEndpointDao(&fixtures.TestTenantData[0].Id)
-		sourceDao = dao.GetSourceDao(&fixtures.TestTenantData[0].Id)
+		sourceDao = dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 		database.CreateFixtures()
 	} else {
 		endpointDao = &dao.MockEndpointDao{}

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -37,7 +37,7 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 
 	switch resourceType {
 	case "Source":
-		sourceDao := dao.GetSourceDao(tenantId)
+		sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantId})
 		applicationAuthentications, applications, endpoints, rhcConnections, source, err := sourceDao.DeleteCascade(resourceId)
 		if err != nil {
 			return fmt.Errorf(`could not completely delete the source: %s`, err)

--- a/service/update_resource.go
+++ b/service/update_resource.go
@@ -23,7 +23,7 @@ func UpdateSourceFromApplicationAvailabilityStatus(application *m.Application, p
 			source.LastAvailableAt = application.LastAvailableAt
 		}
 
-		sourceDao := dao.GetSourceDao(&application.TenantID)
+		sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &application.TenantID})
 		err := sourceDao.Update(source)
 		if err != nil {
 			l.Log.Errorf("unable to load source: %v", err.Error())

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -23,7 +23,7 @@ func getSourceDaoWithTenant(c echo.Context) (dao.SourceDao, error) {
 		return nil, err
 	}
 
-	return dao.GetSourceDao(&tenantId), nil
+	return dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantId}), nil
 }
 
 func SourceList(c echo.Context) error {


### PR DESCRIPTION
PR changes `getDefaultSourceDao` and `GetSourceDao` parameter tenantId to struct use `SourceDaoParams`.

This allows us to extend parameters for `GetSourceDao` function
without changing callers on lot of places.

Lately, this will be use to add `UserID` parameter to struct
`SourceDaoParams` and `UserID` will be passed to `sourceDaoImpl`
struct.

We need `UserID` in dao layer to add support user based filtering.
`UserID` in dao layer allow us to restrict queries to ensure
filtering according to `userID`.


