### PR TITLE
Fix source creation in application handler test

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -736,10 +736,12 @@ func TestApplicationEdit(t *testing.T) {
 
 	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
 
+	uuid := uuid.New().String()
+
 	fixtureSource := m.Source{
 		SourceTypeID:       fixtures.TestSourceTypeData[0].Id,
-		TenantID:           fixtures.TestTenantData[0].Id,
 		AvailabilityStatus: "",
+		Uid:                &uuid,
 	}
 
 	err := sourceDao.Create(&fixtureSource)


### PR DESCRIPTION
Source in `TestApplicationEdit` t created properly, it fails due to missing uuid 


thanks @petracihalova for finding issue and pointing me to a fix!
