### PR TITLE
Clean up `logger/` package in preparation for context logging through request

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,44 +18,41 @@ var parsedConfig *SourcesApiConfig
 
 // SourcesApiConfig is the struct for storing runtime configuration
 type SourcesApiConfig struct {
-	AppName                   string
-	Hostname                  string
-	KafkaBrokerConfig         clowder.BrokerConfig
-	KafkaTopics               map[string]string
-	KafkaGroupID              string
-	MetricsPort               int
-	LogLevel                  string
-	LogLevelForMiddlewareLogs string
-	LogGroup                  string
-	LogHandler                string
-	LogLevelForSqlLogs        string
-	MarketplaceHost           string
-	AwsRegion                 string
-	AwsAccessKeyID            string
-	AwsSecretAccessKey        string
-	DatabaseHost              string
-	DatabasePort              int
-	DatabaseUser              string
-	DatabasePassword          string
-	DatabaseName              string
-	FeatureFlagsEnvironment   string
-	FeatureFlagsUrl           string
-	FeatureFlagsAPIToken      string
-	FeatureFlagsService       string
-	FeatureFlagsBearerToken   string
-	CacheHost                 string
-	CachePort                 int
-	CachePassword             string
-	SlowSQLThreshold          int
-	Psks                      []string
-	BypassRbac                bool
-	StatusListener            bool
-	BackgroundWorker          bool
-	MigrationsSetup           bool
-	MigrationsReset           bool
-	SecretStore               string
-	TenantTranslatorUrl       string
-	ResourceOwnership         string
+	AppName                 string
+	Hostname                string
+	KafkaBrokerConfig       clowder.BrokerConfig
+	KafkaTopics             map[string]string
+	KafkaGroupID            string
+	MetricsPort             int
+	LogLevel                string
+	LogGroup                string
+	MarketplaceHost         string
+	AwsRegion               string
+	AwsAccessKeyID          string
+	AwsSecretAccessKey      string
+	DatabaseHost            string
+	DatabasePort            int
+	DatabaseUser            string
+	DatabasePassword        string
+	DatabaseName            string
+	FeatureFlagsEnvironment string
+	FeatureFlagsUrl         string
+	FeatureFlagsAPIToken    string
+	FeatureFlagsService     string
+	FeatureFlagsBearerToken string
+	CacheHost               string
+	CachePort               int
+	CachePassword           string
+	SlowSQLThreshold        int
+	Psks                    []string
+	BypassRbac              bool
+	StatusListener          bool
+	BackgroundWorker        bool
+	MigrationsSetup         bool
+	MigrationsReset         bool
+	SecretStore             string
+	TenantTranslatorUrl     string
+	ResourceOwnership       string
 }
 
 //String() returns a string that shows the settings in which the pod is running in
