### PR TITLE
Access UserID from DAO in source handlers

### DIFF
--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -174,4 +174,5 @@ type TenantDao interface {
 
 type UserDao interface {
 	CreateIfResourceOwnershipActive(userResource *m.UserResource) error
+	GetIdByUserID(userID string) (*int64, error)
 }

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -17,13 +17,16 @@ var GetSourceDao func(*SourceDaoParams) SourceDao
 
 // getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultSourceDao(daoParams *SourceDaoParams) SourceDao {
-	var tenantID *int64
+	var tenantID, userID *int64
+
 	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
+		userID = daoParams.UserID
 	}
 
 	return &sourceDaoImpl{
 		TenantID: tenantID,
+		UserID:   userID,
 	}
 }
 
@@ -34,10 +37,12 @@ func init() {
 
 type SourceDaoParams struct {
 	TenantID *int64
+	UserID   *int64
 }
 
 type sourceDaoImpl struct {
 	TenantID *int64
+	UserID   *int64
 }
 
 func (s *sourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {

--- a/dao/user_dao.go
+++ b/dao/user_dao.go
@@ -55,3 +55,20 @@ func (u *userDaoImpl) CreateIfResourceOwnershipActive(userResource *m.UserResour
 
 	return nil
 }
+
+func (u *userDaoImpl) GetIdByUserID(userID string) (*int64, error) {
+	var user m.User
+	result := DB.Model(&m.User{}).Where("tenant_id = ? and user_id = ?", u.TenantID, userID).Find(&user)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	var userIDFromDB *int64
+	if result.RowsAffected == 0 {
+		userIDFromDB = nil
+	} else {
+		userIDFromDB = &user.Id
+	}
+
+	return userIDFromDB, nil
+}

--- a/helpers.go
+++ b/helpers.go
@@ -102,6 +102,24 @@ func getTenantFromEchoContext(c echo.Context) (int64, error) {
 	}
 }
 
+func getUserFromEchoContext(c echo.Context) (string, error) {
+	userValue := c.Get(h.USERID)
+
+	if userValue == nil {
+		return "", nil
+	}
+
+	if userId, ok := userValue.(string); ok {
+		if userId == "" {
+			return "", errors.New("incorrect user value provided")
+		}
+
+		return userId, nil
+	} else {
+		return "", errors.New("the user was provided in an invalid format")
+	}
+}
+
 func getAccountNumberFromEchoContext(c echo.Context) (string, error) {
 	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
 	if !ok {

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -7,4 +7,5 @@ const (
 	XRHID           = "x-rh-identity"
 	PARSED_IDENTITY = "identity"
 	TENANTID        = "tenantID"
+	USERID          = "userID"
 )

--- a/middleware/resource_ownership.go
+++ b/middleware/resource_ownership.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"fmt"
+
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+func ResourceOwnership(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		identity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+		if !ok {
+			return fmt.Errorf("invalid identity structure received")
+		}
+
+		c.Set(h.USERID, identity.Identity.User.UserID)
+		return next(c)
+	}
+}

--- a/routes.go
+++ b/routes.go
@@ -33,11 +33,11 @@ func setupRoutes(e *echo.Echo) {
 		r.POST("/bulk_create", BulkCreate, permissionMiddleware...)
 
 		// Sources
-		r.GET("/sources", SourceList, tenancyWithListMiddleware...)
-		r.GET("/sources/:id", SourceGet, middleware.Tenancy)
+		r.GET("/sources", SourceList, append(tenancyWithListMiddleware, middleware.ResourceOwnership)...)
+		r.GET("/sources/:id", SourceGet, middleware.Tenancy, middleware.ResourceOwnership)
 		r.POST("/sources", SourceCreate, permissionMiddleware...)
-		r.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.Notifier)...)
-		r.DELETE("/sources/:id", SourceDelete, append(permissionMiddleware, middleware.SuperKeyDestroySource)...)
+		r.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.Notifier, middleware.ResourceOwnership)...)
+		r.DELETE("/sources/:id", SourceDelete, append(permissionMiddleware, middleware.SuperKeyDestroySource, middleware.ResourceOwnership)...)
 		r.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy)
 		r.GET("/sources/:source_id/application_types", SourceListApplicationTypes, tenancyWithListMiddleware...)
 		r.GET("/sources/:source_id/applications", SourceListApplications, tenancyWithListMiddleware...)

--- a/routes.go
+++ b/routes.go
@@ -16,6 +16,7 @@ var listMiddleware = []echo.MiddlewareFunc{
 var tenancyWithListMiddleware = append([]echo.MiddlewareFunc{middleware.Tenancy}, listMiddleware...)
 var permissionMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.PermissionCheck, middleware.RaiseEvent}
 var permissionWithListMiddleware = append(listMiddleware, middleware.PermissionCheck)
+var userTenancyWithListMiddleware = append(tenancyWithListMiddleware, middleware.ResourceOwnership)
 
 func setupRoutes(e *echo.Echo) {
 	e.GET("/health", func(c echo.Context) error {
@@ -33,7 +34,7 @@ func setupRoutes(e *echo.Echo) {
 		r.POST("/bulk_create", BulkCreate, permissionMiddleware...)
 
 		// Sources
-		r.GET("/sources", SourceList, append(tenancyWithListMiddleware, middleware.ResourceOwnership)...)
+		r.GET("/sources", SourceList, userTenancyWithListMiddleware...)
 		r.GET("/sources/:id", SourceGet, middleware.Tenancy, middleware.ResourceOwnership)
 		r.POST("/sources", SourceCreate, permissionMiddleware...)
 		r.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.Notifier, middleware.ResourceOwnership)...)

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -27,17 +27,11 @@ func getSourceDaoWithTenant(c echo.Context) (dao.SourceDao, error) {
 		return nil, err
 	}
 
-	var user m.User
-	result := dao.DB.Model(&m.User{}).Where("tenant_id = ? and user_id = ?", tenantId, userID).Find(&user)
-	if result.Error != nil {
-		return nil, err
-	}
+	userDao := dao.GetUserDao(&tenantId)
+	userIDFromDB, err := userDao.GetIdByUserID(userID)
 
-	var userIDFromDB *int64
-	if result.RowsAffected == 0 {
-		userIDFromDB = nil
-	} else {
-		userIDFromDB = &user.Id
+	if err != nil {
+		return nil, err
 	}
 
 	return dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantId, UserID: userIDFromDB}), nil


### PR DESCRIPTION
Issue https://github.com/RedHatInsights/sources-api-go/issues/356

This add to source DAO layer users#id from **only when** there is record in users table which matches users#userid from XRHID header. 

NOTE: When `sourceDaoImpl#UserID` is `nil` it means that user single based sources filtering will be skipped and it will behave like before this change. (this is implement in other PR)

This PR populates userid from header only for sources routes.

