### PR TITLE
[RHCLOUD-20139] Rhc handlers test update

### DIFF
--- a/internal/testutils/fixtures/tenant.go
+++ b/internal/testutils/fixtures/tenant.go
@@ -2,6 +2,8 @@ package fixtures
 
 import m "github.com/RedHatInsights/sources-api-go/model"
 
+var NotExistingTenantId = int64(309832948930)
+
 var TestTenantData = []m.Tenant{
 	{
 		Id:             1,

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -89,6 +89,32 @@ func TestRhcConnectionList(t *testing.T) {
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
+func TestRhcConnectionListTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	// For not existing tenant is expected that returned value
+	// will be empty list and return code 200
+	tenantId := fixtures.NotExistingTenantId
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/rhc_connections",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	err := RhcConnectionList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.EmptySubcollectionListTest(t, c, rec)
+}
+
 func TestRhcConnectionListInvalidFilter(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -115,6 +115,32 @@ func TestRhcConnectionListTenantNotExists(t *testing.T) {
 	templates.EmptySubcollectionListTest(t, c, rec)
 }
 
+func TestRhcConnectionListTenantWithoutRhcConnections(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	// For the tenant without rhc connections is expected that returned value
+	// will be empty list and return code 200
+	tenantId := int64(3)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/rhc_connections",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	err := RhcConnectionList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.EmptySubcollectionListTest(t, c, rec)
+}
+
 func TestRhcConnectionListInvalidFilter(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -31,8 +31,6 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-var notExistingTenantId = int64(309832948930)
-
 func TestSourceListAuthentications(t *testing.T) {
 	originalSecretStore := conf.SecretStore
 	tenantId := int64(1)
@@ -161,7 +159,7 @@ func TestSourceListAuthenticationsEmptyList(t *testing.T) {
 // for not existing tenant
 func TestSourceListAuthenticationsTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	tenantId := notExistingTenantId
+	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
 	c, rec := request.CreateTestContext(
@@ -347,7 +345,7 @@ func TestSourceTypeSourceSubcollectionListTenantNotExists(t *testing.T) {
 	// Check existing source type with not existing tenant id
 	// Expected is empty list
 	sourceTypeId := int64(1)
-	tenantId := notExistingTenantId
+	tenantId := fixtures.NotExistingTenantId
 
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
@@ -551,7 +549,7 @@ func TestApplicationTypeListSourceSubcollectionListTenantNotExists(t *testing.T)
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	// Check existing application type with not existing tenant id
 	appTypeId := int64(1)
-	tenantId := notExistingTenantId
+	tenantId := fixtures.NotExistingTenantId
 
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
@@ -764,7 +762,7 @@ func TestSourceListTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	// For not existing tenant is expected that returned value
 	// will be empty list and return code 200
-	tenantId := notExistingTenantId
+	tenantId := fixtures.NotExistingTenantId
 
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
@@ -970,7 +968,7 @@ func TestSourceGetInvalidTenant(t *testing.T) {
 // not existing tenant
 func TestSourceGetTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	tenantId := notExistingTenantId
+	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
 	c, rec := request.CreateTestContext(


### PR DESCRIPTION
Tests update for rhc connections handlers - part I.

main goal is to add/update tests to better tenancy testing
each commit contains one updated or added test (or new helper function)
changes for other rhc handlers will be part of next PR

handlers covered:
- RhcConnectionList()

**JIRA:** [RHCLOUD-20139](https://issues.redhat.com/browse/RHCLOUD-20139)