@@ -68,10 +65,7 @@ func (s SourcesApiConfig) String() string {
 	fmt.Fprintf(&b, "%s=%v ", "KafkaGroupID", parsedConfig.KafkaGroupID)
 	fmt.Fprintf(&b, "%s=%v ", "MetricsPort", parsedConfig.MetricsPort)
 	fmt.Fprintf(&b, "%s=%v ", "LogLevel", parsedConfig.LogLevel)
-	fmt.Fprintf(&b, "%s=%v ", "LogLevelForMiddlewareLogs", parsedConfig.LogLevelForMiddlewareLogs)
 	fmt.Fprintf(&b, "%s=%v ", "LogGroup", parsedConfig.LogGroup)
-	fmt.Fprintf(&b, "%s=%v ", "LogHandler", parsedConfig.LogHandler)
-	fmt.Fprintf(&b, "%s=%v ", "LogLevelForSqlLogs", parsedConfig.LogLevelForSqlLogs)
 	fmt.Fprintf(&b, "%s=%v ", "MarketplaceHost", parsedConfig.MarketplaceHost)
 	fmt.Fprintf(&b, "%s=%v ", "AwsRegion", parsedConfig.AwsRegion)
 	fmt.Fprintf(&b, "%s=%v ", "DatabaseHost", parsedConfig.DatabaseHost)
@@ -202,9 +196,6 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("KafkaTopics", kafkaTopics)
 
 	options.SetDefault("LogLevel", os.Getenv("LOG_LEVEL"))
-	options.SetDefault("LogHandler", os.Getenv("LOG_HANDLER"))
-	options.SetDefault("LogLevelForMiddlewareLogs", "DEBUG")
-	options.SetDefault("LogLevelForSqlLogs", "DEBUG")
 	options.SetDefault("MarketplaceHost", os.Getenv("MARKETPLACE_HOST"))
 	options.SetDefault("SlowSQLThreshold", 2) //seconds
 	options.SetDefault("BypassRbac", os.Getenv("BYPASS_RBAC") == "true")
@@ -255,44 +246,41 @@ func Get() *SourcesApiConfig {
 
 	options.AutomaticEnv()
 	parsedConfig = &SourcesApiConfig{
-		AppName:                   options.GetString("AppName"),
-		Hostname:                  options.GetString("Hostname"),
-		KafkaBrokerConfig:         brokerConfig,
-		KafkaTopics:               options.GetStringMapString("KafkaTopics"),
-		KafkaGroupID:              options.GetString("KafkaGroupID"),
-		MetricsPort:               options.GetInt("MetricsPort"),
-		LogLevel:                  options.GetString("LogLevel"),
-		LogLevelForMiddlewareLogs: options.GetString("LogLevelForMiddlewareLogs"),
-		LogLevelForSqlLogs:        options.GetString("LogLevelForSqlLogs"),
-		SlowSQLThreshold:          options.GetInt("SlowSQLThreshold"),
-		LogHandler:                options.GetString("LogHandler"),
-		LogGroup:                  options.GetString("LogGroup"),
-		MarketplaceHost:           options.GetString("MarketplaceHost"),
-		AwsRegion:                 options.GetString("AwsRegion"),
-		AwsAccessKeyID:            options.GetString("AwsAccessKeyID"),
-		AwsSecretAccessKey:        options.GetString("AwsSecretAccessKey"),
-		DatabaseHost:              options.GetString("DatabaseHost"),
-		DatabasePort:              options.GetInt("DatabasePort"),
-		DatabaseUser:              options.GetString("DatabaseUser"),
-		DatabasePassword:          options.GetString("DatabasePassword"),
-		DatabaseName:              options.GetString("DatabaseName"),
-		FeatureFlagsEnvironment:   options.GetString("FeatureFlagsEnvironment"),
-		FeatureFlagsUrl:           options.GetString("FeatureFlagsUrl"),
-		FeatureFlagsAPIToken:      options.GetString("FeatureFlagsAPIToken"),
-		FeatureFlagsBearerToken:   options.GetString("FeatureFlagsBearerToken"),
-		FeatureFlagsService:       options.GetString("FeatureFlagsService"),
-		CacheHost:                 options.GetString("CacheHost"),
-		CachePort:                 options.GetInt("CachePort"),
-		CachePassword:             options.GetString("CachePassword"),
-		Psks:                      options.GetStringSlice("psks"),
-		BypassRbac:                options.GetBool("BypassRbac"),
-		StatusListener:            options.GetBool("StatusListener"),
-		BackgroundWorker:          options.GetBool("BackgroundWorker"),
-		MigrationsSetup:           options.GetBool("MigrationsSetup"),
-		MigrationsReset:           options.GetBool("MigrationsReset"),
-		SecretStore:               options.GetString("SecretStore"),
-		TenantTranslatorUrl:       options.GetString("TenantTranslatorUrl"),
-		ResourceOwnership:         options.GetString("ResourceOwnership"),
+		AppName:                 options.GetString("AppName"),
+		Hostname:                options.GetString("Hostname"),
+		KafkaBrokerConfig:       brokerConfig,
+		KafkaTopics:             options.GetStringMapString("KafkaTopics"),
+		KafkaGroupID:            options.GetString("KafkaGroupID"),
+		MetricsPort:             options.GetInt("MetricsPort"),
+		LogLevel:                options.GetString("LogLevel"),
+		SlowSQLThreshold:        options.GetInt("SlowSQLThreshold"),
+		LogGroup:                options.GetString("LogGroup"),
+		MarketplaceHost:         options.GetString("MarketplaceHost"),
+		AwsRegion:               options.GetString("AwsRegion"),
+		AwsAccessKeyID:          options.GetString("AwsAccessKeyID"),
+		AwsSecretAccessKey:      options.GetString("AwsSecretAccessKey"),
+		DatabaseHost:            options.GetString("DatabaseHost"),
+		DatabasePort:            options.GetInt("DatabasePort"),
+		DatabaseUser:            options.GetString("DatabaseUser"),
+		DatabasePassword:        options.GetString("DatabasePassword"),
+		DatabaseName:            options.GetString("DatabaseName"),
+		FeatureFlagsEnvironment: options.GetString("FeatureFlagsEnvironment"),
+		FeatureFlagsUrl:         options.GetString("FeatureFlagsUrl"),
+		FeatureFlagsAPIToken:    options.GetString("FeatureFlagsAPIToken"),
+		FeatureFlagsBearerToken: options.GetString("FeatureFlagsBearerToken"),
+		FeatureFlagsService:     options.GetString("FeatureFlagsService"),
+		CacheHost:               options.GetString("CacheHost"),
+		CachePort:               options.GetInt("CachePort"),
+		CachePassword:           options.GetString("CachePassword"),
+		Psks:                    options.GetStringSlice("psks"),
+		BypassRbac:              options.GetBool("BypassRbac"),
+		StatusListener:          options.GetBool("StatusListener"),
+		BackgroundWorker:        options.GetBool("BackgroundWorker"),
+		MigrationsSetup:         options.GetBool("MigrationsSetup"),
+		MigrationsReset:         options.GetBool("MigrationsReset"),
+		SecretStore:             options.GetString("SecretStore"),
+		TenantTranslatorUrl:     options.GetString("TenantTranslatorUrl"),
+		ResourceOwnership:       options.GetString("ResourceOwnership"),
 	}
 
 	return parsedConfig

--- a/dao/db.go
+++ b/dao/db.go
@@ -26,11 +26,10 @@ var (
 )
 
 func Init() {
-	l := &logging.CustomGORMLogger{
+	l := &logging.GormLogger{
 		SkipErrorRecordNotFound: true,
 		Logger:                  logging.Log,
 		SlowThreshold:           time.Duration(conf.SlowSQLThreshold) * time.Second,
-		LogLevelForSqlLogs:      conf.LogLevelForSqlLogs,
 	}
 
 	// Reset the database if the command flag was provided.
@@ -155,7 +154,7 @@ func dbStringDefaultDb() string {
 // connection. A new connection needs to be opened because Postgres doesn't allow deleting the database you are
 // connected too. You can search for "cannot drop the currently open database" error for more information. It is
 // expected to exit the program once you've finished with the database management operations.
-func openPostgresConnection(logger *logging.CustomGORMLogger) {
+func openPostgresConnection(logger *logging.GormLogger) {
 	db, err := gorm.Open(postgres.Open(dbStringDefaultDb()), &gorm.Config{Logger: logger})
 	if err != nil {
 		log.Fatalln(err)

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -251,7 +251,7 @@ parameters:
 - name: KOKU_SOURCES_API_APP_CHECK_PATH
   value: /api/cost-management/v1/source-status/
 - name: LOG_LEVEL
-  value: WARN
+  value: INFO
 - name: MEMORY_LIMIT
   value: 1Gi
 - name: MEMORY_REQUEST

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/labstack/echo-contrib v0.12.0
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/labstack/gommon v0.3.1
-	github.com/neko-neko/echo-logrus/v2 v2.0.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/redhatinsights/app-common-go v1.6.3
 	github.com/redhatinsights/platform-go-middlewares v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -1042,7 +1042,6 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/neko-neko/echo-logrus/v2 v2.0.1 h1:BX2U6uv2N3UiUY75y+SntQak5S1AJIel9j+5Y6h4Nb4=
 github.com/neko-neko/echo-logrus/v2 v2.0.1/go.mod h1:GDYWo9CY4VXk/vn5ac5reoutYEkZEexlFI01MzHXVG0=
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/logger/echo_logger.go
+++ b/logger/echo_logger.go
@@ -1,0 +1,53 @@
+package logger
+
+import (
+	"io"
+
+	"github.com/labstack/gommon/log"
+	"github.com/sirupsen/logrus"
+)
+
+/*
+	Wrapper around logrus.Logger for the methods missing from the echo.Logger
+	interface. All of the "rest" of the methods on the echoLogger interface are
+	called directly on the logrus.Logger
+
+	1. We "may" use the *j methods eventually, so just in case they just log the
+	   map[string]interface{} as it comes in
+	2. The Output method is easy, so it is also implemented
+	3. The setlevel/level  methods panic because we only care about the single
+	   logger level
+	4. The Prefix/Header related methods are not implemented because they don't
+	   matter to the logrus logger.
+*/
+
+type EchoLogger struct {
+	*logrus.Logger
+}
+
+/// Wrapping _level_j methods
+func (el EchoLogger) Printj(j log.JSON) { el.Logger.Printf("%+v", j) }
+func (el EchoLogger) Debugj(j log.JSON) { el.Logger.Debugf("%+v", j) }
+func (el EchoLogger) Infoj(j log.JSON)  { el.Logger.Infof("%+v", j) }
+func (el EchoLogger) Errorj(j log.JSON) { el.Logger.Errorf("%+v", j) }
+func (el EchoLogger) Warnj(j log.JSON)  { el.Logger.Warnf("%+v", j) }
+func (el EchoLogger) Fatalj(j log.JSON) { el.Logger.Fatalf("%+v", j) }
+func (el EchoLogger) Panicj(j log.JSON) { el.Logger.Panicf("%+v", j) }
+
+/// output is easy
+func (el EchoLogger) Output() io.Writer { return el.Logger.Out }
+
+/// we don't use the "set level" on the echo logger since we're using a single unified logger
+func (el EchoLogger) SetLevel(log.Lvl) {
+	panic("DON'T USE THIS METHOD - SET IT ON THE LOGRUS LOGGER")
+}
+func (el EchoLogger) Level() log.Lvl {
+	panic("DON'T USE THIS METHOD - SET IT ON THE LOGRUS LOGGER")
+}
+
+/// we don't set a prefix ever on the logger
+func (el EchoLogger) SetPrefix(string) { panic("DON'T USE THIS METHOD") }
+func (el EchoLogger) Prefix() string   { panic("DON'T USE THIS METHOD") }
+
+/// we don't set a header on the logger either
+func (el EchoLogger) SetHeader(_ string) { panic("DON'T USE THIS METHOD") }

--- a/logger/log_writer.go
+++ b/logger/log_writer.go
@@ -2,40 +2,22 @@ package logger
 
 import (
 	"encoding/json"
-	"os"
 
 	"github.com/sirupsen/logrus"
 )
 
 type LogWriter struct {
-	Logger   *logrus.Logger
-	Output   *os.File
-	LogLevel string
+	Logger *logrus.Logger
 }
 
 func (lw *LogWriter) Write(data []byte) (n int, err error) {
 	logFields := make(map[string]interface{})
 	err = json.Unmarshal(data, &logFields)
 	if err != nil {
-		Log.Warn("Unmarshalling Error in LogWriter: " + err.Error())
+		lw.Logger.Warn("Unmarshalling Error in LogWriter: " + err.Error())
 		return 0, err
 	}
 
-	lw.logByLevel(logFields)
+	lw.Logger.WithFields(logFields).Info()
 	return len(data), nil
-}
-
-func (lw *LogWriter) logByLevel(loggerFields map[string]interface{}) {
-	logger := lw.Logger.WithFields(loggerFields)
-
-	switch lw.LogLevel {
-	case "DEBUG":
-		logger.Info()
-	case "ERROR":
-		logger.Error()
-	case "WARN":
-		logger.Warn()
-	default:
-		logger.Info()
-	}
 }

--- a/main.go
+++ b/main.go
@@ -59,7 +59,9 @@ func main() {
 
 func runServer(shutdown chan struct{}) {
 	e := echo.New()
-	logging.InitEchoLogger(e, conf)
+
+	// set the logger to the wrapper of our main logrus (or maybe someday different) logger
+	e.Logger = logging.EchoLogger{Logger: logging.Log}
 
 	// set the binder to the one that does not allow extra parameters in payload
 	e.Binder = &NoUnknownFieldsBinder{}
@@ -71,9 +73,7 @@ func runServer(shutdown chan struct{}) {
 	// set up logging with our custom logger
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		Format: logging.FormatForMiddleware(conf),
-		Output: &logging.LogWriter{Output: logging.LogOutputFrom(conf.LogHandler),
-			Logger:   logging.Log,
-			LogLevel: conf.LogLevelForMiddlewareLogs},
+		Output: &logging.LogWriter{Logger: logging.Log},
 	}))
 
 	// use the echo prometheus middleware - without having it mount the route on the main listener.


### PR DESCRIPTION
This PR might _look_ big but it really isn't that much of a change. I'll spell out the big changes here below.

## First: the "why"
This is in preparation of logging (by context) throughout the entire pipeline - the main point being "I would like to see the application_id/source_id/request_id on each log message through kibana so it is easier to debug"

#### Removal of `haberdasher` support
This one is pretty self-explanatory, haberdasher isn't going to be the solution going forward so I removed the check of sending to stdout/stderr based on the LOG_MODE env var. 

#### Change default LOG_LEVEL from WARN -> INFO
Got this as a request for the eph env - we're overriding it everywhere but when app teams run our application in the Ephemeral Environment they get no output unless something goes horribly wrong, INFO should be enough for them (which skips the database queries).

#### Removal of `LOG_LEVEL_FOR_MIDDLEWARE_LOGS` and `LOG_LEVEL_FOR_SQL_LOGS`
Since under the hood we're using the single logger implementation - even if one of those was set to debug (which it is by default unless we override it) the logs will get discarded unless the "main" log_level is set that low too. So really it doesn't make sense to have a level for each and run a switch against that log level, instead we just always log the `sql` logs as DEBUG, and the middleware logs will be INFO.

#### Removal of External EchoLogger package
I looked at the wrapper and it worked, but it was yet another layer that we don't really need so I made our own wrapper that just overrides the missing methods. Basically it was just the `(Debug|Info|Print|Error|Warn|Fatal)j` methods and then the "special" level methods. I implemented those just printing the `map[string]any` since that is what they're designed to print. We don't use them at all though so it's more just so we can plug our logger into echo.

Since we're using one logger under the hood - I made the level methods just panic (since we should realistically just be setting the level on the "main" logger). The remaining methods just panic as well, but we don't use them.

#### Removal of `LogByLevel` methods from LogWriter & GormLogger
So this kind of ties in with the extra log level removals - instead of switching through lets just log all the things of a certain type at a certain level.

Echo's middleware logger is always going to be INFO
GORM is always going to be using the Trace method, which is going to be DEBUG
