### PR TITLE
[RHCLOUD-19793] Source handler tests update2

### DIFF
--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -13,4 +13,8 @@ var TestApplicationTypeData = []m.ApplicationType{
 		Name:        "second app type name",
 		DisplayName: "second test app type",
 	},
+	{
+		Id:          100,
+		DisplayName: "app type without related sources",
+	},
 }

--- a/internal/testutils/fixtures/tenant.go
+++ b/internal/testutils/fixtures/tenant.go
@@ -12,4 +12,10 @@ var TestTenantData = []m.Tenant{
 		Id:             2,
 		ExternalTenant: "67890",
 	},
+	{
+		Id:             3,
+		ExternalTenant: "7893720",
+		OrgID:          "tenant without sources",
+	},
+
 }

--- a/internal/testutils/fixtures/tenant.go
+++ b/internal/testutils/fixtures/tenant.go
@@ -17,5 +17,4 @@ var TestTenantData = []m.Tenant{
 		ExternalTenant: "7893720",
 		OrgID:          "tenant without sources",
 	},
-
 }

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -545,6 +545,37 @@ func TestApplicationTypeListSourceSubcollectionList(t *testing.T) {
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
+// TestApplicationTypeListSourceSubcollectionListTenantNotExists tests that empty list
+// is returned for existing application type and not existing tenant
+func TestApplicationTypeListSourceSubcollectionListTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	// Check existing application type with not existing tenant id
+	appTypeId := int64(1)
+	tenantId := notExistingTenantId
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types/1/sources",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("application_type_id")
+	c.SetParamValues(fmt.Sprintf("%d", appTypeId))
+
+	err := ApplicationTypeListSource(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.EmptySubcollectionListTest(t, c, rec)
+}
+
 func TestApplicatioTypeListSourceSubcollectionListNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -479,8 +479,9 @@ func TestSourceTypeSourceSubcollectionListBadRequestInvalidFilter(t *testing.T) 
 	templates.BadRequestTest(t, rec)
 }
 
