### PR TITLE
[RHCLOUD-20398] App auth tenancy tests4

### DIFF
--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -557,7 +557,7 @@ func TestApplicationAuthenticationDelete(t *testing.T) {
 	// Create an application authentication
 	appAuthDao := dao.GetApplicationAuthenticationDao(&daoParams)
 	appAuth := m.ApplicationAuthentication{
-		ApplicationID: app.ID,
+		ApplicationID:    app.ID,
 		AuthenticationID: auth.DbID,
 	}
 	err = appAuthDao.Create(&appAuth)
@@ -602,6 +602,34 @@ func TestApplicationAuthenticationDelete(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+}
+
+// TestApplicationAuthenticationDeleteInvalidTenant tests that not found is returned
+// for tenant who doesn't own the app auth
+func TestApplicationAuthenticationDeleteInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(2)
+	appAuthId := int64(1)
+
+	c, rec := request.CreateTestContext(
+		http.MethodDelete,
+		"/api/sources/v3.1/application_authentications/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+	c.SetParamNames("id")
+	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	notFoundApplicationAuthenticationDelete := ErrorHandlingContext(ApplicationAuthenticationDelete)
+	err := notFoundApplicationAuthenticationDelete(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
 }
 
 func TestApplicationAuthenticationDeleteNotFound(t *testing.T) {


### PR DESCRIPTION
tests update for application authentication handlers PART IV.
(Part I. #423, Part II. #425, Part III. #431)
this PR covers:

- ApplicationAuthenticationDelete()

tests update for other handlers will be covered in next PRs

**JIRA:** [RHCLOUD-20398](https://issues.redhat.com/browse/RHCLOUD-20398)