### PR TITLE
[RHCLOUD-19859] fix: pr check fails due to Bonfire not finding "sources-api-go"

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,7 +4,7 @@
 # Options that must be configured by app owner
 # --------------------------------------------
 APP_NAME="sources"  # name of app-sre "application" folder this component lives in
-COMPONENT_NAME="sources-api-go"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+COMPONENT_NAME="sources-api"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/sources-api-go"
 
 IQE_PLUGINS="sources"  # name of the IQE plugin for this app.


### PR DESCRIPTION
Due to the latest change in AppInterface from "sources-api-go" to
"sources-api", Bonfire is unable to deploy Sources to ephemeral during
the PR check.

## Links

[[RHCLOUD-19859]](https://issues.redhat.com/browse/RHCLOUD-19859)