### PR TITLE
[RHCLOUD-20192] updated method checkIfPrimaryRecordExists() to check tenancy for primary object

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -240,6 +240,35 @@ func TestSourceApplicationSubcollectionListBadRequestInvalidFilter(t *testing.T)
 	templates.BadRequestTest(t, rec)
 }
 
+func TestSourceApplicationSubcollectionListTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(30984093843908490)
+	sourceId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/1/applications",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	notFoundSourceListApplications := ErrorHandlingContext(SourceListApplications)
+	err := notFoundSourceListApplications(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestApplicationList(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,

--- a/internal/testutils/fixtures/tenant.go
+++ b/internal/testutils/fixtures/tenant.go
@@ -2,6 +2,8 @@ package fixtures
 
 import m "github.com/RedHatInsights/sources-api-go/model"
 
+var NotExistingTenantId = int64(309832948930)
+
 var TestTenantData = []m.Tenant{
 	{
 		Id:             1,

--- a/model/relation_object.go
+++ b/model/relation_object.go
@@ -151,7 +151,7 @@ func NewRelationObject(objectModel interface{}, currentTenantID int64, query *go
 		return object, err
 	}
 
-	return object, err
+	return object, nil
 }
 
 func (relationObject *RelationObject) StringBaseObject() string {

--- a/model/relation_object.go
+++ b/model/relation_object.go
@@ -117,7 +117,20 @@ func (relationObject *RelationObject) setRelationObjectID() error {
 
 func (relationObject *RelationObject) checkIfPrimaryRecordExists(query *gorm.DB) error {
 	result := map[string]interface{}{}
-	query.Model(relationObject.baseObject).Find(&result, relationObject.Id)
+
+	switch relationObject.baseObject.(type) {
+	case Source:
+		query.Model(relationObject.baseObject).
+			Where("tenant_id = ?", relationObject.CurrentTenantID).
+			Find(&result, relationObject.Id)
+
+	case SourceType, ApplicationType:
+		query.Model(relationObject.baseObject).
+			Find(&result, relationObject.Id)
+
+	default:
+		return fmt.Errorf("unexpected primary record type")
+	}
 
 	if len(result) == 0 {
 		return fmt.Errorf("record not found")


### PR DESCRIPTION
in application_dao.go `SubCollectionList()` method we check if primary object exists, we use for it method `checkIfPrimaryRecordExists()` in relation_object.go

in the query we are using object without tenant id

consequences are that we are returning the subcollection list of objects even the primary object is not owned by tenant

in this PR is one test for `SubCollectionList()` in application_dao.go and endpoint `/api/sources/v3.1/sources/<id>/applications` but more tests will be added in text PRs (see [RHCLOUD-20138](https://issues.redhat.com/browse/RHCLOUD-20138))

**JIRA:** [RHCLOUD-20192](https://issues.redhat.com/browse/RHCLOUD-20192)