### PR TITLE
[RHCLOUD-19962] Update of tests for SourcePause() and SourceUnpause() handlers

### DIFF
--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1769,6 +1769,28 @@ func TestPauseSourceAndItsApplicationsNotFound(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+func TestPauseSourceAndItsApplicationsBadRequest(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/xxx/pause",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues("xxx")
+
+	badRequestSourcePause := ErrorHandlingContext(SourcePause)
+	err := badRequestSourcePause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.BadRequestTest(t, rec)
+}
+
 // TestResumeSourceAndItsApplications tests that the "unpause source" endpoint sets all the applications and the source
 // itself as resumed, by setting their "paused_at" column as "NULL".
 func TestResumeSourceAndItsApplications(t *testing.T) {

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1907,6 +1907,31 @@ func TestUnpauseSourceAndItsApplicationsNotFound(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+func TestUnpauseSourceAndItsApplicationsBadRequest(t *testing.T) {
+	tenantId := int64(1)
+	sourceId := "xxx"
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/xxx/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(sourceId)
+
+	notFoundSourceUnpause := ErrorHandlingContext(SourceUnpause)
+	err := notFoundSourceUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.BadRequestTest(t, rec)
+}
+
 // MockSender is just a mock which will allow us to control how the "RaiseEvent" function gets executed.
 type MockSender struct {
 }


### PR DESCRIPTION
Tests for SourcePause() and SourceUnpause() were updated to have better test data and better checks of pause/unpause status of source and applications.
+
Added tests for not found and bad request scenarios.

PR will be rebased after merging #371 

**JIRA:** [RHCLOUD-19962](https://issues.redhat.com/browse/RHCLOUD-19962)