-func TestApplicatioTypeListSourceSubcollectionList(t *testing.T) {
+func TestApplicationTypeListSourceSubcollectionList(t *testing.T) {
 	appTypeId := int64(1)
+	tenantId := int64(1)
 	wantSourcesCount := len(testutils.GetSourcesWithAppType(appTypeId))
 
 	c, rec := request.CreateTestContext(
@@ -491,7 +492,7 @@ func TestApplicatioTypeListSourceSubcollectionList(t *testing.T) {
 			"limit":    100,
 			"offset":   0,
 			"filters":  []util.Filter{},
-			"tenantID": int64(1),
+			"tenantID": tenantId,
 		},
 	)
 
@@ -534,6 +535,11 @@ func TestApplicatioTypeListSourceSubcollectionList(t *testing.T) {
 		if s["id"] == 1 && s["name"] != "Source1" {
 			t.Error("ghosts infected the return")
 		}
+	}
+
+	err = checkAllSourcesBelongToTenant(tenantId, out.Data)
+	if err != nil {
+		t.Error(err)
 	}
 
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -883,17 +883,20 @@ func TestSourceListBadRequestInvalidFilter(t *testing.T) {
 }
 
 func TestSourceGet(t *testing.T) {
+	tenantId := int64(1)
+	sourceId := int64(1)
+
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
 		"/api/sources/v3.1/sources/1",
 		nil,
 		map[string]interface{}{
-			"tenantID": int64(1),
+			"tenantID": tenantId,
 		},
 	)
 
 	c.SetParamNames("id")
-	c.SetParamValues("1")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	err := SourceGet(c)
 	if err != nil {
@@ -912,6 +915,19 @@ func TestSourceGet(t *testing.T) {
 
 	if *outSrc.Name != "Source1" {
 		t.Error("ghosts infected the return")
+	}
+
+	if outSrc.ID != fmt.Sprintf("%d", sourceId) {
+		t.Errorf("source with wrong ID returned, expected %d, got %s", sourceId, outSrc.ID)
+	}
+
+	for _, src := range fixtures.TestSourceData {
+		if src.ID == sourceId {
+			if src.TenantID != tenantId {
+				t.Errorf("wrong tenant id, expected %d, got %d", tenantId, src.TenantID)
+			}
+			break
+		}
 	}
 }
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -921,8 +921,15 @@ func TestSourceGet(t *testing.T) {
 		t.Errorf("source with wrong ID returned, expected %d, got %s", sourceId, outSrc.ID)
 	}
 
+	// Convert ID from returned source into int64
+	outSrcId, err := strconv.ParseInt(outSrc.ID, 10, 64)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check in fixtures that returned source belongs to the desired tenant
 	for _, src := range fixtures.TestSourceData {
-		if src.ID == sourceId {
+		if src.ID == outSrcId {
 			if src.TenantID != tenantId {
 				t.Errorf("wrong tenant id, expected %d, got %d", tenantId, src.TenantID)
 			}

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -605,7 +605,7 @@ func TestApplicationTypeListSourceSubcollectionListEmptySubcollection(t *testing
 	templates.EmptySubcollectionListTest(t, c, rec)
 }
 
-func TestApplicatioTypeListSourceSubcollectionListNotFound(t *testing.T) {
+func TestApplicationTypeListSourceSubcollectionListNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
 		"/api/sources/v3.1/application_types/398748974/sources",
@@ -630,7 +630,7 @@ func TestApplicatioTypeListSourceSubcollectionListNotFound(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
-func TestApplicatioTypeListSourceSubcollectionListBadRequestInvalidSyntax(t *testing.T) {
+func TestApplicationTypeListSourceSubcollectionListBadRequestInvalidSyntax(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
 		"/api/sources/v3.1/application_types/xxx/sources",
@@ -655,7 +655,7 @@ func TestApplicatioTypeListSourceSubcollectionListBadRequestInvalidSyntax(t *tes
 	templates.BadRequestTest(t, rec)
 }
 
-func TestApplicatioTypeListSourceSubcollectionListBadRequestInvalidFilter(t *testing.T) {
+func TestApplicationTypeListSourceSubcollectionListBadRequestInvalidFilter(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	c, rec := request.CreateTestContext(

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -576,6 +576,35 @@ func TestApplicationTypeListSourceSubcollectionListTenantNotExists(t *testing.T)
 	templates.EmptySubcollectionListTest(t, c, rec)
 }
 
+// TestApplicationTypeListSourceSubcollectionListEmptySubcollection tests that empty list
+// is returned for existing application type without existing sources for given tenant
+func TestApplicationTypeListSourceSubcollectionListEmptySubcollection(t *testing.T) {
+	appTypeId := int64(100)
+	tenantId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types/1/sources",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("application_type_id")
+	c.SetParamValues(fmt.Sprintf("%d", appTypeId))
+
+	err := ApplicationTypeListSource(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.EmptySubcollectionListTest(t, c, rec)
+}
+
 func TestApplicatioTypeListSourceSubcollectionListNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -943,6 +943,34 @@ func TestSourceGetInvalidTenant(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+// TestSourceGetTenantNotExists tests that not found is returned for
+// not existing tenant
+func TestSourceGetTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := notExistingTenantId
+	sourceId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	notFoundSourceGet := ErrorHandlingContext(SourceGet)
+	err := notFoundSourceGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestSourceGetNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -785,6 +785,33 @@ func TestSourceListTenantNotExists(t *testing.T) {
 	templates.EmptySubcollectionListTest(t, c, rec)
 }
 
+// TestSourceListTenantWithoutSources tests that empty list is returned for existing tenant
+// without related sources
+func TestSourceListTenantWithoutSources(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	// For tenant without sources is expected that returned value
+	// will be empty list and return code 200
+	tenantId := int64(3)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		})
+
+	err := SourceList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.EmptySubcollectionListTest(t, c, rec)
+}
+
 func TestSourceListSatellite(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -915,6 +915,34 @@ func TestSourceGet(t *testing.T) {
 	}
 }
 
+// TestSourceGetInvalidTenant tests that not found is returned for
+// existing source id but with tenant that is now owner of this source
+func TestSourceGetInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(3)
+	sourceId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	notFoundSourceGet := ErrorHandlingContext(SourceGet)
+	err := notFoundSourceGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestSourceGetNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -759,6 +759,32 @@ func TestSourceList(t *testing.T) {
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
+// TestSourceListTenantNotExists tests that empty list is returned for not existing tenant
+func TestSourceListTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	// For not existing tenant is expected that returned value
+	// will be empty list and return code 200
+	tenantId := notExistingTenantId
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		})
+
+	err := SourceList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.EmptySubcollectionListTest(t, c, rec)
+}
+
 func TestSourceListSatellite(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 


### PR DESCRIPTION
Tests update for source handlers - part II. 
(part I. #369)

- main goal is to add/update tests to better tenancy testing
- each commit contains one updated or added test (or new helper function)
- changes for other functions in source handler will be part of next PR

handlers covered:
 - SourceList()
 - SourceGet()

**JIRA:** [RHCLOUD-19793](https://issues.redhat.com/browse/RHCLOUD-19793)