### PR TITLE
Access UserID in source handler and DAO

### DIFF
--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -34,10 +34,12 @@ func init() {
 
 type SourceDaoParams struct {
 	TenantID *int64
+	UserID   *int64
 }
 
 type sourceDaoImpl struct {
 	TenantID *int64
+	UserID   *int64
 }
 
 func (s *sourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -17,13 +17,15 @@ var GetSourceDao func(*SourceDaoParams) SourceDao
 
 // getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultSourceDao(daoParams *SourceDaoParams) SourceDao {
-	var tenantID *int64
+	var tenantID, userID *int64
 	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
+		userID = daoParams.UserID
 	}
 
 	return &sourceDaoImpl{
 		TenantID: tenantID,
+		UserID:   userID,
 	}
 }
 

--- a/helpers.go
+++ b/helpers.go
@@ -80,6 +80,23 @@ func setEventStreamResource(c echo.Context, model m.Event) {
 	c.Set("resource", model)
 }
 
+func getUserFromEchoContext(c echo.Context) (*int64, error) {
+	userValue := c.Get(h.USERID)
+	if userValue == nil {
+		return nil, nil
+	}
+
+	if userId, ok := userValue.(int64); ok {
+		if userId == 0 {
+			return nil, nil
+		}
+
+		return &userId, nil
+	} else {
+		return nil, errors.New("the user was provided in an invalid format")
+	}
+}
+
 // getTenantFromEchoContext tries to extract the tenant from the echo context. If the "tenantID" is missing from the
 // context, then a default value and nil are returned as the int64 and error values.
 func getTenantFromEchoContext(c echo.Context) (int64, error) {

--- a/routes.go
+++ b/routes.go
@@ -13,7 +13,7 @@ var listMiddleware = []echo.MiddlewareFunc{
 	middleware.SortAndFilter, middleware.Pagination,
 }
 
-var tenancyWithListMiddleware = append([]echo.MiddlewareFunc{middleware.Tenancy}, listMiddleware...)
+var tenancyWithListMiddleware = append([]echo.MiddlewareFunc{middleware.Tenancy, middleware.UserCatcher}, listMiddleware...)
 var permissionMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.PermissionCheck, middleware.RaiseEvent}
 var permissionWithListMiddleware = append(listMiddleware, middleware.PermissionCheck)
 
@@ -30,7 +30,7 @@ func setupRoutes(e *echo.Echo) {
 		r.GET("/openapi.json", PublicOpenApi(version))
 
 		// Bulk Create
-		r.POST("/bulk_create", BulkCreate, append(permissionMiddleware, middleware.UserCatcher)...)
+		r.POST("/bulk_create", BulkCreate, permissionMiddleware...)
 
 		// Sources
 		r.GET("/sources", SourceList, tenancyWithListMiddleware...)

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -18,12 +18,16 @@ var getSourceDao func(c echo.Context) (dao.SourceDao, error)
 
 func getSourceDaoWithTenant(c echo.Context) (dao.SourceDao, error) {
 	tenantId, err := getTenantFromEchoContext(c)
-
 	if err != nil {
 		return nil, err
 	}
 
-	return dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantId}), nil
+	userID, err := getUserFromEchoContext(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantId, UserID: userID}), nil
 }
 
 func SourceList(c echo.Context) error {


### PR DESCRIPTION
This PR access user id (from `users#id`) from echo context (populated in UserCatcher middleware) to DAO layer - so we can filter according it in future PRs.

Middleware UserCatcher is added to primary and subcollection sources routes. (except to POST)
 
