### PR TITLE
[RHCLOUD-20398] App auth tenancy tests2

### DIFF
--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/RedHatInsights/sources-api-go/dao"
 	"net/http"
 	"strconv"
 	"testing"
@@ -237,6 +236,34 @@ func TestApplicationAuthenticationGet(t *testing.T) {
 func TestApplicationAuthenticationGetInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	tenantId := int64(2)
+	appAuthId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_authentications/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
+
+	notFoundApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationGet)
+	err := notFoundApplicationAuthenticationGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
+// TestApplicationAuthenticationGetTenantNotExist tests that not found is returned
+// for not existing tenant
+func TestApplicationAuthenticationGetTenantNotExist(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := fixtures.NotExistingTenantId
 	appAuthId := int64(1)
 
 	c, rec := request.CreateTestContext(

--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -232,6 +232,34 @@ func TestApplicationAuthenticationGet(t *testing.T) {
 	}
 }
 
+// TestApplicationAuthenticationGetInvalidTenant tests that not found is returned
+// for existing app auth id but with invalid tenant
+func TestApplicationAuthenticationGetInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(2)
+	appAuthId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_authentications/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
+
+	notFoundApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationGet)
+	err := notFoundApplicationAuthenticationGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestApplicationAuthenticationGetNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodGet,


### PR DESCRIPTION
tests update for application authentication handlers PART II.
(Part I. #423)
this PR covers:

- ApplicationAuthenticationGet()

main goal is to check the tenancy and add missing tests
tests update for other handlers will be covered in next PRs

**JIRA:** [RHCLOUD-20398](https://issues.redhat.com/browse/RHCLOUD-20398)