### PR TITLE
Populate userid in bulk create

### DIFF
--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -79,7 +79,7 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 		t.Error("Could not marshal JSON")
 	}
 
-	c, _ := request.CreateTestContext(
+	c, res := request.CreateTestContext(
 		http.MethodPost,
 		"/api/sources/v3.1/bulk_create",
 		bytes.NewReader(body),
@@ -120,6 +120,22 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 
 	if source.UserID == nil || *source.UserID != user.Id {
 		t.Error("source user id was not populated correctly")
+	}
+
+	var response m.BulkCreateResponse
+	err = json.Unmarshal(res.Body.Bytes(), &response)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var application m.Application
+	err = dao.DB.Model(&m.Application{}).Where("id = ?", response.Applications[0].ID).First(&application).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if application.UserID == nil || *application.UserID != user.Id {
+		t.Error("application user id was not populated correctly")
 	}
 
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/kafka"
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
@@ -60,6 +62,8 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 func TestBulkCreateWithUserCreation(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
+	conf.ResourceOwnership = "user"
+
 	testUserId := "testUser"
 	identityHeader := testutils.IdentityHeaderForUser(testUserId)
 
@@ -106,6 +110,16 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 
 	if user.UserID != testUserId {
 		t.Errorf("expected userid is %s instead of %s", testUserId, user.UserID)
+	}
+
+	var source m.Source
+	err = dao.DB.Model(&m.Source{}).Where("name = ?", nameSource).First(&source).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if source.UserID == nil || *source.UserID != user.Id {
+		t.Error("source user id was not populated correctly")
 	}
 
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
@@ -193,15 +207,13 @@ func TestBulkCreate(t *testing.T) {
 }
 
 func cleanSourceForTenant(sourceName string, tenantID *int64) error {
-	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantID})
-
 	source := &m.Source{Name: sourceName}
 	err := dao.DB.Model(&m.Source{}).Where("name = ?", source.Name).Find(&source).Error
 	if err != nil {
 		return err
 	}
 
-	_, _, _, _, _, err = sourceDao.DeleteCascade(source.ID)
+	err = service.DeleteCascade(tenantID, "Source", source.ID, []kafka.Header{})
 
 	return err
 }

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -148,6 +148,18 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 		t.Error("authentication user id was not populated correctly")
 	}
 
+	var applicationAuthentication m.ApplicationAuthentication
+	err = dao.DB.Model(&m.ApplicationAuthentication{}).
+		Where("application_id = ? AND authentication_id = ?", response.Applications[0].ID, response.Authentications[0].ID).
+		Find(&applicationAuthentication).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if applicationAuthentication.UserID == nil || *applicationAuthentication.UserID != user.Id {
+		t.Error(err)
+	}
+
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
 	if err != nil {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -138,6 +138,16 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 		t.Error("application user id was not populated correctly")
 	}
 
+	var authentication m.Authentication
+	err = dao.DB.Model(&m.Authentication{}).Where("id = ?", response.Authentications[0].ID).First(&authentication).Error
+	if err != nil {
+		t.Error(err)
+	}
+
+	if authentication.UserID == nil || *authentication.UserID != user.Id {
+		t.Error("authentication user id was not populated correctly")
+	}
+
 	err = cleanSourceForTenant(nameSource, &fixtures.TestTenantData[0].Id)
 	if err != nil {
 		t.Errorf(`unexpected error received when deleting the source: %s`, err)

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -1,6 +1,10 @@
 package model
 
-import "github.com/RedHatInsights/sources-api-go/util"
+import (
+	"strings"
+
+	"github.com/RedHatInsights/sources-api-go/util"
+)
 
 const UserOwnership = "user"
 
@@ -39,4 +43,19 @@ func (ur *UserResource) OwnershipPresentForSource(sourceName string) bool {
 	}
 
 	return util.SliceContainsString(ur.SourceNames, sourceName)
+}
+
+func (ur *UserResource) OwnershipPresentForSourceAndApplication(sourceName, applicationTypeName string) bool {
+	return ur.OwnershipPresentForSource(sourceName) && ur.ownershipPresentForApplication(applicationTypeName)
+}
+
+func (ur *UserResource) ownershipPresentForApplication(applicationTypeName string) bool {
+	if len(ur.ApplicationTypesNames) == 0 {
+		return false
+	}
+
+	parts := strings.Split(applicationTypeName, "/")
+	typeName := parts[len(parts)-1]
+
+	return util.SliceContainsString(ur.ApplicationTypesNames, typeName)
 }

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -46,10 +46,10 @@ func (ur *UserResource) OwnershipPresentForSource(sourceName string) bool {
 }
 
 func (ur *UserResource) OwnershipPresentForSourceAndApplication(sourceName, applicationTypeName string) bool {
-	return ur.OwnershipPresentForSource(sourceName) && ur.ownershipPresentForApplication(applicationTypeName)
+	return ur.OwnershipPresentForSource(sourceName) && ur.OwnershipPresentForApplication(applicationTypeName)
 }
 
