### PR TITLE
[RHCLOUD-20008] Source pause unpause fix

### DIFF
--- a/source_handlers.go
+++ b/source_handlers.go
@@ -491,11 +491,19 @@ func SourceUnpause(c echo.Context) error {
 		return err
 	}
 
+	// Check if the source exists
+	_, err = sourceDao.GetById(&sourceId)
+	if err != nil {
+		return err
+	}
+
+	// Unpause the existing source
 	err = sourceDao.Unpause(sourceId)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}
 
+	// Load the source's applications
 	source, err := sourceDao.GetByIdWithPreload(&sourceId, "Applications")
 	if err != nil {
 		return err

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -437,11 +437,19 @@ func SourcePause(c echo.Context) error {
 		return err
 	}
 
+	// Check if the source exists
+	_, err = sourceDao.GetById(&sourceId)
+	if err != nil {
+		return err
+	}
+
+	// Pause the existing source
 	err = sourceDao.Pause(sourceId)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}
 
+	// Load the source's applications
 	source, err := sourceDao.GetByIdWithPreload(&sourceId, "Applications")
 	if err != nil {
 		return err

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1640,6 +1640,31 @@ func TestResumeSourceAndItsApplications(t *testing.T) {
 	}
 }
 
+func TestUnpauseSourceAndItsApplicationsNotFound(t *testing.T) {
+	tenantId := int64(1)
+	sourceId := int64(1789896785)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	notFoundSourceUnpause := ErrorHandlingContext(SourceUnpause)
+	err := notFoundSourceUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 // MockSender is just a mock which will allow us to control how the "RaiseEvent" function gets executed.
 type MockSender struct {
 }

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1590,6 +1590,28 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 	}
 }
 
+func TestPauseSourceAndItsApplicationsNotFound(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/809897868745/pause",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues("809897868745")
+
+	notFoundSourcePause := ErrorHandlingContext(SourcePause)
+	err := notFoundSourcePause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 // TestResumeSourceAndItsApplications tests that the "unpause source" endpoint sets all the applications and the source
 // itself as resumed, by setting their "paused_at" column as "NULL".
 func TestResumeSourceAndItsApplications(t *testing.T) {


### PR DESCRIPTION
In `SourcePause()` handler we get source dao, then we call `Pause()` method and then we load the source's applications. 
```
	sourceDao, err := getSourceDao(c)
	if err != nil {
		return err
	}

	err = sourceDao.Pause(sourceId)
	if err != nil {
		return util.NewErrBadRequest(err)
	}

	source, err := sourceDao.GetByIdWithPreload(&sourceId, "Applications")
	if err != nil {
		return err
	}
```
But when source id doesn't exist (and we expect Not Found Err) we call `Pause()` method and then when we try to load the source's applications, the not found err is returned.

But I believe we want to know that source doesn't exist BEFORE we call `Pause()` method.

Same for SourceUnpause()


**JIRA:** [RHCLOUD-20008](https://issues.redhat.com/browse/RHCLOUD-20008)