### PR TITLE
Unify [Source&Authentication]DaoParams to RequestParams struct

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -735,7 +735,7 @@ func TestApplicationEdit(t *testing.T) {
 	backupNotificationProducer := service.NotificationProducer
 	service.NotificationProducer = &mocks.MockAvailabilityStatusNotificationProducer{}
 
-	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	uuid := uuid.New().String()
 
@@ -974,7 +974,7 @@ func TestApplicationDelete(t *testing.T) {
 
 	// Create a source
 	tenantID := fixtures.TestTenantData[0].Id
-	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantID})
+	sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: &tenantID})
 
 	uid, err := uuid.NewUUID()
 	if err != nil {

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1008,7 +1008,7 @@ func TestApplicationDelete(t *testing.T) {
 	}
 
 	// Create an authentication
-	authenticationDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &tenantID})
+	authenticationDao := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &tenantID})
 
 	authName := "authentication for TestApplicationDelete()"
 	auth := m.Authentication{

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -23,7 +23,7 @@ func getAuthenticationDaoWithTenant(c echo.Context) (dao.AuthenticationDao, erro
 		return nil, err
 	}
 
-	return dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &tenantId}), nil
+	return dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &tenantId}), nil
 }
 
 func AuthenticationList(c echo.Context) error {

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -61,7 +61,7 @@ func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 	SwitchSchema("appauthfind")
 
 	// Get all the DAOs we are going to work with.
-	authDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	authDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	appDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
 	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
@@ -158,7 +158,7 @@ func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
 	SwitchSchema("appauthfind")
 
 	// Get all the DAOs we are going to work with.
-	authDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	authDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
 	// Maximum of authentications to create.

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -148,7 +148,7 @@ func TestApplicationDeleteCascade(t *testing.T) {
 
 	// Create the authentications and the application authentications. The former are needed to avoid the foreign key
 	// constraints.
-	authenticationDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	authenticationDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
 	// Set the maximum amount of authentications we will create.

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -101,7 +101,7 @@ func (a *authenticationDaoImpl) List(limit int, offset int, filters []util.Filte
 
 func (a *authenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	// Check if sourceID exists
-	_, err := GetSourceDao(&SourceDaoParams{TenantID: a.TenantID}).GetById(&sourceID)
+	_, err := GetSourceDao(&RequestParams{TenantID: a.TenantID}).GetById(&sourceID)
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("source")
 	}
@@ -575,7 +575,7 @@ func (a *authenticationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateA
 		return nil, err
 	}
 
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: a.TenantID})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: a.TenantID})
 	source, err := sourceDao.GetById(&authentication.SourceID)
 	if err != nil {
 		return nil, err

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -25,10 +25,10 @@ const vaultSecretPathFormat = "secret/data/%d/%s_%d_%s"
 
 // GetAuthenticationDao is a function definition that can be replaced in runtime in case some other DAO provider is
 // needed.
-var GetAuthenticationDao func(daoParams *AuthenticationDaoParams) AuthenticationDao
+var GetAuthenticationDao func(daoParams *RequestParams) AuthenticationDao
 
 // getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
-func getDefaultAuthenticationDao(daoParams *AuthenticationDaoParams) AuthenticationDao {
+func getDefaultAuthenticationDao(daoParams *RequestParams) AuthenticationDao {
 	var tenantID *int64
 	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
@@ -48,10 +48,6 @@ func getDefaultAuthenticationDao(daoParams *AuthenticationDaoParams) Authenticat
 // init sets the default DAO implementation so that other packages can request it easily.
 func init() {
 	GetAuthenticationDao = getDefaultAuthenticationDao
-}
-
-type AuthenticationDaoParams struct {
-	TenantID *int64
 }
 
 type authenticationDaoImpl struct {

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -272,7 +272,7 @@ func TestAuthenticationListOffsetAndLimit(t *testing.T) {
 		}
 
 		conf.SecretStore = secretStore
-		authenticationDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+		authenticationDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 		for _, d := range fixtures.TestDataOffsetLimit {
 			authentications, gotCount, err := authenticationDao.List(d.Limit, d.Offset, []util.Filter{})

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -390,7 +390,7 @@ func (add *authenticationDaoDbImpl) FetchAndUpdateBy(resource util.Resource, upd
 		return nil, err
 	}
 
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: add.TenantID})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: add.TenantID})
 	source, err := sourceDao.GetById(&authentication.SourceID)
 	if err != nil {
 		return nil, err

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -31,7 +31,7 @@ func setUpValidAuthentication() *model.Authentication {
 
 // createAuthenticationFixture inserts a new authentication fixture in the database.
 func createAuthenticationFixture(t *testing.T) {
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	auth := setUpValidAuthentication()
 
@@ -48,7 +48,7 @@ func TestAuthenticationDbCreate(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	auth := setUpValidAuthentication()
 
@@ -68,7 +68,7 @@ func TestAuthenticationDbBulkCreate(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	auth := setUpValidAuthentication()
 
@@ -86,7 +86,7 @@ func TestAuthenticationDbList(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Create another authentication to see if the listing function also brings it back.
 	createAuthenticationFixture(t)
@@ -127,7 +127,7 @@ func TestAuthenticationDbGetById(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -159,7 +159,7 @@ func TestAuthenticationDbUpdate(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -201,7 +201,7 @@ func TestAuthenticationDbDelete(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -238,7 +238,7 @@ func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	_, err := dao.Delete("12345")
 	if !errors.Is(err, util.ErrNotFoundEmpty) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
@@ -250,7 +250,7 @@ func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 // TestTenantId is a trivial test which tests that a correct tenant ID is returned in the function.
 func TestTenantId(t *testing.T) {
 	tenantId := int64(12345)
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &tenantId})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &tenantId})
 
 	want := tenantId
 	got := dao.Tenant()
@@ -283,7 +283,7 @@ func TestListForSource(t *testing.T) {
 	}
 
 	// Create three new authentications for the new source.
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	var i int
 	var maxAuths = 3
 	for i < maxAuths {
@@ -331,7 +331,7 @@ func TestListForSourceNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 
 	// Call the function under test.
 	_, _, err := dao.ListForSource(12345, 100, 0, []util.Filter{})
@@ -383,7 +383,7 @@ func TestListForApplication(t *testing.T) {
 	}
 
 	// Create three new authentications for the new application.
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	var i int
 	var maxAuths = 3
 	for i < maxAuths {
@@ -430,7 +430,7 @@ func TestListForApplicationNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 
 	// Call the function under test.
 	_, _, err := dao.ListForApplication(12345, 100, 0, []util.Filter{})
@@ -482,7 +482,7 @@ func TestListForApplicationAuthentication(t *testing.T) {
 	}
 
 	// Create a new authentication for the new application authentication.
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	auth := &model.Authentication{
 		AuthType:     TestAuthType,
 		ResourceType: "Application",
@@ -537,7 +537,7 @@ func TestListForApplicationAuthenticationNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 
 	// Call the function under test.
 	_, _, err := dao.ListForApplicationAuthentication(12345, 100, 0, []util.Filter{})
@@ -587,7 +587,7 @@ func TestListForEndpoint(t *testing.T) {
 	}
 
 	// Create three new authentications for the new application authentication.
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	var i int
 	var maxAuths = 3
 	for i < maxAuths {
@@ -634,7 +634,7 @@ func TestListForEndpointNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("authentications_db")
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 
 	// Call the function under test.
 	_, _, err := dao.ListForEndpoint(12345, 0, 0, []util.Filter{})
@@ -659,7 +659,7 @@ func TestFetchAndUpdateBy(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -746,7 +746,7 @@ func TestToEventJSON(t *testing.T) {
 	// Create the authentication fixture that we will be fetching.
 	authFixture := setUpValidAuthentication()
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	// Using bulk create so we don't check to see if the resource is there first
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
@@ -796,7 +796,7 @@ func TestBulkMessage(t *testing.T) {
 	authFixture.ResourceID = fixtures.TestSourceData[0].ID
 	authFixture.ResourceType = "Source"
 
-	dao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
@@ -890,7 +890,7 @@ func TestListIdsForResource(t *testing.T) {
 	// How many authentications will we be creating per resource?
 	maxAuthenticationsPerResource := 5
 
-	authsDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	authsDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Create the authentications.
 	for _, resource := range resources {
@@ -999,7 +999,7 @@ func TestBulkDelete(t *testing.T) {
 	// How many authentications will we be creating per resource?
 	maxAuthenticationsPerResource := 5
 
-	authsDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	authsDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Store the authentications for later.
 	var createdAuthentications = make([]model.Authentication, 0, len(resources)*maxAuthenticationsPerResource)
@@ -1096,7 +1096,7 @@ func TestBulkDeleteRegression(t *testing.T) {
 	// How many authentications will we be creating per resource?
 	maxAuthenticationsPerResource := 5
 
-	authsDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	authsDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	for i := 0; i < maxAuthenticationsPerResource; i++ {
 		authFixture := setUpValidAuthentication()

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -267,7 +267,7 @@ func TestListForSource(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	uuidRaw, _ := uuid.NewUUID()
 	uuidStr := uuidRaw.String()
 	source := model.Source{
@@ -355,7 +355,7 @@ func TestListForApplication(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	uuidRaw, _ := uuid.NewUUID()
 	uuidStr := uuidRaw.String()
 	source := model.Source{
@@ -454,7 +454,7 @@ func TestListForApplicationAuthentication(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	uuidRaw, _ := uuid.NewUUID()
 	uuidStr := uuidRaw.String()
 	source := model.Source{
@@ -560,7 +560,7 @@ func TestListForEndpoint(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	// Create a new source the new fixtures will be attached to.
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[1].Id})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	uuidRaw, _ := uuid.NewUUID()
 	uuidStr := uuidRaw.String()
 	source := model.Source{
@@ -810,7 +810,7 @@ func TestBulkMessage(t *testing.T) {
 	if err != nil {
 		t.Errorf(`could not fetch the authentication from the database: %s`, err)
 	}
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	source, err := sourceDao.GetById(&authFixture.SourceID)
 	if err != nil {
 		t.Errorf(`could not fetch source: %s`, err)

--- a/dao/common.go
+++ b/dao/common.go
@@ -64,7 +64,7 @@ func GetAvailabilityStatusFromStatusMessage(tenantID int64, resourceID string, r
 		}
 		return resource.AvailabilityStatus, err
 	case "Authentication":
-		resource, err := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &tenantID}).GetById(resourceID)
+		resource, err := GetAuthenticationDao(&RequestParams{TenantID: &tenantID}).GetById(resourceID)
 		if err != nil || resource.AvailabilityStatus == nil {
 			return "", err
 		}
@@ -110,7 +110,7 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 
 	bulkMessage["applications"] = applications
 
-	authDao := GetAuthenticationDao(&AuthenticationDaoParams{TenantID: &source.TenantID})
+	authDao := GetAuthenticationDao(&RequestParams{TenantID: &source.TenantID})
 	authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 	if err != nil {
 		return nil, err

--- a/dao/common.go
+++ b/dao/common.go
@@ -38,7 +38,7 @@ func GetAvailabilityStatusFromStatusMessage(tenantID int64, resourceID string, r
 		if err != nil {
 			return "", err
 		}
-		resource, err := GetSourceDao(&SourceDaoParams{TenantID: &tenantID}).GetById(&recordID)
+		resource, err := GetSourceDao(&RequestParams{TenantID: &tenantID}).GetById(&recordID)
 		if err != nil {
 			return "", err
 		}

--- a/dao/request_params.go
+++ b/dao/request_params.go
@@ -1,0 +1,6 @@
+package dao
+
+type RequestParams struct {
+	TenantID *int64
+	UserID   *int64
+}

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -34,11 +34,6 @@ func init() {
 	GetSourceDao = getDefaultSourceDao
 }
 
-type RequestParams struct {
-	TenantID *int64
-	UserID   *int64
-}
-
 type sourceDaoImpl struct {
 	TenantID *int64
 	UserID   *int64

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -13,10 +13,10 @@ import (
 
 // GetSourceDao is a function definition that can be replaced in runtime in case some other DAO provider is
 // needed.
-var GetSourceDao func(*SourceDaoParams) SourceDao
+var GetSourceDao func(*RequestParams) SourceDao
 
 // getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
-func getDefaultSourceDao(daoParams *SourceDaoParams) SourceDao {
+func getDefaultSourceDao(daoParams *RequestParams) SourceDao {
 	var tenantID, userID *int64
 	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
@@ -34,7 +34,7 @@ func init() {
 	GetSourceDao = getDefaultSourceDao
 }
 
-type SourceDaoParams struct {
+type RequestParams struct {
 	TenantID *int64
 	UserID   *int64
 }

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -271,7 +271,7 @@ func TestDeleteCascade(t *testing.T) {
 	// Grab the DAOs which we will use to create the subresources.
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 	applicationsDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
-	authDaoParams := AuthenticationDaoParams{TenantID: &fixtures.TestTenantData[0].Id}
+	authDaoParams := RequestParams{TenantID: &fixtures.TestTenantData[0].Id}
 	authenticationDao := GetAuthenticationDao(&authDaoParams)
 	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
 	rhcConnectionsDao := GetRhcConnectionDao(&fixtures.TestTenantData[0].Id)

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -70,7 +70,7 @@ func TestPausingSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("pause_unpause")
 
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &testSource.TenantID})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &testSource.TenantID})
 	err := sourceDao.Pause(testSource.ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -100,7 +100,7 @@ func TestResumingSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("pause_unpause")
 
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &testSource.TenantID})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &testSource.TenantID})
 	err := sourceDao.Unpause(fixtures.TestSourceData[0].ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -130,7 +130,7 @@ func TestDeleteSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestSourceData[0].TenantID})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestSourceData[0].TenantID})
 
 	source := fixtures.TestSourceData[0]
 	// Set the ID to 0 to let GORM know it should insert a new source and not update an existing one.
@@ -177,7 +177,7 @@ func TestDeleteSourceNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestSourceData[0].TenantID})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestSourceData[0].TenantID})
 
 	nonExistentId := int64(12345)
 	_, err := sourceDao.Delete(&nonExistentId)
@@ -208,7 +208,7 @@ func TestDeleteCascade(t *testing.T) {
 	}
 
 	// Try inserting the source in the database.
-	sourceDaoParams := SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id}
+	sourceDaoParams := RequestParams{TenantID: &fixtures.TestTenantData[0].Id}
 	sourceDao := GetSourceDao(&sourceDaoParams)
 	err := sourceDao.Create(&fixtureSource)
 	if err != nil {
@@ -640,7 +640,7 @@ func TestSourceExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("exists")
 
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	got, err := sourceDao.Exists(fixtures.TestSourceData[0].ID)
 	if err != nil {
@@ -659,7 +659,7 @@ func TestSourceNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("exists")
 
-	sourceDao := GetSourceDao(&SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	got, err := sourceDao.Exists(12345)
 	if err != nil {

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -612,7 +612,7 @@ func TestEndpointDelete(t *testing.T) {
 	}
 
 	// Create an authentication for endpoint
-	authenticationDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &tenantID})
+	authenticationDao := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &tenantID})
 
 	authName3 := "authentication for endpoint"
 	auth := m.Authentication{

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -577,7 +577,7 @@ func TestEndpointDelete(t *testing.T) {
 
 	// Create a source
 	tenantID := fixtures.TestTenantData[0].Id
-	sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantID})
+	sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: &tenantID})
 
 	uid, err := uuid.NewUUID()
 	if err != nil {

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -69,7 +69,7 @@ func (r *applicationTypeResolver) SupportedAuthenticationTypes(ctx context.Conte
 }
 
 func (r *applicationTypeResolver) Sources(ctx context.Context, obj *model.ApplicationType) ([]*model.Source, error) {
-	srces, _, err := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantIdFromCtx(ctx)}).SubCollectionList(model.ApplicationType{Id: obj.Id}, 500, 0, []util.Filter{})
+	srces, _, err := dao.GetSourceDao(&dao.RequestParams{TenantID: tenantIdFromCtx(ctx)}).SubCollectionList(model.ApplicationType{Id: obj.Id}, 500, 0, []util.Filter{})
 	out := make([]*model.Source, len(srces))
 	for i := range srces {
 		out[i] = &srces[i]
@@ -131,7 +131,7 @@ func (r *queryResolver) Sources(ctx context.Context, limit *int, offset *int, so
 	f := parseArgs(sortBy, filter)
 
 	// list the sources with filters en tote!
-	srces, count, err := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantIdFromCtx(ctx)}).List(*limit, *offset, f)
+	srces, count, err := dao.GetSourceDao(&dao.RequestParams{TenantID: tenantIdFromCtx(ctx)}).List(*limit, *offset, f)
 	sendCount(ctx, count)
 
 	// storing the IDs of relevant sources on the request context for later subresources

--- a/graph/types.go
+++ b/graph/types.go
@@ -109,7 +109,7 @@ func (rd *RequestData) EnsureAuthenticationsAreLoaded() error {
 	defer rd.SourceMutex.Unlock()
 
 	if rd.authenticationMap == nil {
-		auths, _, err := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &rd.TenantID}).List(defaultLimit, 0, []util.Filter{{Name: "source_id", Value: *rd.sourceIdList}})
+		auths, _, err := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &rd.TenantID}).List(defaultLimit, 0, []util.Filter{{Name: "source_id", Value: *rd.sourceIdList}})
 		if err != nil {
 			return err
 		}

--- a/jobs/retry_create.go
+++ b/jobs/retry_create.go
@@ -104,7 +104,7 @@ func resendCreateMessages(applicationId, applicationTypeId, tenantId int64) {
 		return
 	}
 
-	authentications, _, err := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &app.TenantID}).ListForApplication(app.ID, 100, 0, []util.Filter{})
+	authentications, _, err := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &app.TenantID}).ListForApplication(app.ID, 100, 0, []util.Filter{})
 	if err != nil {
 		l.Log.Warnf("Error listing authentications for application %v: %v", applicationId, err)
 		return

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -33,7 +33,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 			return util.NewErrBadRequest(err)
 		}
 
-		s := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantId})
+		s := dao.GetSourceDao(&dao.RequestParams{TenantID: &tenantId})
 
 		if s.IsSuperkey(id) {
 			xrhid, ok := c.Get(h.XRHID).(string)

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -295,7 +295,7 @@ func updateRhcStatus(source *m.Source, status string, errstr string, rhcConnecti
 		rhcConnection.AvailabilityStatusError = errstr
 	}
 
-	err := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &source.TenantID}).Update(source)
+	err := dao.GetSourceDao(&dao.RequestParams{TenantID: &source.TenantID}).Update(source)
 	if err != nil {
 		l.Log.Warnf("failed to update source availability status: %v", err)
 		return

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -82,7 +82,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 		}
 
 		for i := 0; i < len(output.Authentications); i++ {
-			err = dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &tenant.Id}).BulkCreate(&output.Authentications[i])
+			err = dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &tenant.Id}).BulkCreate(&output.Authentications[i])
 			if err != nil {
 				return err
 			}

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -169,7 +169,7 @@ func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant, userResourc
 		s.SourceType = *sourceType
 
 		// validate the source request
-		err = ValidateSourceCreationRequest(dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenant.Id}), &source.SourceCreateRequest)
+		err = ValidateSourceCreationRequest(dao.GetSourceDao(&dao.RequestParams{TenantID: &tenant.Id}), &source.SourceCreateRequest)
 		if err != nil {
 			return nil, err
 		}
@@ -313,7 +313,7 @@ func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput,
 			var err error
 			switch strings.ToLower(auth.ResourceType) {
 			case "source":
-				_, err = dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenant.Id}).GetById(&id)
+				_, err = dao.GetSourceDao(&dao.RequestParams{TenantID: &tenant.Id}).GetById(&id)
 				if err == nil {
 					l.Log.Debugf("Found existing Source with id %v, adding to list and continuing", id)
 					a.ResourceID = id

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -28,7 +28,7 @@ func TestMain(t *testing.M) {
 		database.ConnectAndMigrateDB("service")
 
 		endpointDao = dao.GetEndpointDao(&fixtures.TestTenantData[0].Id)
-		sourceDao = dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &fixtures.TestTenantData[0].Id})
+		sourceDao = dao.GetSourceDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 		database.CreateFixtures("service")
 	} else {
 		endpointDao = &dao.MockEndpointDao{}

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -32,7 +32,7 @@ import (
 // Finally, those authentications are safely encrypted so they can stay in their datastores until we manually remove
 // them.
 func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, headers []kafka.Header) error {
-	authenticationsDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: tenantId})
+	authenticationsDao := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: tenantId})
 	var authentications []model.Authentication
 
 	switch resourceType {

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -37,7 +37,7 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 
 	switch resourceType {
 	case "Source":
-		sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: tenantId})
+		sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: tenantId})
 		applicationAuthentications, applications, endpoints, rhcConnections, source, err := sourceDao.DeleteCascade(resourceId)
 		if err != nil {
 			return fmt.Errorf(`could not completely delete the source: %s`, err)

--- a/service/superkey_helpers.go
+++ b/service/superkey_helpers.go
@@ -89,7 +89,7 @@ func getExtraValues(application *m.Application, provider string) (map[string]str
 // returns the "super key" e.g. the authentication used to communicate with the
 // provider
 func getSuperKeyAuthentication(application *m.Application) (*m.Authentication, error) {
-	authDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &application.TenantID})
+	authDao := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &application.TenantID})
 
 	// fetch auths for this source
 	auths, _, err := authDao.ListForSource(application.SourceID, 100, 0, nil)

