### PR TITLE
Use getSourceDao instead of dao.GetSourceDao(..) in authentication_handlers

### DIFF
--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -176,7 +176,11 @@ func AuthenticationEdit(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
-	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: authDao.Tenant()})
+	sourceDao, err := getSourceDao(c)
+	if err != nil {
+		return err
+	}
+
 	source, err := sourceDao.GetById(&auth.SourceID)
 	if err != nil {
 		return err


### PR DESCRIPTION
dao.GetSourceDao is called in getSourceDao with
all necessary parameters



related to https://github.com/RedHatInsights/sources-api-go/issues/356