### PR TITLE
[RHCLOUD-19817] chore: add more logs to the RHC Connection availability check

### DIFF
--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -250,6 +250,7 @@ func pingRHC(source *m.Source, rhcConnection *m.RhcConnection, headers []kafka.H
 
 	// Log everything from the response
 	l.Log.Debugf(`[source_id: %d][rhc_connection_id: %d][rhc_connection_rhcid: %s] RHC connection status sent request: %#v`, source.ID, rhcConnection.ID, rhcConnection.RhcId, req)
+	l.Log.Debugf(`[source_id: %d][rhc_connection_id: %d][rhc_connection_rhcid: %s] RHC connection status sent body: %v`, source.ID, rhcConnection.ID, rhcConnection.RhcId, body)
 	l.Log.Debugf(`[source_id: %d][rhc_connection_id: %d][rhc_connection_rhcid: %s] RHC connection status received response: %#v`, source.ID, rhcConnection.ID, rhcConnection.RhcId, resp)
 	l.Log.Debugf(`[source_id: %d][rhc_connection_id: %d][rhc_connection_rhcid: %s] RHC connection status response status code: %d`, source.ID, rhcConnection.ID, rhcConnection.RhcId, resp.StatusCode)
 	l.Log.Debugf(`[source_id: %d][rhc_connection_id: %d][rhc_connection_rhcid: %s] RHC connection status response body: %s`, source.ID, rhcConnection.ID, rhcConnection.RhcId, b)


### PR DESCRIPTION
Adds another log to see which request body is being sent to the cloud connector availability check endpoint.

## Links

[[RHCLOUD-19817]](https://issues.redhat.com/browse/RHCLOUD-19817)