-func (ur *UserResource) ownershipPresentForApplication(applicationTypeName string) bool {
+func (ur *UserResource) OwnershipPresentForApplication(applicationTypeName string) bool {
 	if len(ur.ApplicationTypesNames) == 0 {
 		return false
 	}

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/RedHatInsights/sources-api-go/util"
+
 const UserOwnership = "user"
 
 type UserResource struct {
@@ -18,4 +20,23 @@ func (ur *UserResource) AddSourceAndApplicationTypeNames(sourceName, application
 
 func (ur *UserResource) userResourceOwnership() bool {
 	return ur.ResourceOwnership == UserOwnership
+}
+
+func (ur *UserResource) UserOwnershipActive() bool {
+	return len(ur.SourceNames) > 0 &&
+		len(ur.ApplicationTypesNames) > 0 &&
+		ur.userIDPresent() &&
+		ur.userResourceOwnership()
+}
+
+func (ur *UserResource) userIDPresent() bool {
+	return ur.User != nil && ur.User.UserID != ""
+}
+
+func (ur *UserResource) OwnershipPresentForSource(sourceName string) bool {
+	if !ur.UserOwnershipActive() {
+		return false
+	}
+
+	return util.SliceContainsString(ur.SourceNames, sourceName)
 }

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -48,7 +48,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 		userResource.User = user
 
 		// parse the sources, then save them in the transaction.
-		output.Sources, err = parseSources(req.Sources, tenant)
+		output.Sources, err = parseSources(req.Sources, tenant, userResource)
 		if err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 	return &output, err
 }
 
-func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant) ([]m.Source, error) {
+func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant, userResource *m.UserResource) ([]m.Source, error) {
 	sources := make([]m.Source, len(reqSources))
 
 	for i, source := range reqSources {
@@ -168,6 +168,10 @@ func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant) ([]m.Source
 		s.Endpoints = make([]m.Endpoint, 0)
 		s.Applications = make([]m.Application, 0)
 		s.Authentications = make([]m.Authentication, 0)
+
+		if userResource.OwnershipPresentForSource(s.Name) {
+			s.UserID = &userResource.User.Id
+		}
 
 		// add it to the list
 		sources[i] = s

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -57,7 +57,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 			return err
 		}
 
-		output.Applications, err = parseApplications(req.Applications, &output, tenant)
+		output.Applications, err = parseApplications(req.Applications, &output, tenant, userResource)
 		if err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant, userResourc
 	return sources, nil
 }
 
-func parseApplications(reqApplications []m.BulkCreateApplication, current *m.BulkCreateOutput, tenant *m.Tenant) ([]m.Application, error) {
+func parseApplications(reqApplications []m.BulkCreateApplication, current *m.BulkCreateOutput, tenant *m.Tenant, userResource *m.UserResource) ([]m.Application, error) {
 	applications := make([]m.Application, 0)
 
 	for _, app := range reqApplications {
@@ -206,6 +206,10 @@ func parseApplications(reqApplications []m.BulkCreateApplication, current *m.Bul
 			a.SourceID = src.ID
 			a.Tenant = *tenant
 			a.TenantID = tenant.Id
+
+			if userResource.OwnershipPresentForSourceAndApplication(app.SourceName, app.ApplicationTypeName) {
+				a.UserID = &userResource.User.Id
+			}
 
 			applications = append(applications, *a)
 		}


### PR DESCRIPTION
This is last PR from series about creation user based resources.


### Prerequisites 

To make this work we need to set `resource_ownership = user` in app-studio app type.

```diff
diff --git a/dao/seeds/application_types.yml b/dao/seeds/application_types.yml
index b27b4e7..51d1c20 100644
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -19,6 +19,7 @@
       - gitlab-personal-access-token
     quay:
       - quay-encrypted-password
+  resource_ownership: user

 "/insights/platform/catalog":
   display_name: Automation Services Catalog
```

## Description

Changes in this PR adds to creation with `bulk_create` possibility to populate column userid in created records of tables:
sources, applications, application_authentications and authentications.


`user_id` is taken from table `users` - Users are  created from xhr header- [added here](https://github.com/RedHatInsights/sources-api-go/pull/412) 

`user_id` is populated in records which are associated with `application_type` with column `resource_ownership=user`. App studio application type will set `resource_ownership=user` in future PR.

## How it works

In bulk create we call `loadUserResourceSettingFromBulkCreateApplication` (It is not added in this PR). We collect application type names which have `resource_ownership=user` to `UserResource#ApplicationTypesNames` and also we collect  source names(to `UserResource#SourceNames`) which are tied with this used based application type `resource_ownership=user` .

With those  `UserResource#ApplicationTypesNames` and `UserResource#SourceNames` we can easily ask whether we should populate userid on resources in parsing methods(parseSources,...).

Examples of bulk create request. (let's count that diff above was applied):

```
POST /api/sources/v3.1/bulk_create

{
  "sources": [
    {
      "name": "B17",
      "source_type_name": "bitbucket"
    }
  ],
  "applications": [
    {
      "source_name": "B17",
      "application_type_name": "app-studio"
    }
  ],
  "authentications": [
    {
      "resource_type": "application",
      "resource_name": "app-studio",
      "username": "myUser",
      "password": "myPass"
    }
  ]
}
```

```
POST /api/sources/v3.1/bulk_create

{
  "sources": [
    {
      "name": "B15",
      "source_type_name": "bitbucket"
    }
  ],
  "applications": [
    {
      "source_name": "B15",
      "application_type_name": "app-studio"
    }
  ],
  "authentications": [
    {
      "resource_type": "source",
      "username": "myUser",
      "password": "myPass"
    }
  ]
}
```
