### PR TITLE
[RHCLOUD-19856] Not found err for GetByName methods

### DIFF
--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -94,8 +94,11 @@ func (a *applicationTypeDaoImpl) GetById(id *int64) (*m.ApplicationType, error) 
 func (a *applicationTypeDaoImpl) GetByName(name string) (*m.ApplicationType, error) {
 	apptype := &m.ApplicationType{}
 	result := DB.Debug().Where("name LIKE ?", "%"+name+"%").First(&apptype)
+	if result.Error != nil {
+		return nil, util.NewErrNotFound("application type")
+	}
 
-	return apptype, result.Error
+	return apptype, nil
 }
 
 func (a *applicationTypeDaoImpl) Create(_ *m.ApplicationType) error {

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
@@ -85,4 +86,44 @@ func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
 		}
 	}
 	DropSchema("offset_limit")
+}
+
+func TestApplicationTypeGetByName(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_type_by_name")
+	wantAppType := fixtures.TestApplicationTypeData[0]
+
+	tenantId := int64(1)
+	appTypeDao := GetApplicationTypeDao(&tenantId)
+
+	gotAppType, err := appTypeDao.GetByName(wantAppType.Name)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if gotAppType.Name != wantAppType.Name {
+		t.Errorf("want source type name '%s', got source type name '%s'", wantAppType.Name, gotAppType.Name)
+	}
+
+	DropSchema("app_type_by_name")
+}
+
+func TestApplicationTypeGetByNameNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_type_by_name")
+	wantAppType := m.ApplicationType{Name: "not existing name"}
+
+	tenantId := int64(1)
+	appTypeDao := GetApplicationTypeDao(&tenantId)
+
+	gotAppType, err := appTypeDao.GetByName(wantAppType.Name)
+	if gotAppType != nil {
+		t.Error("got application type object, want nil")
+	}
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf("want not found err, got '%v'", err)
+	}
+
+	DropSchema("app_type_by_name")
 }

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -58,8 +58,10 @@ func (st *sourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
 func (st *sourceTypeDaoImpl) GetByName(name string) (*m.SourceType, error) {
 	sourceType := &m.SourceType{}
 	result := DB.Debug().Where("name LIKE ?", "%"+name+"%").First(sourceType)
-
-	return sourceType, result.Error
+	if result.Error != nil {
+		return nil, util.NewErrNotFound("source type")
+	}
+	return sourceType, nil
 }
 
 func (a *sourceTypeDaoImpl) Create(_ *m.SourceType) error {

--- a/dao/source_type_dao_test.go
+++ b/dao/source_type_dao_test.go
@@ -1,10 +1,12 @@
 package dao
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
@@ -41,4 +43,40 @@ func TestSourceTypeListOffsetAndLimit(t *testing.T) {
 		}
 	}
 	DropSchema("offset_limit")
+}
+
+func TestSourceTypeGetByName(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("source_type_by_name")
+	wantSourceType := fixtures.TestSourceTypeData[0]
+
+	sourceTypeDao := GetSourceTypeDao()
+	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if gotSourceType.Name != wantSourceType.Name {
+		t.Errorf("want source type name '%s', got source type name '%s'", wantSourceType.Name, gotSourceType.Name)
+	}
+
+	DropSchema("source_type_by_name")
+}
+
+func TestSourceTypeGetByNameNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("source_type_by_name")
+	wantSourceType := m.SourceType{Name: "not existing name"}
+
+	sourceTypeDao := GetSourceTypeDao()
+	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
+	if gotSourceType != nil {
+		t.Error("got source type object, want nil")
+	}
+
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf("want not found err, got '%v'", err)
+	}
+
+	DropSchema("source_type_by_name")
 }

--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -5,10 +5,12 @@ import m "github.com/RedHatInsights/sources-api-go/model"
 var TestApplicationTypeData = []m.ApplicationType{
 	{
 		Id:          1,
+		Name:        "app type name",
 		DisplayName: "test app type",
 	},
 	{
 		Id:          2,
+		Name:        "second app type name",
 		DisplayName: "second test app type",
 	},
 }


### PR DESCRIPTION
GetByName() methods in source type and application type dao should return NotFound err object in case the given name of source/app type is not found. Same logic we have in GetById() methods.

**JIRA:** [RHCLOUD-19856](https://issues.redhat.com/browse/RHCLOUD-19856)