### PR TITLE
Fix endpoint matching

### DIFF
--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/RedHatInsights/rbac-client-go"
@@ -111,9 +111,10 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 }
 
 func certDeleteAllowed(c echo.Context) bool {
-	//Cant get c.Path() to work (returns "")
+
 	//Limit to "sources" endpoint - further filtering done by source handler
-	allowed := strings.HasPrefix(c.Request().URL.Path, "/sources/")
+	m := regexp.MustCompile(`/sources/\d+$`)
+	allowed := m.MatchString(c.Request().URL.Path)
 	return allowed
 }
 

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -230,6 +230,31 @@ func TestSystemDeleteSource(t *testing.T) {
 	}
 }
 
+func TestSystemDeleteSourceVersioned(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodDelete,
+		"/api/sources/v3.1/sources/1235",
+		nil,
+		map[string]interface{}{
+			"x-rh-identity": "dummy",
+			"identity": &identity.XRHID{
+				Identity: identity.Identity{
+					System: map[string]interface{}{"cn": "test_cert"},
+				},
+			},
+		},
+	)
+
+	err := permCheckOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one")
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	}
+}
+
 // yay dummy structs!
 type dummyRbac struct {
 	access bool


### PR DESCRIPTION
@dehort  @syncrou this fixes our matching of the sources path.
Will clean this up when we move to middleware implementation.