### PR TITLE
Use AuthenticationDaoParams struct as parameter of GetAuthenticationDao

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -749,7 +749,7 @@ func TestApplicationDelete(t *testing.T) {
 	}
 
 	// Create an authentication
-	authenticationDao := dao.GetAuthenticationDao(&tenantID)
+	authenticationDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &tenantID})
 
 	authName := "authentication for TestApplicationDelete()"
 	auth := m.Authentication{

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -23,7 +23,7 @@ func getAuthenticationDaoWithTenant(c echo.Context) (dao.AuthenticationDao, erro
 		return nil, err
 	}
 
-	return dao.GetAuthenticationDao(&tenantId), nil
+	return dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &tenantId}), nil
 }
 
 func AuthenticationList(c echo.Context) error {

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -73,7 +73,7 @@ func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 	SwitchSchema("appauthfind")
 
 	// Get all the DAOs we are going to work with.
-	authDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	authDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	appDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
 	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
@@ -170,7 +170,7 @@ func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
 	SwitchSchema("appauthfind")
 
 	// Get all the DAOs we are going to work with.
-	authDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	authDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
 	// Maximum of authentications to create.

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -148,7 +148,7 @@ func TestApplicationDeleteCascade(t *testing.T) {
 
 	// Create the authentications and the application authentications. The former are needed to avoid the foreign key
 	// constraints.
-	authenticationDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	authenticationDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
 	// Set the maximum amount of authentications we will create.

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -25,17 +25,22 @@ const vaultSecretPathFormat = "secret/data/%d/%s_%d_%s"
 
 // GetAuthenticationDao is a function definition that can be replaced in runtime in case some other DAO provider is
 // needed.
-var GetAuthenticationDao func(*int64) AuthenticationDao
+var GetAuthenticationDao func(daoParams *AuthenticationDaoParams) AuthenticationDao
 
 // getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
-func getDefaultAuthenticationDao(tenantId *int64) AuthenticationDao {
+func getDefaultAuthenticationDao(daoParams *AuthenticationDaoParams) AuthenticationDao {
+	var tenantID *int64
+	if daoParams != nil && daoParams.TenantID != nil {
+		tenantID = daoParams.TenantID
+	}
+
 	if config.IsVaultOn() {
 		return &authenticationDaoImpl{
-			TenantID: tenantId,
+			TenantID: tenantID,
 		}
 	} else {
 		return &authenticationDaoDbImpl{
-			TenantID: tenantId,
+			TenantID: tenantID,
 		}
 	}
 }

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -45,6 +45,10 @@ func init() {
 	GetAuthenticationDao = getDefaultAuthenticationDao
 }
 
+type AuthenticationDaoParams struct {
+	TenantID *int64
+}
+
 type authenticationDaoImpl struct {
 	TenantID *int64
 }

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -272,7 +272,7 @@ func TestAuthenticationListOffsetAndLimit(t *testing.T) {
 		}
 
 		conf.SecretStore = secretStore
-		authenticationDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+		authenticationDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 		for _, d := range fixtures.TestDataOffsetLimit {
 			authentications, gotCount, err := authenticationDao.List(d.Limit, d.Offset, []util.Filter{})

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -30,7 +30,7 @@ func setUpValidAuthentication() *model.Authentication {
 
 // createAuthenticationFixture inserts a new authentication fixture in the database.
 func createAuthenticationFixture(t *testing.T) {
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	auth := setUpValidAuthentication()
 
@@ -47,7 +47,7 @@ func TestAuthenticationDbCreate(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	auth := setUpValidAuthentication()
 
@@ -67,7 +67,7 @@ func TestAuthenticationDbBulkCreate(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	auth := setUpValidAuthentication()
 
@@ -85,7 +85,7 @@ func TestAuthenticationDbList(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Create another authentication to see if the listing function also brings it back.
 	createAuthenticationFixture(t)
@@ -126,7 +126,7 @@ func TestAuthenticationDbGetById(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -158,7 +158,7 @@ func TestAuthenticationDbUpdate(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -200,7 +200,7 @@ func TestAuthenticationDbDelete(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -237,7 +237,7 @@ func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	_, err := dao.Delete("12345")
 	if !errors.Is(err, util.ErrNotFoundEmpty) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
@@ -249,7 +249,7 @@ func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 // TestTenantId is a trivial test which tests that a correct tenant ID is returned in the function.
 func TestTenantId(t *testing.T) {
 	tenantId := int64(12345)
-	dao := GetAuthenticationDao(&tenantId)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &tenantId})
 
 	want := tenantId
 	got := dao.Tenant()
@@ -279,7 +279,7 @@ func TestListForSource(t *testing.T) {
 	}
 
 	// Create three new authentications for the new source.
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 	var i int
 	var maxAuths = 3
 	for i < maxAuths {
@@ -327,7 +327,7 @@ func TestListForSourceNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 
 	// Call the function under test.
 	_, _, err := dao.ListForSource(12345, 100, 0, []util.Filter{})
@@ -376,7 +376,7 @@ func TestListForApplication(t *testing.T) {
 	}
 
 	// Create three new authentications for the new application.
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 	var i int
 	var maxAuths = 3
 	for i < maxAuths {
@@ -423,7 +423,7 @@ func TestListForApplicationNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 
 	// Call the function under test.
 	_, _, err := dao.ListForApplication(12345, 100, 0, []util.Filter{})
@@ -472,7 +472,7 @@ func TestListForApplicationAuthentication(t *testing.T) {
 	}
 
 	// Create a new authentication for the new application authentication.
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 	auth := &model.Authentication{
 		AuthType:     TestAuthType,
 		ResourceType: "Application",
@@ -527,7 +527,7 @@ func TestListForApplicationAuthenticationNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 
 	// Call the function under test.
 	_, _, err := dao.ListForApplicationAuthentication(12345, 100, 0, []util.Filter{})
@@ -574,7 +574,7 @@ func TestListForEndpoint(t *testing.T) {
 	}
 
 	// Create three new authentications for the new application authentication.
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 	var i int
 	var maxAuths = 3
 	for i < maxAuths {
@@ -621,7 +621,7 @@ func TestListForEndpointNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
 
 	// Call the function under test.
 	_, _, err := dao.ListForEndpoint(12345, 0, 0, []util.Filter{})
@@ -646,7 +646,7 @@ func TestFetchAndUpdateBy(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -733,7 +733,7 @@ func TestToEventJSON(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -783,7 +783,7 @@ func TestBulkMessage(t *testing.T) {
 	authFixture.ResourceID = fixtures.TestSourceData[0].ID
 	authFixture.ResourceType = "Source"
 
-	dao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
@@ -877,7 +877,7 @@ func TestListIdsForResource(t *testing.T) {
 	// How many authentications will we be creating per resource?
 	maxAuthenticationsPerResource := 5
 
-	authsDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	authsDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Create the authentications.
 	for _, resource := range resources {
@@ -986,7 +986,7 @@ func TestBulkDelete(t *testing.T) {
 	// How many authentications will we be creating per resource?
 	maxAuthenticationsPerResource := 5
 
-	authsDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	authsDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Store the authentications for later.
 	var createdAuthentications = make([]model.Authentication, 0, len(resources)*maxAuthenticationsPerResource)
@@ -1083,7 +1083,7 @@ func TestBulkDeleteRegression(t *testing.T) {
 	// How many authentications will we be creating per resource?
 	maxAuthenticationsPerResource := 5
 
-	authsDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	authsDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	for i := 0; i < maxAuthenticationsPerResource; i++ {
 		authFixture := setUpValidAuthentication()

--- a/dao/common.go
+++ b/dao/common.go
@@ -64,7 +64,7 @@ func GetAvailabilityStatusFromStatusMessage(tenantID int64, resourceID string, r
 		}
 		return resource.AvailabilityStatus, err
 	case "Authentication":
-		resource, err := GetAuthenticationDao(&tenantID).GetById(resourceID)
+		resource, err := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &tenantID}).GetById(resourceID)
 		if err != nil || resource.AvailabilityStatus == nil {
 			return "", err
 		}
@@ -110,7 +110,7 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 
 	bulkMessage["applications"] = applications
 
-	authDao := GetAuthenticationDao(&source.TenantID)
+	authDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &source.TenantID})
 	authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 	if err != nil {
 		return nil, err

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -266,7 +266,7 @@ func TestDeleteSourceNotExists(t *testing.T) {
 // 	// Grab the DAOs which we will use to create the subresources.
 // 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 // 	applicationsDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
-// 	authenticationDao := GetAuthenticationDao(&fixtures.TestTenantData[0].Id)
+// 	authenticationDao := GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 // 	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
 // 	rhcConnectionsDao := GetRhcConnectionDao(&fixtures.TestTenantData[0].Id)
 

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -604,7 +604,7 @@ func TestEndpointDelete(t *testing.T) {
 	}
 
 	// Create an authentication for endpoint
-	authenticationDao := dao.GetAuthenticationDao(&tenantID)
+	authenticationDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &tenantID})
 
 	authName3 := "authentication for endpoint"
 	auth := m.Authentication{

--- a/graph/types.go
+++ b/graph/types.go
@@ -109,7 +109,7 @@ func (rd *RequestData) EnsureAuthenticationsAreLoaded() error {
 	defer rd.SourceMutex.Unlock()
 
 	if rd.authenticationMap == nil {
-		auths, _, err := dao.GetAuthenticationDao(&rd.TenantID).List(defaultLimit, 0, []util.Filter{{Name: "source_id", Value: *rd.sourceIdList}})
+		auths, _, err := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &rd.TenantID}).List(defaultLimit, 0, []util.Filter{{Name: "source_id", Value: *rd.sourceIdList}})
 		if err != nil {
 			return err
 		}

--- a/jobs/retry_create.go
+++ b/jobs/retry_create.go
@@ -104,7 +104,7 @@ func resendCreateMessages(applicationId, applicationTypeId, tenantId int64) {
 		return
 	}
 
-	authentications, _, err := dao.GetAuthenticationDao(&app.TenantID).ListForApplication(app.ID, 100, 0, []util.Filter{})
+	authentications, _, err := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &app.TenantID}).ListForApplication(app.ID, 100, 0, []util.Filter{})
 	if err != nil {
 		l.Log.Warnf("Error listing authentications for application %v: %v", applicationId, err)
 		return

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -86,7 +86,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 		}
 
 		for i := 0; i < len(output.Authentications); i++ {
-			err = dao.GetAuthenticationDao(&tenant.Id).BulkCreate(&output.Authentications[i])
+			err = dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &tenant.Id}).BulkCreate(&output.Authentications[i])
 			if err != nil {
 				return err
 			}

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -32,7 +32,7 @@ import (
 // Finally, those authentications are safely encrypted so they can stay in their datastores until we manually remove
 // them.
 func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, headers []kafka.Header) error {
-	authenticationsDao := dao.GetAuthenticationDao(tenantId)
+	authenticationsDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: tenantId})
 	var authentications []model.Authentication
 
 	switch resourceType {

--- a/service/superkey_helpers.go
+++ b/service/superkey_helpers.go
@@ -89,7 +89,7 @@ func getExtraValues(application *m.Application, provider string) (map[string]str
 // returns the "super key" e.g. the authentication used to communicate with the
 // provider
 func getSuperKeyAuthentication(application *m.Application) (*m.Authentication, error) {
-	authDao := dao.GetAuthenticationDao(&application.TenantID)
+	authDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &application.TenantID})
 
 	// fetch auths for this source
 	auths, _, err := authDao.ListForSource(application.SourceID, 100, 0, nil)

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -171,7 +171,7 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 			ApplicationAuthentications: []m.ApplicationAuthentication{},
 		}
 
-		authDao := dao.GetAuthenticationDao(&application.TenantID)
+		authDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &application.TenantID})
 		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 		if err != nil {
 			panic("error to fetch authentications: " + err.Error())
@@ -208,7 +208,7 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 			ResourceType:               "Endpoint",
 			ApplicationAuthentications: []m.ApplicationAuthentication{},
 		}
-		authDao := dao.GetAuthenticationDao(&endpoint.TenantID)
+		authDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &endpoint.TenantID})
 		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 		if err != nil {
 			return err, nil


### PR DESCRIPTION
This change is required to be able pass userid to `GetAuthenticationDao` through `AuthenticationDaoParams` struct.

Similarly it is done for `GetSourceDao`: in https://github.com/RedHatInsights/sources-api-go/pull/357 and https://github.com/RedHatInsights/sources-api-go/pull/358


Issue: https://github.com/RedHatInsights/sources-api-go/issues/356

