### PR TITLE
[RHCLOUD-19931] fix: bulk create with an endpoint returns a "missing source id" error

### DIFF
--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -214,6 +214,18 @@ func parseEndpoints(reqEndpoints []m.BulkCreateEndpoint, current *m.BulkCreateOu
 	for _, endpt := range reqEndpoints {
 		e := m.Endpoint{}
 
+		// The source ID needs to be set before validating the endpoint, since otherwise the validation always fails.
+		for _, src := range current.Sources {
+			if src.Name != endpt.SourceName {
+				continue
+			}
+
+			// "IDRaw" is the one validated by the validator.
+			endpt.EndpointCreateRequest.SourceIDRaw = src.ID
+			// We will pick this one, however, to assign it to the endpoint struct.
+			endpt.SourceID = src.ID
+		}
+
 		err := ValidateEndpointCreateRequest(dao.GetEndpointDao(&tenant.Id), &endpt.EndpointCreateRequest)
 		if err != nil {
 			return nil, err
@@ -224,17 +236,11 @@ func parseEndpoints(reqEndpoints []m.BulkCreateEndpoint, current *m.BulkCreateOu
 		e.Path = &endpt.Path
 		e.Port = endpt.Port
 		e.VerifySsl = endpt.VerifySsl
+		e.SourceID = endpt.SourceID
 		e.Tenant = *tenant
 		e.TenantID = tenant.Id
 
-		for _, src := range current.Sources {
-			if src.Name != endpt.SourceName {
-				continue
-			}
-
-			e.SourceID = src.ID
-			endpoints = append(endpoints, e)
-		}
+		endpoints = append(endpoints, e)
 	}
 
 	// if all of the endpoints did not get linked up - there was a problem

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// TestParseEndpointsTestRegression is a regression test for RHCLOUD-19931. It tests that the "parseEndpoints" function
+// correctly maps all the fields —including the one that was failing, the source ID— from the request to an endpoint
+// struct.
+func TestParseEndpointsTestRegression(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare all the fixtures to simulate a valid Bulk Create request.
+	var endpointFixture = fixtures.TestEndpointData[0]
+	endpointFixture.Role = util.StringRef("endpoint-role")
+	endpointFixture.ReceptorNode = util.StringRef("endpoint-receptor-node")
+	var verifySsl = true
+	endpointFixture.VerifySsl = &verifySsl
+	endpointFixture.CertificateAuthority = util.StringRef("endpoint-ca")
+
+	var sourceFixture = fixtures.TestSourceData[0]
+	var tenantFixture = fixtures.TestTenantData[0]
+
+	var reqEndpoints = []model.BulkCreateEndpoint{
+		{
+			EndpointCreateRequest: model.EndpointCreateRequest{
+				Default:              false,
+				ReceptorNode:         endpointFixture.ReceptorNode,
+				Role:                 *endpointFixture.Role,
+				Scheme:               endpointFixture.Scheme,
+				Host:                 *endpointFixture.Host,
+				Port:                 endpointFixture.Port,
+				Path:                 *endpointFixture.Path,
+				VerifySsl:            endpointFixture.VerifySsl,
+				CertificateAuthority: endpointFixture.CertificateAuthority,
+				AvailabilityStatus:   endpointFixture.AvailabilityStatus,
+				SourceIDRaw:          sourceFixture.ID,
+			},
+		},
+	}
+	bulkCreateOutput := model.BulkCreateOutput{
+		Sources: []model.Source{sourceFixture},
+	}
+
+	// Call the function under test.
+	endpoints, err := parseEndpoints(reqEndpoints, &bulkCreateOutput, &tenantFixture)
+	if err != nil {
+		t.Errorf(`unexpected error when parsing the endpoints from bulk create: %s`, err)
+	}
+
+	if len(endpoints) != 1 {
+		t.Errorf(`unexpected number of endpoints received. Want "%d", got "%d"`, 1, len(endpoints))
+	}
+
+	resultEndpoint := endpoints[0]
+
+	{
+		want := *endpointFixture.Scheme
+		got := *resultEndpoint.Scheme
+
+		if want != got {
+			t.Errorf(`wrong endpoint scheme parsed. Want "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := *endpointFixture.Host
+		got := *resultEndpoint.Host
+
+		if want != got {
+			t.Errorf(`wrong endpoint host parsed. Want "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := *endpointFixture.Path
+		got := *resultEndpoint.Path
+
+		if want != got {
+			t.Errorf(`wrong endpoint path parsed. Want "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := *endpointFixture.Port
+		got := *resultEndpoint.Port
+
+		if want != got {
+			t.Errorf(`wrong endpoint port parsed. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := *endpointFixture.VerifySsl
+		got := *resultEndpoint.VerifySsl
+
+		if want != got {
+			t.Errorf(`wrong endpoint verify ssl parsed. Want "%t", got "%t"`, want, got)
+		}
+	}
+
+	{
+		want := tenantFixture
+		got := resultEndpoint.Tenant
+
+		if want != got {
+			t.Errorf(`wrong endpoint tenant parsed. Want "%v", got "%v"`, want, got)
+		}
+	}
+
+	{
+		want := endpointFixture.TenantID
+		got := resultEndpoint.TenantID
+
+		if want != got {
+			t.Errorf(`wrong endpoint tenant ID parsed. Want "%d", got "%d"`, want, got)
+		}
+	}
+
+	{
+		want := endpointFixture.SourceID
+		got := resultEndpoint.SourceID
+
+		if want != got {
+			t.Errorf(`wrong endpoint source id parsed. Want "%d", got "%d"`, want, got)
+		}
+	}
+}


### PR DESCRIPTION
Since the endpoint validator was running before the source ID for the
endpoint had been set, the validator was complaining about that source
ID missing, which caused bulk create requests with endpoints in the
payload to be rejected.

## Links

[[RHCLOUD-19931]](https://issues.redhat.com/browse/RHCLOUD-19931)