### PR TITLE
[RHCLOUD-19793] Source handler tests update4

### DIFF
--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1955,6 +1955,35 @@ func TestUnpauseSourceAndItsApplications(t *testing.T) {
 	}
 }
 
+// TestUnpauseSourceAndItsApplicationsInvalidTenant tests that not found is returned
+// when tenant tries to unpause not owned source
+func TestUnpauseSourceAndItsApplicationsInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	// The source is not owned by the tenant
+	tenantId := int64(2)
+	sourceId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	notFoundSourceUnpause := ErrorHandlingContext(SourceUnpause)
+	err := notFoundSourceUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestUnpauseSourceAndItsApplicationsNotFound(t *testing.T) {
 	tenantId := int64(1)
 	sourceId := int64(1789896785)

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1934,7 +1934,12 @@ func TestUnpauseSourceAndItsApplications(t *testing.T) {
 		t.Error("the source is paused and the opposite is expected")
 	}
 
-	// Check that related applications are not paused
+	// Check that the source belongs to desired tenant
+	if src.TenantID != tenantId {
+		t.Errorf("expected tenant %d, got %d", tenantId, src.TenantID)
+	}
+
+	// Check that related applications are not paused and belongs to the desired tenant
 	appDao := dao.GetApplicationDao(&tenantId)
 	apps, _, err := appDao.SubCollectionList(m.Source{ID: sourceId}, 100, 0, nil)
 	if err != nil {
@@ -1943,6 +1948,9 @@ func TestUnpauseSourceAndItsApplications(t *testing.T) {
 	for _, a := range apps {
 		if a.PausedAt != nil {
 			t.Errorf("application with id = %d is paused and the opposite is expected", a.ID)
+		}
+		if a.TenantID != tenantId {
+			t.Errorf("expected tenant %d, got %d", tenantId, a.TenantID)
 		}
 	}
 }

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1759,7 +1759,12 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 		t.Error("the source is not paused => 'paused_at' is nil and the opposite is expected")
 	}
 
-	// Check that relation applications are paused
+	// Check that paused source belongs to desired tenant
+	if src.TenantID != tenantId {
+		t.Errorf("expected tenant %d, got %d", tenantId, src.TenantID)
+	}
+
+	// Check that relation applications are paused and belongs to desired tenant
 	appDao := dao.GetApplicationDao(&tenantId)
 	apps, _, err := appDao.SubCollectionList(m.Source{ID: sourceId}, 100, 0, nil)
 	if err != nil {
@@ -1768,6 +1773,9 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 	for _, a := range apps {
 		if a.PausedAt == nil {
 			t.Errorf("application with id = %d is not paused and the opposite is expected", a.ID)
+		}
+		if a.TenantID != tenantId {
+			t.Errorf("expected tenant %d, got %d", tenantId, a.TenantID)
 		}
 	}
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1815,6 +1815,34 @@ func TestPauseSourceAndItsApplicationsInvalidTenant(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+// TestPauseSourceAndItsApplicationsTenantNotExists tests that not found is returned
+// for not existing tenant
+func TestPauseSourceAndItsApplicationsTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := fixtures.NotExistingTenantId
+	sourceId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/pause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	notFoundSourcePause := ErrorHandlingContext(SourcePause)
+	err := notFoundSourcePause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestPauseSourceAndItsApplicationsNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodPost,

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1786,6 +1786,35 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 	}
 }
 
+// TestPauseSourceAndItsApplicationsInvalidTenant tests that not found is returned
+// when tenant tries to pause not owned source
+func TestPauseSourceAndItsApplicationsInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	// The source is not owned by the tenant
+	tenantId := int64(2)
+	sourceId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/pause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	notFoundSourcePause := ErrorHandlingContext(SourcePause)
+	err := notFoundSourcePause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestPauseSourceAndItsApplicationsNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodPost,

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1984,6 +1984,34 @@ func TestUnpauseSourceAndItsApplicationsInvalidTenant(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+// TestUnpauseSourceAndItsApplicationsTenantNotExists tests that not found is returned
+// for not existing tenant
+func TestUnpauseSourceAndItsApplicationsTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := fixtures.NotExistingTenantId
+	sourceId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	notFoundSourceUnpause := ErrorHandlingContext(SourceUnpause)
+	err := notFoundSourceUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestUnpauseSourceAndItsApplicationsNotFound(t *testing.T) {
 	tenantId := int64(1)
 	sourceId := int64(1789896785)


### PR DESCRIPTION
Tests update for source handlers - part IV. 
(part I. #369, part II. #370, part III. #371)

- main goal is to add/update tests to better tenancy testing
- each commit contains one updated or added test (or new helper function)
- changes for other functions in source handler will be part of next PR

handlers covered:
 - SourcePause()
 - SourceUnpause()

**JIRA:** [RHCLOUD-19793](https://issues.redhat.com/browse/RHCLOUD-19793)