### PR TITLE
Add additional logs in source list internal endpoint

### DIFF
--- a/util/slice_utils.go
+++ b/util/slice_utils.go
@@ -9,3 +9,18 @@ func SliceContainsString(slice []string, target string) bool {
 	}
 	return false
 }
+
+// Difference  returns the elements in `a` that aren't in `b`.
+func Difference(a, b []string) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x] = struct{}{}
+	}
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
+}


### PR DESCRIPTION
This adds message with listing sources IDs, tenant IDs and status in source list internal endpoint from query 
`result := query.Joins("Tenant").Limit(limit).Offset(offset).Find(&sources)`

There is also added logging from query without join: `query.Limit(limit).Offset(offset).Find(&sources)`. For this message are displayed only differences between queries with/without `Joins("Tenant")`.

For logging is used error level to make sure we see it in production.(also in container logs).

log example message:

```
{
   "@timestamp":"2022-06-24T13:43:12.702Z",
   "@version":1,
   "app":"source-api-go",
   "backtrace":[
      "logger.backtrace(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:136)",
      "logger.(*CustomLoggerFormatter).Format(/Users/liborpichler/Projects/sources-api-go/logger/logger.go:201)",
      "dao.(*sourceDaoImpl).ListInternal(/Users/liborpichler/Projects/sources-api-go/dao/source_dao.go:144)",
      "main.InternalSourceList(/Users/liborpichler/Projects/sources-api-go/internal_handlers.go:46)",
      "middleware.PermissionCheck.func1(/Users/liborpichler/Projects/sources-api-go/middleware/authorization.go:102)",
      "middleware.Pagination.func1(/Users/liborpichler/Projects/sources-api-go/middleware/pagination.go:17)",
      "middleware.SortAndFilter.func1(/Users/liborpichler/Projects/sources-api-go/middleware/filtering.go:20)",
      "middleware.ParseHeaders.func1(/Users/liborpichler/Projects/sources-api-go/middleware/headers.go:75)",
      "middleware.HandleErrors.func1(/Users/liborpichler/Projects/sources-api-go/middleware/error_handling.go:13)"
   ],
   "caller":"github.com/RedHatInsights/sources-api-go/dao.(*sourceDaoImpl).ListInternal",
   "filename":"/Users/liborpichler/Projects/sources-api-go/dao/source_dao.go:144",
   "hostname":"lpichler1-mac",
   "labels":{
      "app":"source-api-go"
   },
   "level":"error",
   "log_type":"default",
   "message":"[MISSING-242154] Found 70 sources with limit 100 and offset 100 of 170 source records. Filters []. List of source IDs: [ID:114 TID:14(ac62acbf-cd45-11ec-bde8-0242ac110002) S:in_progress] [ID:7 TID:1(123456) S:unavailable] [ID:190 TID:23(59b8c02c-f396-11ec-af15-0242ac110002) S:in_progress] [ID:189 TID:23(59b8c02c-f396-11ec-af15-0242ac110002) S:in_progress] [ID:195 TID:23(59b8c02c-f396-11ec-af15-0242ac110002) S:in_progress] [ID:118 TID:1(123456) S:] [ID:119 TID:1(123456) S:] [ID:196 TID:23(59b8c02c-f396-11ec-af15-0242ac110002) S:available] [ID:121 TID:1(123456) S:] [ID:197 TID:23(59b8c02c-f396-11ec-af15-0242ac110002) S:partially_available] [ID:209 TID:22(59b8c6ca-f396-11ec-af15-0242ac110002) S:partially_available] [ID:213 TID:22(59b8c6ca-f396-11ec-af15-0242ac110002) S:available] [ID:217 TID:22(59b8c6ca-f396-11ec-af15-0242ac110002) S:in_progress] [ID:133 TID:1(123456) S:] [ID:134 TID:1(123456) S:] [ID:140 TID:1(123456) S:] [ID:141 TID:1(123456) S:] [ID:144 TID:1(123456) S:] [ID:145 TID:1(123456) S:] [ID:146 TID:1(123456) S:] [ID:147 TID:1(123456) S:] [ID:148 TID:1(123456) S:] [ID:149 TID:1(123456) S:] [ID:150 TID:1(123456) S:] [ID:180 TID:18(6089719) S:] [ID:152 TID:1(123456) S:] [ID:153 TID:1(123456) S:] [ID:154 TID:1(123456) S:] [ID:191 TID:23(59b8c02c-f396-11ec-af15-0242ac110002) S:partially_available] [ID:156 TID:1(123456) S:] [ID:157 TID:1(123456) S:] [ID:158 TID:1(123456) S:] [ID:159 TID:1(123456) S:] [ID:198 TID:23(59b8c02c-f396-11ec-af15-0242ac110002) S:in_progress] [ID:161 TID:1(123456) S:] [ID:162 TID:1(123456) S:] [ID:163 TID:1(123456) S:] [ID:164 TID:1(123456) S:] [ID:165 TID:1(123456) S:] [ID:166 TID:1(123456) S:] [ID:167 TID:1(123456) S:] [ID:168 TID:1(123456) S:] [ID:169 TID:1(123456) S:] [ID:170 TID:1(123456) S:] [ID:171 TID:17() S:] [ID:172 TID:17() S:] [ID:173 TID:17() S:] [ID:210 TID:22(59b8c6ca-f396-11ec-af15-0242ac110002) S:in_progress] [ID:175 TID:17() S:] [ID:95 TID:15(ac62a6dd-cd45-11ec-bde8-0242ac110002) S:in_progress] [ID:96 TID:15(ac62a6dd-cd45-11ec-bde8-0242ac110002) S:in_progress] [ID:97 TID:15(ac62a6dd-cd45-11ec-bde8-0242ac110002) S:partially_available] [ID:98 TID:15(ac62a6dd-cd45-11ec-bde8-0242ac110002) S:in_progress] [ID:99 TID:15(ac62a6dd-cd45-11ec-bde8-0242ac110002) S:in_progress] [ID:100 TID:15(ac62a6dd-cd45-11ec-bde8-0242ac110002) S:available] [ID:102 TID:15(ac62a6dd-cd45-11ec-bde8-0242ac110002) S:in_progress] [ID:104 TID:15(ac62a6dd-cd45-11ec-bde8-0242ac110002) S:available] [ID:46 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:in_progress] [ID:47 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:available] [ID:48 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:in_progress] [ID:49 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:in_progress] [ID:50 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:partially_available] [ID:51 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:available] [ID:52 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:partially_available] [ID:53 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:in_progress] [ID:54 TID:11(b5b25a5e-cc71-11ec-a3f9-025000000001) S:partially_available] [ID:211 TID:22(59b8c6ca-f396-11ec-af15-0242ac110002) S:in_progress] [ID:212 TID:22(59b8c6ca-f396-11ec-af15-0242ac110002) S:partially_available] [ID:214 TID:22(59b8c6ca-f396-11ec-af15-0242ac110002) S:partially_available] [ID:218 TID:22(59b8c6ca-f396-11ec-af15-0242ac110002) S:in_progress] Affected records 70",
   "tags":[
      "source-api-go"
   ]
}
```

We need take a look in message part - everything on one line:

```
[MISSING-242154] Found 70 sources with limit 100 and offset 100 of 170 source records. Filters []. List of source IDs: [ID:114 TID:14(ac62acbf-cd45-11ec-bde8-0242ac110002) S:in_progress] [ID:7 TID:1(123456) S:unavailable]....Affected records 70
```

It there are differences - they are also added to log message.
