### PR TITLE
[WIP] Populate userid in bulk create 

### DIFF
--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -81,18 +81,14 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
-	var users []m.User
-	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).Find(&users).Error
+	var user m.User
+	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).First(&user).Error
 	if err != nil {
 		t.Error(err)
 	}
 
-	if len(users) != 1 {
-		t.Errorf("1 user expected instead of %d", len(users))
-	}
-
-	if users[0].UserID != testUserId {
-		t.Errorf("expected userid is %s instead of %s", testUserId, users[0].UserID)
+	if user.UserID != testUserId {
+		t.Errorf("expected userid is %s instead of %s", testUserId, user.UserID)
 	}
 
 	var sources []m.Source
@@ -101,7 +97,7 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
-	if *(sources[0].UserID) != users[0].Id {
+	if *(sources[0].UserID) != user.Id {
 		t.Error(err)
 	}
 
@@ -117,7 +113,7 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
-	if *(applications[0].UserID) != users[0].Id {
+	if *(applications[0].UserID) != user.Id {
 		t.Error(err)
 	}
 
@@ -127,7 +123,7 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
-	if *(authentications[0].UserID) != users[0].Id {
+	if *(authentications[0].UserID) != user.Id {
 		t.Error(err)
 	}
 
@@ -139,7 +135,7 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
-	if *(authentications[0].UserID) != users[0].Id {
+	if *(authentications[0].UserID) != user.Id {
 		t.Error(err)
 	}
 
@@ -148,7 +144,7 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)
 	}
 
-	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).Delete(&users).Error
+	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).Delete(&user).Error
 	if err != nil {
 		t.Error(err)
 	}
@@ -191,14 +187,10 @@ func TestCreateUserWithoutResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
-	var users []m.User
-	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).Find(&users).Error
-	if err != nil {
+	var user m.User
+	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).First(&user).Error
+	if err == nil {
 		t.Error(err)
-	}
-
-	if len(users) != 0 {
-		t.Errorf("0 user expected instead of %d", len(users))
 	}
 
 	var sources []m.Source

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -10,7 +10,9 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/kafka"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
@@ -318,15 +320,13 @@ func TestCreateUserWithoutResourceOwnershipConfig(t *testing.T) {
 }
 
 func cleanSourceForTenant(sourceName string, tenantID *int64) error {
-	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantID})
-
 	source := &m.Source{Name: sourceName}
 	err := dao.DB.Model(&m.Source{}).Where("name = ?", source.Name).Find(&source).Error
 	if err != nil {
 		return err
 	}
 
-	_, _, _, _, _, err = sourceDao.DeleteCascade(source.ID)
+	err = service.DeleteCascade(tenantID, "Source", source.ID, []kafka.Header{})
 
 	return err
 }

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -93,6 +93,16 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Errorf("expected userid is %s instead of %s", testUserId, users[0].UserID)
 	}
 
+	var sources []m.Source
+	err = dao.DB.Model(&m.Source{}).Where("name = ?", nameSource).Find(&sources).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if *(sources[0].UserID) != users[0].Id {
+		t.Error(err)
+	}
+
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
 	if err != nil {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)
@@ -151,6 +161,16 @@ func TestCreateUserWithoutResourceOwnershipApplicationType(t *testing.T) {
 		t.Errorf("0 user expected instead of %d", len(users))
 	}
 
+	var sources []m.Source
+	err = dao.DB.Model(&m.Source{}).Where("name = ?", nameSource).Find(&sources).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if sources[0].UserID != nil {
+		t.Error(err)
+	}
+
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
 	if err != nil {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)
