### PR TITLE
[RHCLOUD-20139] Rhc handlers test update4

### DIFF
--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -538,6 +538,8 @@ func TestRhcConnectionCreateRelationExists(t *testing.T) {
 }
 
 func TestRhcConnectionEdit(t *testing.T) {
+	tenantId := int64(1)
+	rhcId := fixtures.TestRhcConnectionData[2].ID
 	requestBody := model.RhcConnectionEditRequest{
 		Extra: nil,
 	}
@@ -547,21 +549,19 @@ func TestRhcConnectionEdit(t *testing.T) {
 		t.Error("Could not marshal JSON")
 	}
 
-	id := strconv.FormatInt(fixtures.TestRhcConnectionData[2].ID, 10)
-
 	c, rec := request.CreateTestContext(
 		http.MethodPatch,
-		"/api/sources/v3.1/rhc_connections/"+id,
+		fmt.Sprintf("/api/sources/v3.1/rhc_connections/%d", rhcId),
 		bytes.NewReader(body),
 		map[string]interface{}{
-			"tenantID": int64(1),
+			"tenantID": tenantId,
 		},
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	c.SetParamNames("id")
-	c.SetParamValues(id)
+	c.SetParamValues(fmt.Sprintf("%d", rhcId))
 
 	err = RhcConnectionEdit(c)
 	if err != nil {
@@ -570,6 +570,16 @@ func TestRhcConnectionEdit(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Errorf("Want status code %d. Got %d. Body: %s", http.StatusOK, rec.Code, rec.Body.String())
+	}
+
+	// check in fixtures that changed rhc connection belongs to the desired tenant
+	for _, srcRhc := range fixtures.TestSourceRhcConnectionData {
+		if srcRhc.RhcConnectionId == rhcId {
+			if srcRhc.TenantId != tenantId {
+				t.Errorf("wrong tenant id, expected %d, got %d", tenantId, srcRhc.TenantId)
+			}
+			break
+		}
 	}
 }
 

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -583,6 +583,44 @@ func TestRhcConnectionEdit(t *testing.T) {
 	}
 }
 
+// TestRhcConnectionEditInvalidTenant tests situation when the tenant tries to
+// edit existing not owned rhc connection
+func TestRhcConnectionEditInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(2)
+	rhcId := fixtures.TestRhcConnectionData[2].ID
+	requestBody := model.RhcConnectionEditRequest{
+		Extra: nil,
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, rec := request.CreateTestContext(
+		http.MethodPatch,
+		fmt.Sprintf("/api/sources/v3.1/rhc_connections/%d", rhcId),
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", rhcId))
+
+	notFoundRhcConnectionEdit := ErrorHandlingContext(RhcConnectionEdit)
+	err = notFoundRhcConnectionEdit(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestRhcConnectionEditInvalidParam(t *testing.T) {
 	invalidId := "xxx"
 


### PR DESCRIPTION
Tests update for rhc connections handlers - part IV.
(part I. https://github.com/RedHatInsights/sources-api-go/pull/381, part II. https://github.com/RedHatInsights/sources-api-go/pull/382, part III. https://github.com/RedHatInsights/sources-api-go/pull/383)

main goal is to add/update tests to better tenancy testing
each commit contains one updated or added test (or new helper function)
changes for other rhc handlers will be part of next PR

handlers covered:
- RhcConnectionEdit()

**JIRA:** [RHCLOUD-20139](https://issues.redhat.com/browse/RHCLOUD-20139)