### PR TITLE
[RHCLOUD-20153] added check if rhc connection exists for given tenant

### DIFF
--- a/dao/rhc_connection_dao.go
+++ b/dao/rhc_connection_dao.go
@@ -216,6 +216,12 @@ func (s *rhcConnectionDaoImpl) Update(rhcConnection *m.RhcConnection) error {
 func (s *rhcConnectionDaoImpl) Delete(id *int64) (*m.RhcConnection, error) {
 	var rhcConnection m.RhcConnection
 
+	// Check if rhc connection exists for given tenant
+	_, err := s.GetById(id)
+	if err != nil {
+		return nil, err
+	}
+
 	// The foreign key and the "cascade on delete" in the join table takes care of deleting the related
 	// "source_rhc_connection" row.
 	result := DB.
@@ -226,10 +232,6 @@ func (s *rhcConnectionDaoImpl) Delete(id *int64) (*m.RhcConnection, error) {
 
 	if result.Error != nil {
 		return nil, fmt.Errorf(`failed to delete rhcConnection with id "%d": %s`, id, result.Error)
-	}
-
-	if result.RowsAffected == 0 {
-		return nil, util.NewErrNotFound("rhcConnection")
 	}
 
 	return &rhcConnection, nil

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -579,6 +579,35 @@ func TestRhcConnectionDeleteInvalidTenant(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+// TestRhcConnectionDeleteTenantNotExists tests that not found err is returned
+// when tenant doesn't exist
+func TestRhcConnectionDeleteTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(98304983)
+	rhcId := fixtures.TestRhcConnectionData[2].ID
+
+	c, rec := request.CreateTestContext(
+		http.MethodDelete,
+		fmt.Sprintf("/api/sources/v3.1/rhc_connections/%d", rhcId),
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", rhcId))
+
+	notFoundRhcConnectionDelete := ErrorHandlingContext(RhcConnectionDelete)
+	err := notFoundRhcConnectionDelete(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestRhcConnectionDeleteNotFound(t *testing.T) {
 	nonExistingId := "12345"
 

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -550,6 +550,35 @@ func TestRhcConnectionDeleteMissingParam(t *testing.T) {
 	templates.BadRequestTest(t, rec)
 }
 
+// TestRhcConnectionDeleteInvalidTenant tests that not found err is returned
+// when tenant tries to delete not owned rhc connection
+func TestRhcConnectionDeleteInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(2)
+	rhcId := fixtures.TestRhcConnectionData[2].ID
+
+	c, rec := request.CreateTestContext(
+		http.MethodDelete,
+		fmt.Sprintf("/api/sources/v3.1/rhc_connections/%d", rhcId),
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", rhcId))
+
+	notFoundRhcConnectionDelete := ErrorHandlingContext(RhcConnectionDelete)
+	err := notFoundRhcConnectionDelete(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestRhcConnectionDeleteNotFound(t *testing.T) {
 	nonExistingId := "12345"
 


### PR DESCRIPTION
this PR adds check if record exists into Delete method for rhc connections

problem is, that table with rhc connections doesn't contain info about tenant and before delete we need to check if the rhc connection belongs to the given tenant

so I added a GetById() call that already contains a query that solves this

**JIRA:** [RHCLOUD-20153](https://issues.redhat.com/browse/RHCLOUD-20153)