### PR TITLE
[RHCLOUD-20139] Rhc handlers test update3

### DIFF
--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -406,6 +406,43 @@ func TestRhcConnectionCreateTenantNotExists(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+// TestRhcConnectionCreateTenantNotOwnsSource tests that not found is returned for
+// existing tenant who doesn't own the source
+func TestRhcConnectionCreateTenantNotOwnsSource(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(3)
+
+	requestBody := model.RhcConnectionCreateRequest{
+		Extra:       nil,
+		SourceIdRaw: fixtures.TestSourceData[1].ID,
+		RhcId:       "12345",
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/rhc_connections",
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	notFoundRhcConnectionCreate := ErrorHandlingContext(RhcConnectionCreate)
+	err = notFoundRhcConnectionCreate(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestRhcConnectionCreateInvalidInput(t *testing.T) {
 	requestBody := model.RhcConnectionCreateRequest{
 		Extra:    nil,

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -369,6 +369,43 @@ func TestRhcConnectionCreate(t *testing.T) {
 	}
 }
 
+// TestRhcConnectionCreateTenantNotExists tests that not found is returned for
+// not existing tenant
+func TestRhcConnectionCreateTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := fixtures.NotExistingTenantId
+
+	requestBody := model.RhcConnectionCreateRequest{
+		Extra:       nil,
+		SourceIdRaw: fixtures.TestSourceData[1].ID,
+		RhcId:       "12345",
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/rhc_connections",
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	notFoundRhcConnectionCreate := ErrorHandlingContext(RhcConnectionCreate)
+	err = notFoundRhcConnectionCreate(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestRhcConnectionCreateInvalidInput(t *testing.T) {
 	requestBody := model.RhcConnectionCreateRequest{
 		Extra:    nil,


### PR DESCRIPTION
Tests update for rhc connections handlers - part III.
(part I. https://github.com/RedHatInsights/sources-api-go/pull/381, part II. https://github.com/RedHatInsights/sources-api-go/pull/382)

main goal is to add/update tests to better tenancy testing
each commit contains one updated or added test (or new helper function)
changes for other rhc handlers will be part of next PR

handlers covered:
- RhcConnectionCreate()

JIRA:[RHCLOUD-20139](https://issues.redhat.com/browse/RHCLOUD-20139)