### PR TITLE
Pass User ID to occurrences of GetSourceDao

### DIFF
--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -440,7 +440,7 @@ func TestApplicationAuthenticationCreate(t *testing.T) {
 	}
 
 	// Delete the created test data
-	err = service.DeleteCascade(&tenantId, "Source", src.ID, []kafka.Header{})
+	err = service.DeleteCascade(&tenantId, nil, "Source", src.ID, []kafka.Header{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -234,7 +234,7 @@ func ApplicationDelete(c echo.Context) error {
 		return err
 	}
 
-	err = service.DeleteCascade(applicationDB.Tenant(), "Application", id, forwardableHeaders)
+	err = service.DeleteCascade(applicationDB.Tenant(), nil, "Application", id, forwardableHeaders)
 	if err != nil {
 		return err
 	}

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -315,7 +315,7 @@ func cleanSourceForTenant(sourceName string, tenantID *int64) error {
 		return err
 	}
 
-	err = service.DeleteCascade(tenantID, "Source", source.ID, []kafka.Header{})
+	err = service.DeleteCascade(tenantID, nil, "Source", source.ID, []kafka.Header{})
 
 	return err
 }

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -18,6 +18,7 @@ type SourceDao interface {
 	Update(src *m.Source) error
 	Delete(id *int64) (*m.Source, error)
 	Tenant() *int64
+	User() *int64
 	NameExistsInCurrentTenant(name string) bool
 	GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error)
 	// ListForRhcConnection gets all the sources that are related to a given rhcConnection id.

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -141,6 +141,10 @@ func (src *MockSourceDao) Tenant() *int64 {
 	tenant := int64(1)
 	return &tenant
 }
+func (src *MockSourceDao) User() *int64 {
+	user := int64(1)
+	return &user
+}
 
 func (src *MockSourceDao) Exists(sourceId int64) (bool, error) {
 	for _, source := range src.Sources {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -176,6 +176,10 @@ func (s *sourceDaoImpl) Delete(id *int64) (*m.Source, error) {
 	return &source, nil
 }
 
+func (s *sourceDaoImpl) User() *int64 {
+	return s.UserID
+}
+
 func (s *sourceDaoImpl) Tenant() *int64 {
 	return s.TenantID
 }

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -243,7 +243,7 @@ func EndpointDelete(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	err = service.DeleteCascade(endpointDao.Tenant(), "Endpoint", id, forwardableHeaders)
+	err = service.DeleteCascade(endpointDao.Tenant(), nil, "Endpoint", id, forwardableHeaders)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}

--- a/jobs/async_destroy.go
+++ b/jobs/async_destroy.go
@@ -37,12 +37,12 @@ func (ad AsyncDestroyJob) Name() string {
 func (ad AsyncDestroyJob) Run() error {
 	switch strings.ToLower(ad.Model) {
 	case "source":
-		err := service.DeleteCascade(&ad.Tenant, "Source", ad.Id, ad.Headers)
+		err := service.DeleteCascade(&ad.Tenant, nil, "Source", ad.Id, ad.Headers)
 		if err != nil {
 			return err
 		}
 	case "application":
-		err := service.DeleteCascade(&ad.Tenant, "Application", ad.Id, ad.Headers)
+		err := service.DeleteCascade(&ad.Tenant, nil, "Application", ad.Id, ad.Headers)
 		if err != nil {
 			return err
 		}

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -33,7 +33,12 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 			return util.NewErrBadRequest(err)
 		}
 
-		s := dao.GetSourceDao(&dao.RequestParams{TenantID: &tenantId})
+		requestParams, err := dao.NewRequestParamsFromContext(c)
+		if err != nil {
+			return fmt.Errorf("unable to process user id or tenant id value from request: %v", err)
+		}
+
+		s := dao.GetSourceDao(requestParams)
 
 		if s.IsSuperkey(id) {
 			xrhid, ok := c.Get(h.XRHID).(string)

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -313,7 +313,7 @@ func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput,
 			var err error
 			switch strings.ToLower(auth.ResourceType) {
 			case "source":
-				_, err = dao.GetSourceDao(&dao.RequestParams{TenantID: &tenant.Id}).GetById(&id)
+				_, err = dao.GetSourceDao(&dao.RequestParams{TenantID: &tenant.Id, UserID: &userResource.User.Id}).GetById(&id)
 				if err == nil {
 					l.Log.Debugf("Found existing Source with id %v, adding to list and continuing", id)
 					a.ResourceID = id

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -31,13 +31,14 @@ import (
 //
 // Finally, those authentications are safely encrypted so they can stay in their datastores until we manually remove
 // them.
-func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, headers []kafka.Header) error {
+func DeleteCascade(tenantId *int64, userId *int64, resourceType string, resourceId int64, headers []kafka.Header) error {
 	authenticationsDao := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: tenantId})
+
 	var authentications []model.Authentication
 
 	switch resourceType {
 	case "Source":
-		sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: tenantId})
+		sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: tenantId, UserID: userId})
 		applicationAuthentications, applications, endpoints, rhcConnections, source, err := sourceDao.DeleteCascade(resourceId)
 		if err != nil {
 			return fmt.Errorf(`could not completely delete the source: %s`, err)

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -207,7 +207,7 @@ func SourceDelete(c echo.Context) (err error) {
 		return err
 	}
 
-	err = service.DeleteCascade(sourcesDB.Tenant(), "Source", id, forwardableHeaders)
+	err = service.DeleteCascade(sourcesDB.Tenant(), sourcesDB.User(), "Source", id, forwardableHeaders)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}


### PR DESCRIPTION
This is about calls of `GetSourceDao(&dao.RequestParams{TenantID: &application.TenantID})`.
`dao.RequestParams` is passed as parameter to this method but just subset of occurrences of those call requires also UserID.

 example of passing UserID: `GetSourceDao(&dao.RequestParams{TenantID: &application.TenantID, UserID: 1})`.

I created commits for places where UserID is needed to pass.

NOTE: For DeleteCascade -  where second parameter is nil - this nil will be change in other PR related to model DAOs.

Those parts don't requires UserID:

- status listener
- update resource
- availability check

### Links 
Required PRs
- [x] https://github.com/RedHatInsights/sources-api-go/pull/426
 