@@ -202,6 +222,16 @@ func TestCreateUserWithoutResourceOwnershipConfig(t *testing.T) {
 
 	if len(users) != 0 {
 		t.Errorf("0 users expected instead of %d", len(users))
+	}
+
+	var sources []m.Source
+	err = dao.DB.Model(&m.Source{}).Where("name = ?", nameSource).Find(&sources).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if sources[0].UserID != nil {
+		t.Error(err)
 	}
 
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -119,6 +119,16 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
+	var authentications []m.Authentication
+	err = dao.DB.Model(&m.Authentication{}).Where("id = ?", response.Authentications[0].ID).Find(&authentications).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if *(authentications[0].UserID) != users[0].Id {
+		t.Error(err)
+	}
+
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
 	if err != nil {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)
@@ -200,6 +210,16 @@ func TestCreateUserWithoutResourceOwnershipApplicationType(t *testing.T) {
 	}
 
 	if applications[0].UserID != nil {
+		t.Error(err)
+	}
+
+	var authentications []m.Authentication
+	err = dao.DB.Model(&m.Authentication{}).Where("id = ?", response.Authentications[0].ID).Find(&authentications).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if authentications[0].UserID != nil {
 		t.Error(err)
 	}
 

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -129,6 +129,18 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
+	var applicationAuthentications []m.ApplicationAuthentication
+	err = dao.DB.Model(&m.ApplicationAuthentication{}).
+		Where("application_id = ? AND authentication_id = ?", response.Applications[0].ID, response.Authentications[0].ID).
+		Find(&applicationAuthentications).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if *(authentications[0].UserID) != users[0].Id {
+		t.Error(err)
+	}
+
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
 	if err != nil {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)
@@ -215,6 +227,19 @@ func TestCreateUserWithoutResourceOwnershipApplicationType(t *testing.T) {
 
 	var authentications []m.Authentication
 	err = dao.DB.Model(&m.Authentication{}).Where("id = ?", response.Authentications[0].ID).Find(&authentications).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if authentications[0].UserID != nil {
+		t.Error(err)
+	}
+
+	var applicationAuthentications []m.ApplicationAuthentication
+	err = dao.DB.Model(&m.ApplicationAuthentication{}).
+		Where("application_id = ? AND authentication_id = ?", response.Applications[0].ID, response.Authentications[0].ID).
+		Find(&applicationAuthentications).Error
+
 	if err != nil {
 		t.Error(err)
 	}

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -62,7 +62,7 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error("Could not marshal JSON")
 	}
 
-	c, _ := request.CreateTestContext(
+	c, res := request.CreateTestContext(
 		http.MethodPost,
 		"/api/sources/v3.1/bulk_create",
 		bytes.NewReader(body),
@@ -103,6 +103,22 @@ func TestCreateUserWithResourceOwnershipApplicationType(t *testing.T) {
 		t.Error(err)
 	}
 
+	var response m.BulkCreateResponse
+	err = json.Unmarshal(res.Body.Bytes(), &response)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var applications []m.Application
+	err = dao.DB.Model(&m.Application{}).Where("id = ?", response.Applications[0].ID).Find(&applications).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if *(applications[0].UserID) != users[0].Id {
+		t.Error(err)
+	}
+
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
 	if err != nil {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)
@@ -134,7 +150,7 @@ func TestCreateUserWithoutResourceOwnershipApplicationType(t *testing.T) {
 		t.Error("Could not marshal JSON")
 	}
 
-	c, _ := request.CreateTestContext(
+	c, res := request.CreateTestContext(
 		http.MethodPost,
 		"/api/sources/v3.1/bulk_create",
 		bytes.NewReader(body),
@@ -168,6 +184,22 @@ func TestCreateUserWithoutResourceOwnershipApplicationType(t *testing.T) {
 	}
 
 	if sources[0].UserID != nil {
+		t.Error(err)
+	}
+
+	var response m.BulkCreateResponse
+	err = json.Unmarshal(res.Body.Bytes(), &response)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var applications []m.Application
+	err = dao.DB.Model(&m.Application{}).Where("id = ?", response.Applications[0].ID).Find(&applications).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if applications[0].UserID != nil {
 		t.Error(err)
 	}
 

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -173,5 +173,5 @@ type TenantDao interface {
 }
 
 type UserDao interface {
-	CreateIfResourceOwnershipActive(userResource *m.UserResource) error
+	FindOrCreateUserIfResourceOwnershipActive(userResource *m.UserResource) error
 }

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -1,6 +1,10 @@
 package model
 
-import "github.com/RedHatInsights/sources-api-go/util"
+import (
+	"strings"
+
+	"github.com/RedHatInsights/sources-api-go/util"
+)
 
 const UserOwnership = "user"
 
@@ -39,4 +43,19 @@ func (ur *UserResource) OwnershipPresentForSource(sourceName string) bool {
 	}
 
 	return util.SliceContainsString(ur.SourceNames, sourceName)
+}
+
+func (ur *UserResource) OwnershipPresentForSourceAndApplication(sourceName, applicationTypeName string) bool {
+	return ur.OwnershipPresentForSource(sourceName) && ur.ownershipPresentForApplication(applicationTypeName)
+}
+
+func (ur *UserResource) ownershipPresentForApplication(applicationTypeName string) bool {
+	if len(ur.ApplicationTypesNames) == 0 {
+		return false
+	}
+
+	parts := strings.Split(applicationTypeName, "/")
+	typeName := parts[len(parts)-1]
+
+	return util.SliceContainsString(ur.ApplicationTypesNames, typeName)
 }

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -46,10 +46,10 @@ func (ur *UserResource) OwnershipPresentForSource(sourceName string) bool {
 }
 
 func (ur *UserResource) OwnershipPresentForSourceAndApplication(sourceName, applicationTypeName string) bool {
-	return ur.OwnershipPresentForSource(sourceName) && ur.ownershipPresentForApplication(applicationTypeName)
+	return ur.OwnershipPresentForSource(sourceName) && ur.OwnershipPresentForApplication(applicationTypeName)
 }
 
-func (ur *UserResource) ownershipPresentForApplication(applicationTypeName string) bool {
+func (ur *UserResource) OwnershipPresentForApplication(applicationTypeName string) bool {
 	if len(ur.ApplicationTypesNames) == 0 {
 		return false
 	}

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/RedHatInsights/sources-api-go/util"
+
 const UserOwnership = "user"
 
 type UserResource struct {
@@ -29,4 +31,12 @@ func (ur *UserResource) userIDPresent() bool {
 
 func (ur *UserResource) userResourceOwnership() bool {
 	return ur.ResourceOwnership == UserOwnership
+}
+
+func (ur *UserResource) OwnershipPresentForSource(sourceName string) bool {
+	if !ur.UserOwnershipActive() {
+		return false
+	}
+
+	return util.SliceContainsString(ur.SourceNames, sourceName)
 }

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -80,7 +80,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 		}
 
 		// link up the authentications to their polymorphic relations.
-		output.Authentications, err = linkUpAuthentications(req, &output, tenant)
+		output.Authentications, err = linkUpAuthentications(req, &output, tenant, userResource)
 		if err != nil {
 			return err
 		}
@@ -272,7 +272,7 @@ func parseEndpoints(reqEndpoints []m.BulkCreateEndpoint, current *m.BulkCreateOu
 	return endpoints, nil
 }
 
-func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput, tenant *m.Tenant) ([]m.Authentication, error) {
+func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput, tenant *m.Tenant, userResource *m.UserResource) ([]m.Authentication, error) {
 	authentications := make([]m.Authentication, 0)
 
 	for _, auth := range req.Authentications {
@@ -326,6 +326,11 @@ func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput,
 		case "source":
 			a.ResourceID = current.Sources[0].ID
 			a.SourceID = current.Sources[0].ID
+
+			if userResource.OwnershipPresentForSource(current.Sources[0].Name) {
+				a.UserID = &userResource.User.Id
+			}
+
 			l.Log.Infof("Source Authentication does not need linked - continuing")
 
 		case "application":
@@ -336,6 +341,9 @@ func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput,
 
 			a.ResourceID = id
 			a.SourceID = current.Sources[0].ID
+			if userResource.OwnershipPresentForSourceAndApplication(current.Sources[0].Name, auth.ResourceName) {
+				a.UserID = &userResource.User.Id
+			}
 
 		case "endpoint":
 			id, err := linkupEndpoint(auth.ResourceName, current.Endpoints)

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -52,7 +52,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 		}
 
 		// parse the sources, then save them in the transaction.
-		output.Sources, err = parseSources(req.Sources, tenant)
+		output.Sources, err = parseSources(req.Sources, tenant, userResource)
 		if err != nil {
 			return err
 		}
@@ -114,7 +114,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 	return &output, err
 }
 
-func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant) ([]m.Source, error) {
+func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant, userResource *m.UserResource) ([]m.Source, error) {
 	sources := make([]m.Source, len(reqSources))
 
 	for i, source := range reqSources {
@@ -172,6 +172,10 @@ func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant) ([]m.Source
 		s.Endpoints = make([]m.Endpoint, 0)
 		s.Applications = make([]m.Application, 0)
 		s.Authentications = make([]m.Authentication, 0)
+
+		if userResource.OwnershipPresentForSource(s.Name) {
+			s.UserID = &userResource.User.Id
+		}
 
 		// add it to the list
 		sources[i] = s

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -92,14 +92,26 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 			}
 
 			if strings.ToLower(output.Authentications[i].ResourceType) == "application" {
-				output.ApplicationAuthentications = append(output.ApplicationAuthentications, m.ApplicationAuthentication{
+				applicationAuthentication := m.ApplicationAuthentication{
 					// TODO: After vault migration.
-					// VaultPath:         output.Authentications[i].Path(),
+					// VaultPath:
+					//output.Authentications[i].Path(),
 					ApplicationID:    output.Authentications[i].ResourceID,
 					AuthenticationID: output.Authentications[i].DbID,
 					TenantID:         tenant.Id,
 					Tenant:           *tenant,
-				})
+				}
+
+				applicationFromAuthentication := &m.Application{ID: output.Authentications[i].ResourceID}
+				tx.Debug().Preload("ApplicationType").Find(&applicationFromAuthentication)
+
+				applicationType := &m.ApplicationType{Id: applicationFromAuthentication.ApplicationTypeID}
+				if tx.Debug().First(&applicationType).Error == nil {
+					if userResource.OwnershipPresentForApplication(applicationType.Name) {
+						applicationAuthentication.UserID = &userResource.User.Id
+					}
+				}
+				output.ApplicationAuthentications = append(output.ApplicationAuthentications, applicationAuthentication)
 			}
 		}
 

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -46,7 +46,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 		}
 
 		userDao := dao.GetUserDao(&tenant.Id)
-		err = userDao.CreateIfResourceOwnershipActive(userResource)
+		err = userDao.FindOrCreateUserIfResourceOwnershipActive(userResource)
 		if err != nil {
 			return err
 		}

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -61,7 +61,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 			return err
 		}
 
-		output.Applications, err = parseApplications(req.Applications, &output, tenant)
+		output.Applications, err = parseApplications(req.Applications, &output, tenant, userResource)
 		if err != nil {
 			return err
 		}
@@ -184,7 +184,7 @@ func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant, userResourc
 	return sources, nil
 }
 
-func parseApplications(reqApplications []m.BulkCreateApplication, current *m.BulkCreateOutput, tenant *m.Tenant) ([]m.Application, error) {
+func parseApplications(reqApplications []m.BulkCreateApplication, current *m.BulkCreateOutput, tenant *m.Tenant, userResource *m.UserResource) ([]m.Application, error) {
 	applications := make([]m.Application, 0)
 
 	for _, app := range reqApplications {
@@ -210,6 +210,10 @@ func parseApplications(reqApplications []m.BulkCreateApplication, current *m.Bul
 			a.SourceID = src.ID
 			a.Tenant = *tenant
 			a.TenantID = tenant.Id
+
+			if userResource.OwnershipPresentForSourceAndApplication(app.SourceName, app.ApplicationTypeName) {
+				a.UserID = &userResource.User.Id
+			}
 
 			applications = append(applications, *a)
 		}


### PR DESCRIPTION
### Prerequisites 

To make this work we need to set `resource_ownership = user` in app-studio app type.

```diff
diff --git a/dao/seeds/application_types.yml b/dao/seeds/application_types.yml
index b27b4e7..51d1c20 100644
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -19,6 +19,7 @@
       - gitlab-personal-access-token
     quay:
       - quay-encrypted-password
+  resource_ownership: user

 "/insights/platform/catalog":
   display_name: Automation Services Catalog
```

### Description
Changes in this PR adds to creation with bulk create possibility to populate column `userid` in created records of tables:
`sources, applications, application_authentications and authentications`.

`userid` is taken from table `users` where user record here was added from XRHID header - user creation was added [here](https://github.com/RedHatInsights/sources-api-go/pull/348) 

`userid` is populated in records which are associated with `application_type` with column `resource_ownership=user`. App studio application type will have `resource_ownership=user` in future PR.

Examples of bulk create request. (let's count that diff above was applied):

```
POST /api/sources/v3.1/bulk_create

{
  "sources": [
    {
      "name": "B17",
      "source_type_name": "bitbucket"
    }
  ],
  "applications": [
    {
      "source_name": "B17",
      "application_type_name": "app-studio"
    }
  ],
  "authentications": [
    {
      "resource_type": "application",
      "resource_name": "app-studio",
      "username": "myUser",
      "password": "myPass"
    }
  ]
}
```

```
POST /api/sources/v3.1/bulk_create

{
  "sources": [
    {
      "name": "B15",
      "source_type_name": "bitbucket"
    }
  ],
  "applications": [
    {
      "source_name": "B15",
      "application_type_name": "app-studio"
    }
  ],
  "authentications": [
    {
      "resource_type": "source",
      "username": "myUser",
      "password": "myPass"
    }
  ]
}
```


### Depends on
- [x] https://github.com/RedHatInsights/sources-api-go/pull/348