--- a/service/update_resource.go
+++ b/service/update_resource.go
@@ -23,7 +23,7 @@ func UpdateSourceFromApplicationAvailabilityStatus(application *m.Application, p
 			source.LastAvailableAt = application.LastAvailableAt
 		}
 
-		sourceDao := dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &application.TenantID})
+		sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: &application.TenantID})
 		err := sourceDao.Update(source)
 		if err != nil {
 			l.Log.Errorf("unable to load source: %v", err.Error())

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -27,7 +27,7 @@ func getSourceDaoWithTenant(c echo.Context) (dao.SourceDao, error) {
 		return nil, err
 	}
 
-	return dao.GetSourceDao(&dao.SourceDaoParams{TenantID: &tenantId, UserID: userID}), nil
+	return dao.GetSourceDao(&dao.RequestParams{TenantID: &tenantId, UserID: userID}), nil
 }
 
 func SourceList(c echo.Context) error {

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1319,7 +1319,7 @@ func TestSourceDelete(t *testing.T) {
 	// Create a source
 
 	tenantID := int64(1)
-	sourceDaoParams := dao.SourceDaoParams{TenantID: &tenantID}
+	sourceDaoParams := dao.RequestParams{TenantID: &tenantID}
 	sourceDao := dao.GetSourceDao(&sourceDaoParams)
 
 	uid := "bd2ba6d6-4630-40e2-b829-cf09b03bdb9f"
@@ -1911,7 +1911,7 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 	}
 
 	// Check that the source is paused
-	daoParams := dao.SourceDaoParams{TenantID: &tenantId}
+	daoParams := dao.RequestParams{TenantID: &tenantId}
 	sourceDao := dao.GetSourceDao(&daoParams)
 	src, err := sourceDao.GetById(&sourceId)
 	if err != nil {
@@ -2058,7 +2058,7 @@ func TestUnpauseSourceAndItsApplications(t *testing.T) {
 	sourceId := int64(1)
 
 	// Test data preparation = pause the source and its apps
-	daoParams := dao.SourceDaoParams{TenantID: &tenantId}
+	daoParams := dao.RequestParams{TenantID: &tenantId}
 	sourceDao := dao.GetSourceDao(&daoParams)
 	err := sourceDao.Pause(sourceId)
 	if err != nil {

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1335,7 +1335,7 @@ func TestSourceDelete(t *testing.T) {
 	}
 
 	// Create and authentication for source
-	authDaoParams := dao.AuthenticationDaoParams{TenantID: &tenantID}
+	authDaoParams := dao.RequestParams{TenantID: &tenantID}
 	authenticationDao := dao.GetAuthenticationDao(&authDaoParams)
 
 	authNameForSource := "authentication for source"

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -171,7 +171,7 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 			ApplicationAuthentications: []m.ApplicationAuthentication{},
 		}
 
-		authDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &application.TenantID})
+		authDao := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &application.TenantID})
 		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 		if err != nil {
 			panic("error to fetch authentications: " + err.Error())
@@ -208,7 +208,7 @@ func FetchDataFor(resourceType string, resourceID string, forBulkMessage bool) (
 			ResourceType:               "Endpoint",
 			ApplicationAuthentications: []m.ApplicationAuthentication{},
 		}
-		authDao := dao.GetAuthenticationDao(&dao.AuthenticationDaoParams{TenantID: &endpoint.TenantID})
+		authDao := dao.GetAuthenticationDao(&dao.RequestParams{TenantID: &endpoint.TenantID})
 		authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 		if err != nil {
 			return err, nil


### PR DESCRIPTION
Partially addressed [comment](https://github.com/RedHatInsights/sources-api-go/pull/397#discussion_r917926822).

I am doing this change now because there is no reason to follow old pattern with adding [Model]DaoParams.

Feel free to bring better name for the struct Request Params.

### Links

https://github.com/RedHatInsights/sources-api-go/issues/356
