### PR TITLE
[RHCLOUD-20440] Return 400 responses when the provided IDs are invalid

### DIFF
--- a/middleware/id_validation.go
+++ b/middleware/id_validation.go
@@ -3,12 +3,15 @@ package middleware
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
+
+var idValidationRegex = regexp.MustCompile(`^\d+$`)
 
 // IdValidation takes all the parameters which end with "id" and checks for their validity. Returns a bad request if
 // they're not valid.
@@ -44,12 +47,17 @@ func UuidValidation(next echo.HandlerFunc) echo.HandlerFunc {
 func validateId(c echo.Context, idParamName string) error {
 	idRaw := c.Param(idParamName)
 
+	if !idValidationRegex.MatchString(idRaw) {
+		return errors.New("the provided ID must be a greater than zero, positive number")
+	}
+
+	// This check is required for the edge case of an out of range error.
 	id, err := strconv.ParseInt(idRaw, 10, 64)
 	if err != nil {
 		return fmt.Errorf("could not parse the provided ID: %s", err)
 	}
 
-	if !(id > 0) {
+	if id == 0 {
 		return errors.New("the provided ID must be greater than zero")
 	}
 

--- a/middleware/id_validation.go
+++ b/middleware/id_validation.go
@@ -44,10 +44,6 @@ func UuidValidation(next echo.HandlerFunc) echo.HandlerFunc {
 func validateId(c echo.Context, idParamName string) error {
 	idRaw := c.Param(idParamName)
 
-	if idRaw == "" {
-		return errors.New("the provided ID cannot be empty or missing")
-	}
-
 	id, err := strconv.ParseInt(idRaw, 10, 64)
 	if err != nil {
 		return fmt.Errorf("could not parse the provided ID: %s", err)

--- a/middleware/id_validation_test.go
+++ b/middleware/id_validation_test.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -48,33 +47,6 @@ func TestExtractValidateId(t *testing.T) {
 
 	if want != got {
 		t.Errorf(`unexpected status code received. Want "%d", got "%d"`, want, got)
-	}
-}
-
-// TestExtractValidateIdEmpty tests that a bad request response is returned when the set ID is empty.
-func TestExtractValidateIdEmpty(t *testing.T) {
-	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, nil)
-
-	fmt.Println(rec)
-
-	paramName := "id"
-	paramValue := ""
-
-	c.SetParamNames(paramName)
-	c.SetParamValues(paramValue)
-
-	err := idValidationFunc(c)
-	if err != nil {
-		t.Errorf(`unexpected error received when a validating an empty ID: %s`, err)
-	}
-
-	templates.BadRequestTest(t, rec)
-
-	want := "the provided ID cannot be empty or missing"
-	got := rec.Body.String()
-
-	if !strings.Contains(got, want) {
-		t.Errorf(`unexpected error received when testing for an empty ID. Want "%s", got "%s"`, want, got)
 	}
 }
 

--- a/middleware/id_validation_test.go
+++ b/middleware/id_validation_test.go
@@ -1,0 +1,213 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
+	"github.com/labstack/echo/v4"
+)
+
+// idValidationFunc is a helper variable which makes the context to actually handle the errors produced by the
+// middleware.
+var idValidationFunc = HandleErrors(
+	IdValidation(
+		func(c echo.Context) error { return nil },
+	),
+)
+
+// uuidValidationFunc is a helper variable which makes the context to actually handle the errors produced by the
+// middleware.
+var uuidValidationFunc = HandleErrors(
+	UuidValidation(
+		func(c echo.Context) error { return nil },
+	),
+)
+
+// TestExtractValidateId tests that the function under test works as expected when a valid parameter name and ID are
+// provided.
+func TestExtractValidateId(t *testing.T) {
+	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, nil)
+
+	paramName := "id"
+	paramValue := "12345"
+
+	c.SetParamNames(paramName)
+	c.SetParamValues(paramValue)
+
+	err := idValidationFunc(c)
+	if err != nil {
+		t.Errorf(`unexpected error received when a validating a valid ID: %s`, err)
+	}
+
+	want := http.StatusOK
+	got := rec.Code
+
+	if want != got {
+		t.Errorf(`unexpected status code received. Want "%d", got "%d"`, want, got)
+	}
+}
+
+// TestExtractValidateIdEmpty tests that a bad request response is returned when the set ID is empty.
+func TestExtractValidateIdEmpty(t *testing.T) {
+	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, nil)
+
+	fmt.Println(rec)
+
+	paramName := "id"
+	paramValue := ""
+
+	c.SetParamNames(paramName)
+	c.SetParamValues(paramValue)
+
+	err := idValidationFunc(c)
+	if err != nil {
+		t.Errorf(`unexpected error received when a validating an empty ID: %s`, err)
+	}
+
+	templates.BadRequestTest(t, rec)
+
+	want := "the provided ID cannot be empty or missing"
+	got := rec.Body.String()
+
+	if !strings.Contains(got, want) {
+		t.Errorf(`unexpected error received when testing for an empty ID. Want "%s", got "%s"`, want, got)
+	}
+}
+
+// TestExtractValidateIdNonParseable tests that a bad request response is returned when a non-parseable ID is set.
+func TestExtractValidateIdNonParseable(t *testing.T) {
+	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, nil)
+
+	paramName := "id"
+	paramValue := "abcde"
+
+	c.SetParamNames(paramName)
+	c.SetParamValues(paramValue)
+
+	err := idValidationFunc(c)
+	if err != nil {
+		t.Errorf(`unexpected error received when a validating a non parseable ID: %s`, err)
+	}
+
+	templates.BadRequestTest(t, rec)
+
+	want := "could not parse the provided ID"
+	got := rec.Body.String()
+
+	if !strings.Contains(got, want) {
+		t.Errorf(`unexpected error received when testing for a non parseable ID. Want an error containing "%s", got "%s"`, want, got)
+	}
+}
+
+// TestExtractValidateIdGreaterZero tests that a bad request response is returned when an ID which is not greater than
+// zero is set.
+func TestExtractValidateIdGreaterZero(t *testing.T) {
+	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, nil)
+
+	paramName := "id"
+	paramValue := "0"
+
+	c.SetParamNames(paramName)
+	c.SetParamValues(paramValue)
+
+	err := idValidationFunc(c)
+	if err != nil {
+		t.Errorf(`unexpected error received when a validating a not greater than zero ID: %s`, err)
+	}
+
+	templates.BadRequestTest(t, rec)
+
+	want := "the provided ID must be greater than zero"
+	got := rec.Body.String()
+
+	if !strings.Contains(got, want) {
+		t.Errorf(`unexpected error received when testing for a non greater than zero ID. Want "%s", got "%s"`, want, got)
+	}
+}
+
+// TestExtractValidateAuthUuid tests that the function under test properly works when the UUIDs are set on the right
+// parameter name.
+func TestExtractValidateAuthUuid(t *testing.T) {
+	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, nil)
+
+	paramName := "uid"
+	paramValue := "15"
+
+	c.SetParamNames(paramName)
+	c.SetParamValues(paramValue)
+
+	err := uuidValidationFunc(c)
+	if err != nil {
+		t.Errorf(`unexpected error received when a validating a valid ID: %s`, err)
+	}
+
+	want := http.StatusOK
+	got := rec.Code
+
+	if want != got {
+		t.Errorf(`unexpected status code received. Want "%d", got "%d"`, want, got)
+	}
+}
+
+// TestExtractValidateAuthUuidWrongParamName tests that a bad request is returned when the UUID has been set on a parameter
+// name different to the one expected.
+func TestExtractValidateAuthUuidWrongParamName(t *testing.T) {
+	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, nil)
+	originalSecretStore := conf.SecretStore
+	conf.SecretStore = "vault"
+
+	paramName := "uuid"
+	paramValue := ""
+
+	c.SetParamNames(paramName)
+	c.SetParamValues(paramValue)
+
+	err := uuidValidationFunc(c)
+	if err != nil {
+		t.Errorf(`unexpected error received when a validating a valid ID: %s`, err)
+	}
+
+	templates.BadRequestTest(t, rec)
+
+	want := "the UUID cannot be empty or missing"
+	got := rec.Body.String()
+
+	if !strings.Contains(got, want) {
+		t.Errorf(`unexpected error when validating an UUID which was incorrectly set in a different parameter name. Want "%s", got "%s"`, want, got)
+	}
+
+	conf.SecretStore = originalSecretStore
+}
+
+// TestExtractValidateAuthUuidEmpty tests that an error is returned when the given UUID is empty.
+func TestExtractValidateAuthUuidEmpty(t *testing.T) {
+	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, nil)
+	originalSecretStore := conf.SecretStore
+	conf.SecretStore = "vault"
+
+	paramName := "uid"
+	paramValue := ""
+
+	c.SetParamNames(paramName)
+	c.SetParamValues(paramValue)
+
+	err := uuidValidationFunc(c)
+	if err != nil {
+		t.Errorf(`unexpected error received when a validating a valid ID: %s`, err)
+	}
+
+	templates.BadRequestTest(t, rec)
+
+	want := "the UUID cannot be empty or missing"
+	got := rec.Body.String()
+
+	if !strings.Contains(got, want) {
+		t.Errorf(`unexpected error when validating an empty UUID. Want "%s", got "%s"`, want, got)
+	}
+
+	conf.SecretStore = originalSecretStore
+}

