### PR TITLE
[RHCLOUD-19727] Fix brokerconfig not working locally

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -160,7 +160,7 @@ func Get() *SourcesApiConfig {
 				log.Fatalf(`the provided "QUEUE_PORT", "%s",  is not a valid integer: %s`, kafkaPort, err)
 			}
 
-			brokerConfig := &clowder.BrokerConfig{
+			brokerConfig := clowder.BrokerConfig{
 				Hostname: os.Getenv("QUEUE_HOST"),
 				Port:     &port,
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -247,17 +247,17 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("psks", strings.Split(os.Getenv("SOURCES_PSKS"), ","))
 
 	// Grab the Kafka Sasl Settings.
-	var brokerConifg clowder.BrokerConfig
+	var brokerConfig clowder.BrokerConfig
 	bcRaw, ok := options.Get("KafkaBrokerConfig").(clowder.BrokerConfig)
 	if ok {
-		brokerConifg = bcRaw
+		brokerConfig = bcRaw
 	}
 
 	options.AutomaticEnv()
 	parsedConfig = &SourcesApiConfig{
 		AppName:                   options.GetString("AppName"),
 		Hostname:                  options.GetString("Hostname"),
-		KafkaBrokerConfig:         brokerConifg,
+		KafkaBrokerConfig:         brokerConfig,
 		KafkaTopics:               options.GetStringMapString("KafkaTopics"),
 		KafkaGroupID:              options.GetString("KafkaGroupID"),
 		MetricsPort:               options.GetInt("MetricsPort"),

--- a/config/config.go
+++ b/config/config.go
@@ -116,8 +116,7 @@ func Get() *SourcesApiConfig {
 		}
 
 		// Grab the first broker
-		kafkaBroker := cfg.Kafka.Brokers[0]
-		options.SetDefault("KafkaBrokerConfig", kafkaBroker)
+		options.SetDefault("KafkaBrokerConfig", cfg.Kafka.Brokers[0])
 		// [/Kafka]
 
 		options.SetDefault("LogGroup", cfg.Logging.Cloudwatch.LogGroup)


### PR DESCRIPTION
When launching the application locally, the broker config was being created as a pointer, and the type assertion for that configuration was using a non-pointer value. Therefore, you could not set up Kafka locally with sources-api-go.

## Links

[[RHCLOUD-19727]](https://issues.redhat.com/browse/RHCLOUD-19727)