### PR TITLE
[RHCLOUD-20139] Rhc handlers test update5

### DIFF
--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -1004,3 +1004,34 @@ func TestRhcConnectionGetRelatedSourcesInvalidTenant(t *testing.T) {
 
 	templates.NotFoundTest(t, rec)
 }
+
+// TestRhcConnectionGetRelatedSourcesTenantNotExists tests that not found err is returned
+// when tenant doesn't exist
+func TestRhcConnectionGetRelatedSourcesTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := fixtures.NotExistingTenantId
+	rhcConnectionId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		fmt.Sprintf("/api/sources/v3.1/rhc_connections/%d/sources", rhcConnectionId),
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", rhcConnectionId))
+
+	notFoundRhcConnectionSourcesList := ErrorHandlingContext(RhcConnectionSourcesList)
+	err := notFoundRhcConnectionSourcesList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -829,6 +829,7 @@ func TestRhcConnectionDeleteNotFound(t *testing.T) {
 }
 
 func TestRhcConnectionGetRelatedSources(t *testing.T) {
+	tenantId := int64(1)
 	rhcConnectionId := "2"
 
 	c, rec := request.CreateTestContext(
@@ -839,7 +840,7 @@ func TestRhcConnectionGetRelatedSources(t *testing.T) {
 			"limit":    100,
 			"offset":   0,
 			"filters":  []util.Filter{},
-			"tenantID": int64(1),
+			"tenantID": tenantId,
 		},
 	)
 
@@ -885,7 +886,12 @@ func TestRhcConnectionGetRelatedSources(t *testing.T) {
 		if !ok {
 			t.Error("model did not deserialize as a source")
 		}
+	}
 
+	// Check that all sources belong to our tenant
+	err = checkAllSourcesBelongToTenant(tenantId, out.Data)
+	if err != nil {
+		t.Error(err)
 	}
 }
 

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -973,3 +973,34 @@ func TestRhcConnectionGetRelatedSourcesNotFound(t *testing.T) {
 
 	templates.NotFoundTest(t, rec)
 }
+
+// TestRhcConnectionGetRelatedSourcesInvalidTenant tests that not found err is returned
+// when tenant tries to list sources for not owned rhc connection
+func TestRhcConnectionGetRelatedSourcesInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(3)
+	rhcConnectionId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		fmt.Sprintf("/api/sources/v3.1/rhc_connections/%d/sources", rhcConnectionId),
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", rhcConnectionId))
+
+	notFoundRhcConnectionSourcesList := ErrorHandlingContext(RhcConnectionSourcesList)
+	err := notFoundRhcConnectionSourcesList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}


### PR DESCRIPTION
Tests update for rhc connections handlers - part V.
(part I. https://github.com/RedHatInsights/sources-api-go/pull/381, part II. https://github.com/RedHatInsights/sources-api-go/pull/382, part III. https://github.com/RedHatInsights/sources-api-go/pull/383, part IV. #387)

main goal is to add/update tests to better tenancy testing
each commit contains one updated or added test (or new helper function)
changes for other rhc handlers will be part of next PR

handlers covered:
- RhcConnectionSourcesList()

**JIRA:** [RHCLOUD-20139](https://issues.redhat.com/browse/RHCLOUD-20139)