### PR TITLE
[RHCLOUD-20393] Added check if app exists into ApplicationPause() and ApplicationUnpause()

### DIFF
--- a/application_handlers.go
+++ b/application_handlers.go
@@ -327,6 +327,17 @@ func ApplicationPause(c echo.Context) error {
 		return err
 	}
 
+	// Check if the application exists
+	appExists, err := applicationDao.Exists(applicationId)
+	if err != nil {
+		return err
+	}
+
+	if !appExists {
+		return util.NewErrNotFound("application")
+	}
+
+	// Pause the existing application
 	err = applicationDao.Pause(applicationId)
 	if err != nil {
 		return util.NewErrBadRequest(err)

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -375,6 +375,17 @@ func ApplicationUnpause(c echo.Context) error {
 		return err
 	}
 
+	// Check if the application exists
+	appExists, err := applicationDao.Exists(applicationId)
+	if err != nil {
+		return err
+	}
+
+	if !appExists {
+		return util.NewErrNotFound("application")
+	}
+
+	// Unpause the existing application
 	err = applicationDao.Unpause(applicationId)
 	if err != nil {
 		return util.NewErrBadRequest(err)

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1222,6 +1222,31 @@ func TestResumeApplication(t *testing.T) {
 	}
 }
 
+func TestUnpauseApplicationNotFound(t *testing.T) {
+	tenantId := int64(1)
+	appId := int64(809897868745)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/applications/809897868745/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", appId))
+
+	notFoundApplicationUnpause := ErrorHandlingContext(ApplicationUnpause)
+	err := notFoundApplicationUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 // TestPauseApplicationPauseRaiseEventCheck tests that a proper "raise event" is raised when a source is paused.
 func TestPauseApplicationPauseRaiseEventCheck(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1171,6 +1171,31 @@ func TestPauseApplication(t *testing.T) {
 	}
 }
 
+func TestPauseApplicationNotFound(t *testing.T) {
+	tenantId := int64(1)
+	appId := int64(809897868745)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/applications/809897868745/pause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", appId))
+
+	notFoundApplicationPause := ErrorHandlingContext(ApplicationPause)
+	err := notFoundApplicationPause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 // TestResumeApplication tests that an application gets successfully resumed.
 func TestResumeApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)


### PR DESCRIPTION
in ApplicationPause() and ApplicationUnpause() we need a check if app exists before we pause or unpause the application

**JIRA:** [RHCLOUD-20393](https://issues.redhat.com/browse/RHCLOUD-20393)