### PR TITLE
[RHCLOUD-20187] App handler tests update7

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1610,6 +1610,31 @@ func TestUnpauseApplicationNotFound(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+func TestUnpauseApplicationBadRequest(t *testing.T) {
+	tenantId := int64(1)
+	appId := "xxx"
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/applications/xxx/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(appId)
+
+	badRequestApplicationUnpause := ErrorHandlingContext(ApplicationUnpause)
+	err := badRequestApplicationUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.BadRequestTest(t, rec)
+}
+
 // TestPauseApplicationPauseRaiseEventCheck tests that a proper "raise event" is raised when a source is paused.
 func TestPauseApplicationPauseRaiseEventCheck(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1635,6 +1635,35 @@ func TestUnpauseApplicationBadRequest(t *testing.T) {
 	templates.BadRequestTest(t, rec)
 }
 
+// TestUnpauseApplicationInvalidTenant tests that not found is returned
+// when tenant tries to unpause not owned application
+func TestUnpauseApplicationInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	// The application is not owned by the tenant
+	tenantId := int64(2)
+	appId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/applications/1/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", appId))
+
+	notFoundApplicationUnpause := ErrorHandlingContext(ApplicationUnpause)
+	err := notFoundApplicationUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 // TestPauseApplicationPauseRaiseEventCheck tests that a proper "raise event" is raised when a source is paused.
 func TestPauseApplicationPauseRaiseEventCheck(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1664,6 +1664,34 @@ func TestUnpauseApplicationInvalidTenant(t *testing.T) {
 	templates.NotFoundTest(t, rec)
 }
 
+// TestUnpauseApplicationTenantNotExists tests that not found is returned
+// for not existing tenant
+func TestUnpauseApplicationTenantNotExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := fixtures.NotExistingTenantId
+	appId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/applications/1/unpause",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", appId))
+
+	notFoundApplicationUnpause := ErrorHandlingContext(ApplicationUnpause)
+	err := notFoundApplicationUnpause(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 // TestPauseApplicationPauseRaiseEventCheck tests that a proper "raise event" is raised when a source is paused.
 func TestPauseApplicationPauseRaiseEventCheck(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)


### PR DESCRIPTION
Tests update for **application handlers** - part VII.
(part I. #398, part II. #400, part III. #401, part IV. #403, part V. #406, part VI. #408)
- ApplicationUnpause()

other app handlers will be covered in next PR

**JIRA:** [RHCLOUD-20187](https://issues.redhat.com/browse/RHCLOUD-20187)