### PR TITLE
Fix endpoints in bulk create response

### DIFF
--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -82,7 +82,11 @@ func SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationType
 	authenticationCreateRequest := model.AuthenticationCreateRequest{ResourceType: authenticationResourceType}
 	bulkCreateAuthentication := model.BulkCreateAuthentication{AuthenticationCreateRequest: authenticationCreateRequest, ResourceName: applicationTypeName}
 
+	endpointCreateRequest := model.EndpointCreateRequest{}
+	bulkCreateEndpoints := model.BulkCreateEndpoint{EndpointCreateRequest: endpointCreateRequest, SourceName: nameSource}
+
 	return &model.BulkCreateRequest{Sources: []model.BulkCreateSource{bulkCreateSource},
 		Applications:    []model.BulkCreateApplication{bulkCreateApplication},
-		Authentications: []model.BulkCreateAuthentication{bulkCreateAuthentication}}
+		Authentications: []model.BulkCreateAuthentication{bulkCreateAuthentication},
+		Endpoints:       []model.BulkCreateEndpoint{bulkCreateEndpoints}}
 }

--- a/model/bulk_create_http.go
+++ b/model/bulk_create_http.go
@@ -81,7 +81,7 @@ func (b BulkCreateOutput) ToResponse() *BulkCreateResponse {
 		resp.Applications[i] = *b.Applications[i].ToResponse()
 	}
 
-	for i := 0; i < len(b.Sources[i].Endpoints); i++ {
+	for i := 0; i < len(b.Endpoints); i++ {
 		resp.Endpoints[i] = *b.Endpoints[i].ToResponse()
 	}
 


### PR DESCRIPTION
Bulk Create Request:
```

POST http://localhost:{{port}}/api/sources/v3.1/bulk_create
Content-Type: application/json; charset=UTF-8
x-rh-identity: {{x-rh-identity}}

{
    "applications": [
        {
            "application_type_id": null,
            "application_type_name": "cloud-meter",
            "extra": null,
            "source_name": "C10"
        }
    ],
    "authentications": [
        {
            "authtype": "cloud-meter-arn",
            "extra": null,
            "password": null,
            "resource_name": "cloud-meter",
            "resource_type": "Application",
            "username": "arn:aws:iam::<correct_arn_but_keeping_secret>"
        }
    ],
    "endpoints": [
        {
            "host": "test.test.test",
            "path": null,
            "port": null,
            "scheme": "https",
            "source_name": "C10",
            "verify_ssl": false
        }
    ],
    "sources": [
        {
            "app_creation_workflow": "manual_configuration",
            "name": "C10",
            "source_ref": null,
            "source_type_id": null,
            "source_type_name": "amazon"
        }
    ]
}
```

### Responses 

### Before - see endpoints
```
{
  "sources": [
    {
      "id": "37",
      "created_at": "2022-07-15T14:37:19+02:00",
      "updated_at": "2022-07-15T14:37:19+02:00",
      "name": "C11",
      "uid": "3de32c26-c92f-4e0d-b9a4-71e1d9d213e3",
      "app_creation_workflow": "manual_configuration",
      "source_type_id": "11"
    }
  ],
  "applications": [
    {
      "id": "34",
      "created_at": "2022-07-15T14:37:19+02:00",
      "updated_at": "2022-07-15T14:37:19+02:00",
      "extra": null,
      "source_id": "37",
      "application_type_id": "6"
    }
  ],
  "endpoints": [ <---- empty response
    {
      "id": "",
      "created_at": "",
      "updated_at": "",
      "source_id": ""
    }
  ],
  "authentications": [
    {
      "id": "28",
      "authtype": "cloud-meter-arn",
      "username": "arn:aws:iam::<correct_arn_but_keeping_secret>",
      "resource_type": "Application",
      "resource_id": "34"
    }
  ]
}
```
### After 
```
{
  "sources": [
    {
      "id": "36",
      "created_at": "2022-07-15T13:37:41+02:00",
      "updated_at": "2022-07-15T13:37:41+02:00",
      "name": "C10",
      "uid": "ced05c0a-28d6-402d-9281-4ab8d8138d3b",
      "app_creation_workflow": "manual_configuration",
      "source_type_id": "11"
    }
  ],
  "applications": [
    {
      "id": "33",
      "created_at": "2022-07-15T13:37:41+02:00",
      "updated_at": "2022-07-15T13:37:41+02:00",
      "extra": null,
      "source_id": "36",
      "application_type_id": "6"
    }
  ],
  "endpoints": [
    {
      "id": "11",
      "created_at": "2022-07-15T13:37:41+02:00",
      "updated_at": "2022-07-15T13:37:41+02:00",
      "port": 443,
      "scheme": "https",
      "host": "test.test.test",
      "path": "",
      "verify_ssl": false,
      "source_id": "36"
    }
  ],
  "authentications": [
    {
      "id": "27",
      "authtype": "cloud-meter-arn",
      "username": "arn:aws:iam::<correct_arn_but_keeping_secret>",
      "resource_type": "Application",
      "resource_id": "33"
    }
  ]
}

```