--- a/routes.go
+++ b/routes.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/99designs/gqlgen/graphql/playground"
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/middleware"
 	"github.com/labstack/echo/v4"
 )
@@ -34,73 +35,79 @@ func setupRoutes(e *echo.Echo) {
 
 		// Sources
 		r.GET("/sources", SourceList, tenancyWithListMiddleware...)
-		r.GET("/sources/:id", SourceGet, middleware.Tenancy)
+		r.GET("/sources/:id", SourceGet, middleware.Tenancy, middleware.IdValidation)
 		r.POST("/sources", SourceCreate, permissionMiddleware...)
-		r.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.Notifier)...)
-		r.DELETE("/sources/:id", SourceDelete, append(permissionMiddleware, middleware.SuperKeyDestroySource)...)
-		r.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy)
-		r.GET("/sources/:source_id/application_types", SourceListApplicationTypes, tenancyWithListMiddleware...)
-		r.GET("/sources/:source_id/applications", SourceListApplications, tenancyWithListMiddleware...)
-		r.GET("/sources/:source_id/endpoints", SourceListEndpoint, tenancyWithListMiddleware...)
-		r.GET("/sources/:source_id/authentications", SourceListAuthentications, tenancyWithListMiddleware...)
-		r.GET("/sources/:source_id/rhc_connections", SourcesRhcConnectionList, tenancyWithListMiddleware...)
-		r.POST("/sources/:source_id/pause", SourcePause, middleware.Tenancy)
-		r.POST("/sources/:source_id/unpause", SourceUnpause, middleware.Tenancy)
+		r.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
+		r.DELETE("/sources/:id", SourceDelete, append(permissionMiddleware, middleware.SuperKeyDestroySource, middleware.IdValidation)...)
+		r.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy, middleware.IdValidation)
+		r.GET("/sources/:source_id/application_types", SourceListApplicationTypes, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.GET("/sources/:source_id/applications", SourceListApplications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.GET("/sources/:source_id/endpoints", SourceListEndpoint, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.GET("/sources/:source_id/authentications", SourceListAuthentications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.GET("/sources/:source_id/rhc_connections", SourcesRhcConnectionList, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.POST("/sources/:source_id/pause", SourcePause, middleware.Tenancy, middleware.IdValidation)
+		r.POST("/sources/:source_id/unpause", SourceUnpause, middleware.Tenancy, middleware.IdValidation)
 
 		// Applications
 		r.GET("/applications", ApplicationList, tenancyWithListMiddleware...)
-		r.GET("/applications/:id", ApplicationGet, middleware.Tenancy)
+		r.GET("/applications/:id", ApplicationGet, middleware.Tenancy, middleware.IdValidation)
 		r.POST("/applications", ApplicationCreate, permissionMiddleware...)
-		r.PATCH("/applications/:id", ApplicationEdit, append(permissionMiddleware, middleware.Notifier)...)
-		r.DELETE("/applications/:id", ApplicationDelete, append(permissionMiddleware, middleware.SuperKeyDestroyApplication)...)
-		r.GET("/applications/:application_id/authentications", ApplicationListAuthentications, tenancyWithListMiddleware...)
-		r.POST("/applications/:id/pause", ApplicationPause, middleware.Tenancy)
-		r.POST("/applications/:id/unpause", ApplicationUnpause, middleware.Tenancy)
+		r.PATCH("/applications/:id", ApplicationEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
+		r.DELETE("/applications/:id", ApplicationDelete, append(permissionMiddleware, middleware.SuperKeyDestroyApplication, middleware.IdValidation)...)
+		r.GET("/applications/:application_id/authentications", ApplicationListAuthentications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.POST("/applications/:id/pause", ApplicationPause, middleware.Tenancy, middleware.IdValidation)
+		r.POST("/applications/:id/unpause", ApplicationUnpause, middleware.Tenancy, middleware.IdValidation)
 
 		// Authentications
 		r.GET("/authentications", AuthenticationList, tenancyWithListMiddleware...)
-		r.GET("/authentications/:uid", AuthenticationGet, middleware.Tenancy)
 		r.POST("/authentications", AuthenticationCreate, permissionMiddleware...)
-		r.PATCH("/authentications/:uid", AuthenticationEdit, append(permissionMiddleware, middleware.Notifier)...)
-		r.DELETE("/authentications/:uid", AuthenticationDelete, permissionMiddleware...)
+		if config.IsVaultOn() {
+			r.GET("/authentications/:uid", AuthenticationGet, middleware.Tenancy, middleware.UuidValidation)
+			r.PATCH("/authentications/:uid", AuthenticationEdit, append(permissionMiddleware, middleware.Notifier, middleware.UuidValidation)...)
+			r.DELETE("/authentications/:uid", AuthenticationDelete, append(permissionMiddleware, middleware.UuidValidation)...)
+		} else {
+			r.GET("/authentications/:uid", AuthenticationGet, middleware.Tenancy, middleware.IdValidation)
+			r.PATCH("/authentications/:uid", AuthenticationEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
+			r.DELETE("/authentications/:uid", AuthenticationDelete, append(permissionMiddleware, middleware.IdValidation)...)
+		}
 
 		// ApplicationTypes
 		r.GET("/application_types", ApplicationTypeList, listMiddleware...)
-		r.GET("/application_types/:id", ApplicationTypeGet)
-		r.GET("/application_types/:application_type_id/sources", ApplicationTypeListSource, tenancyWithListMiddleware...)
+		r.GET("/application_types/:id", ApplicationTypeGet, middleware.IdValidation)
+		r.GET("/application_types/:application_type_id/sources", ApplicationTypeListSource, append(tenancyWithListMiddleware, middleware.IdValidation)...)
 
 		// Endpoints
 		r.GET("/endpoints", EndpointList, tenancyWithListMiddleware...)
-		r.GET("/endpoints/:id", EndpointGet, middleware.Tenancy)
+		r.GET("/endpoints/:id", EndpointGet, middleware.Tenancy, middleware.IdValidation)
 		r.POST("/endpoints", EndpointCreate, permissionMiddleware...)
-		r.PATCH("/endpoints/:id", EndpointEdit, append(permissionMiddleware, middleware.Notifier)...)
-		r.DELETE("/endpoints/:id", EndpointDelete, permissionMiddleware...)
-		r.GET("/endpoints/:endpoint_id/authentications", EndpointListAuthentications, tenancyWithListMiddleware...)
+		r.PATCH("/endpoints/:id", EndpointEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
+		r.DELETE("/endpoints/:id", EndpointDelete, append(permissionMiddleware, middleware.IdValidation)...)
+		r.GET("/endpoints/:endpoint_id/authentications", EndpointListAuthentications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
 
 		// ApplicationAuthentications
 		r.GET("/application_authentications", ApplicationAuthenticationList, tenancyWithListMiddleware...)
-		r.GET("/application_authentications/:id", ApplicationAuthenticationGet, middleware.Tenancy)
-		r.GET("/application_authentications/:application_authentication_id/authentications", ApplicationAuthenticationListAuthentications, tenancyWithListMiddleware...)
+		r.GET("/application_authentications/:id", ApplicationAuthenticationGet, middleware.Tenancy, middleware.IdValidation)
+		r.GET("/application_authentications/:application_authentication_id/authentications", ApplicationAuthenticationListAuthentications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
 		r.POST("/application_authentications", ApplicationAuthenticationCreate, permissionMiddleware...)
-		r.DELETE("/application_authentications/:id", ApplicationAuthenticationDelete, permissionMiddleware...)
+		r.DELETE("/application_authentications/:id", ApplicationAuthenticationDelete, append(permissionMiddleware, middleware.IdValidation)...)
 
 		// AppMetaData
 		r.GET("/app_meta_data", MetaDataList, listMiddleware...)
-		r.GET("/app_meta_data/:id", MetaDataGet)
-		r.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, listMiddleware...)
+		r.GET("/app_meta_data/:id", MetaDataGet, middleware.IdValidation)
+		r.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, append(listMiddleware, middleware.IdValidation)...)
 
 		// SourceTypes
 		r.GET("/source_types", SourceTypeList, listMiddleware...)
-		r.GET("/source_types/:id", SourceTypeGet)
-		r.GET("/source_types/:source_type_id/sources", SourceTypeListSource, tenancyWithListMiddleware...)
+		r.GET("/source_types/:id", SourceTypeGet, middleware.IdValidation)
+		r.GET("/source_types/:source_type_id/sources", SourceTypeListSource, append(tenancyWithListMiddleware, middleware.IdValidation)...)
 
 		// Red Hat Connector Connections
 		r.GET("/rhc_connections", RhcConnectionList, tenancyWithListMiddleware...)
-		r.GET("/rhc_connections/:id", RhcConnectionGetById, permissionMiddleware...)
+		r.GET("/rhc_connections/:id", RhcConnectionGetById, append(permissionMiddleware, middleware.IdValidation)...)
 		r.POST("/rhc_connections", RhcConnectionCreate, permissionMiddleware...)
-		r.PATCH("/rhc_connections/:id", RhcConnectionEdit, append(permissionMiddleware, middleware.Notifier)...)
-		r.DELETE("/rhc_connections/:id", RhcConnectionDelete, permissionMiddleware...)
-		r.GET("/rhc_connections/:id/sources", RhcConnectionSourcesList, permissionWithListMiddleware...)
+		r.PATCH("/rhc_connections/:id", RhcConnectionEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
+		r.DELETE("/rhc_connections/:id", RhcConnectionDelete, append(permissionMiddleware, middleware.IdValidation)...)
+		r.GET("/rhc_connections/:id/sources", RhcConnectionSourcesList, append(permissionWithListMiddleware, middleware.IdValidation)...)
 
 		// GraphQL
 		// TODO: remove this once we get the crazy filtering going on the gqlgen graphql


### PR DESCRIPTION
Essentially this ensures that all the endpoints which are expecting an ID, return a bad request response when that ID is empty or zero. I've also moved all the ID processing to the top of those handlers, since it doesn't make sense to get the DAOs, process the filters and then stop the execution because the ID is invalid.

I initially tried doing it as a middleware, but the code ended up being like the sample below, which in my opinion is not worth having on every handler.

```go
idRaw := c.Get("id")
id, ok := idRaw.(int64)
if !ok {
    return errors.New("could not extract ID from the request")
}
```