### PR TITLE
Add functionality for Delete allow for Satellite only

### DIFF
--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -205,6 +205,31 @@ func TestSystemDelete(t *testing.T) {
 	}
 }
 
+func TestSystemDeleteSource(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodDelete,
+		"/sources/1235",
+		nil,
+		map[string]interface{}{
+			"x-rh-identity": "dummy",
+			"identity": &identity.XRHID{
+				Identity: identity.Identity{
+					System: map[string]interface{}{"cn": "test_cert"},
+				},
+			},
+		},
+	)
+
+	err := permCheckOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one")
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	}
+}
+
 // yay dummy structs!
 type dummyRbac struct {
 	access bool

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -187,14 +187,17 @@ func SourceDelete(c echo.Context) (err error) {
 		return util.NewErrBadRequest(err)
 	}
 
-	// Check if the source exists before proceeding.
-	sourceExists, err := sourcesDB.Exists(id)
-	if err != nil {
-		return util.NewErrBadRequest(err)
-	}
+	s, err := sourcesDB.GetById(&id)
 
-	if !sourceExists {
-		return util.NewErrNotFound("source")
+	if err != nil {
+		return err
+	}
+	if c.Get("cert-auth") != nil {
+		satelliteId := dao.Static.GetSourceTypeId("satellite")
+		if s.SourceTypeID != satelliteId {
+			//We only allow delete with cert auth if source type is Satellite
+			return util.NewErrBadRequest("Unauthorized.")
+		}
 	}
 
 	c.Logger().Infof("Deleting Source Id %v", id)


### PR DESCRIPTION
@lpichler  @dehort  here is a POC for the behavior we want to have for 

https://issues.redhat.com/browse/RHCLOUD-19895

It needs some more Sources handler tests, but did not get time to figure out how the mocks work (need to set Satellite source_type_id).
Not crazy about putting the "source" specifics in the permission middleware - can probably be done more cleanly, but was looking for a fast path.

cc @syncrou 

Lindani