### PR TITLE
Add user id header for PSK

### DIFF
--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -38,6 +38,10 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.ORGID, c.Request().Header.Get(h.ORGID))
 		}
 
+		if c.Request().Header.Get(h.PSK_USER) != "" {
+			c.Set(h.PSK_USER, c.Request().Header.Get(h.PSK_USER))
+		}
+
 		// parsing the base64-encoded identity header if present
 		if c.Request().Header.Get(h.XRHID) != "" {
 			// store it raw first.

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -4,6 +4,7 @@ const (
 	PSK             = "x-rh-sources-psk"
 	ACCOUNT_NUMBER  = "x-rh-sources-account-number"
 	ORGID           = "x-rh-sources-org-id"
+	PSK_USER        = "x-rh-sources-user-id"
 	XRHID           = "x-rh-identity"
 	PARSED_IDENTITY = "identity"
 	TENANTID        = "tenantID"

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -48,7 +48,7 @@ func TestParseAll(t *testing.T) {
 	}
 
 	if c.Get(h.PSK_USER).(string) != "55555" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "55555")
 	}
 
 	if c.Get(h.ORGID).(string) != "abcde" {
@@ -170,6 +170,6 @@ func TestOnlyPskHeaders(t *testing.T) {
 	}
 
 	if c.Get(h.PSK_USER).(string) != "555555" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "555555")
 	}
 }

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -27,6 +27,7 @@ func TestParseAll(t *testing.T) {
 	c.Request().Header.Set(h.XRHID, xrhid)
 	c.Request().Header.Set(h.PSK, "1234")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "1a2b3c4d5e")
+	c.Request().Header.Set(h.PSK_USER, "55555")
 	c.Request().Header.Set(h.ORGID, "abcde")
 
 	err := parseOrElse204(c)
@@ -43,6 +44,10 @@ func TestParseAll(t *testing.T) {
 	}
 
 	if c.Get(h.ACCOUNT_NUMBER).(string) != "1a2b3c4d5e" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+	}
+
+	if c.Get(h.PSK_USER).(string) != "55555" {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
 	}
 
@@ -145,6 +150,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 
 	c.Request().Header.Set(h.PSK, "1234")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
+	c.Request().Header.Set(h.PSK_USER, "555555")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -160,6 +166,10 @@ func TestOnlyPskHeaders(t *testing.T) {
 	}
 
 	if c.Get(h.ACCOUNT_NUMBER).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+	}
+
+	if c.Get(h.PSK_USER).(string) != "555555" {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
 	}
 }

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -16,13 +16,13 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
 
-		userIDFromContext := ""
+		var userIDFromContext string
 
 		switch {
 		case c.Get(h.PSK_USER) != nil:
 			userID, ok := c.Get(h.PSK_USER).(string)
 			if !ok {
-				return fmt.Errorf("failed to pull tenant from request")
+				return fmt.Errorf("failed to pull user id from request")
 			}
 
 			userIDFromContext = userID

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -11,21 +11,35 @@ import (
 
 func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		xRhIdentity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
-		if !ok {
-			return fmt.Errorf("failed to fetch the identity header")
-		}
-
 		tenantId, ok := c.Get(h.TENANTID).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
 
-		userID := xRhIdentity.Identity.User.UserID
-		if userID != "" {
-			user, err := dao.GetUserDao(&tenantId).FindOrCreate(userID)
+		userIDFromContext := ""
+
+		switch {
+		case c.Get(h.PSK_USER) != nil:
+			userID, ok := c.Get(h.PSK_USER).(string)
+			if !ok {
+				return fmt.Errorf("failed to pull tenant from request")
+			}
+
+			userIDFromContext = userID
+
+		case c.Get(h.PARSED_IDENTITY) != nil:
+			xRhIdentity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+			if !ok {
+				return fmt.Errorf("failed to fetch the identity header")
+			}
+
+			userIDFromContext = xRhIdentity.Identity.User.UserID
+		}
+
+		if userIDFromContext != "" {
+			user, err := dao.GetUserDao(&tenantId).FindOrCreate(userIDFromContext)
 			if err != nil {
-				return fmt.Errorf("unable to find or create user %v: %v", userID, err)
+				return fmt.Errorf("unable to find or create user %v: %v", userIDFromContext, err)
 			}
 
 			c.Set(h.USERID, user.Id)

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -1,0 +1,107 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/labstack/echo/v4"
+)
+
+var catchUserOrElse204 = UserCatcher(func(c echo.Context) error {
+	return c.NoContent(http.StatusNoContent)
+})
+
+func TestUserCreationFromXRHID(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantID := int64(1)
+	testUserID := "55555"
+	identity := testutils.IdentityHeaderForUser(testUserID)
+
+	database.ConnectAndMigrateDB("middleware")
+	database.CreateFixtures("middleware")
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	c.Set(h.TENANTID, tenantID)
+	c.Set(h.PARSED_IDENTITY, identity)
+
+	err := catchUserOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	}
+
+	var user m.User
+	result := dao.DB.Find(&user, "user_id = ? AND tenant_id = ?", testUserID, tenantID)
+	if result.Error != nil {
+		t.Error(err)
+	}
+
+	if result.RowsAffected == 0 {
+		t.Errorf("unable to find user %v", testUserID)
+	}
+
+	if user.Id == 0 || c.Get(h.USERID) != user.Id {
+		t.Errorf("unable to find user id %v in context", user.Id)
+	}
+
+	database.DropSchema("middleware")
+}
+
+func TestUserCreationFromPSK(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantID := int64(1)
+	testUserID := "55555"
+
+	database.ConnectAndMigrateDB("middleware")
+	database.CreateFixtures("middleware")
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/",
+		nil,
+		map[string]interface{}{},
+	)
+
+	c.Set(h.TENANTID, tenantID)
+	c.Set(h.PSK_USER, testUserID)
+
+	err := catchUserOrElse204(c)
+	if err != nil {
+		t.Errorf("caught an error when there should not have been one: %v", err)
+	}
+
+	if rec.Code != 204 {
+		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	}
+
+	var user m.User
+	result := dao.DB.Find(&user, "user_id = ? AND tenant_id = ?", testUserID, tenantID)
+	if result.Error != nil {
+		t.Error(err)
+	}
+
+	if user.Id == 0 || c.Get(h.USERID) != user.Id {
+		t.Errorf("unable to find user id %v in context", user.Id)
+	}
+
+	if result.RowsAffected == 0 {
+		t.Errorf("unable to find user %v", testUserID)
+	}
+
+	database.DropSchema("middleware")
+}


### PR DESCRIPTION
This adds possibility to pass user id when PSK is used.
Header has name `x-rh-sources-user-id`.

I also added some test for `UserCatcherMiddleware`.


### Links
https://github.com/RedHatInsights/sources-api-go/issues/356
