### PR TITLE
[RHCLOUD-20441] refactor: replace query structs with explicit "where" conditions

### DIFF
--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -119,13 +119,20 @@ func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 }
 
 func (a *applicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAuthentication, error) {
-	appAuth := &m.ApplicationAuthentication{ID: *id}
-	result := DB.Debug().
-		Where("tenant_id = ?", a.TenantID).First(&appAuth)
-	if result.Error != nil {
+	var appAuth m.ApplicationAuthentication
+
+	err := DB.Debug().
+		Model(&m.ApplicationAuthentication{}).
+		Where("id = ?", *id).
+		Where("tenant_id = ?", a.TenantID).
+		First(&appAuth).
+		Error
+
+	if err != nil {
 		return nil, util.NewErrNotFound("application authentication")
 	}
-	return appAuth, nil
+
+	return &appAuth, nil
 }
 
 func (a *applicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthentication) error {

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -81,32 +81,43 @@ func (a *applicationDaoImpl) List(limit int, offset int, filters []util.Filter) 
 }
 
 func (a *applicationDaoImpl) GetById(id *int64) (*m.Application, error) {
-	app := &m.Application{ID: *id}
-	result := DB.Debug().
+	var app m.Application
+
+	err := DB.Debug().
+		Model(&m.Application{}).
+		Where("id = ?", *id).
 		Where("tenant_id = ?", a.TenantID).
-		First(&app)
-	if result.Error != nil {
+		First(&app).
+		Error
+
+	if err != nil {
 		return nil, util.NewErrNotFound("application")
 	}
 
-	return app, nil
+	return &app, nil
 }
 
-// Function that searches for an application and preloads any specified relations
+// GetByIdWithPreload searches for an application and preloads any specified relations.
 func (a *applicationDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.Application, error) {
-	app := &m.Application{ID: *id}
-	q := DB.Where("tenant_id = ?", a.TenantID)
+	q := DB.Debug().
+		Model(&m.Application{}).
+		Where("id = ?", *id).
+		Where("tenant_id = ?", a.TenantID)
 
 	for _, preload := range preloads {
 		q = q.Preload(preload)
 	}
 
-	result := q.First(&app)
-	if result.Error != nil {
+	var app m.Application
+	err := q.
+		First(&app).
+		Error
+
+	if err != nil {
 		return nil, util.NewErrNotFound("application")
 	}
 
-	return app, nil
+	return &app, nil
 }
 
 func (a *applicationDaoImpl) Create(app *m.Application) error {
@@ -164,11 +175,17 @@ func (a *applicationDaoImpl) IsSuperkey(id int64) bool {
 }
 
 func (a *applicationDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
-	application := &m.Application{ID: resource.ResourceID}
-	result := DB.Debug().Preload("Source").Find(&application)
+	var application m.Application
 
-	if result.Error != nil {
-		return nil, result.Error
+	err := DB.Debug().
+		Model(&m.Application{}).
+		Where("id = ?", resource.ResourceID).
+		Preload("Source").
+		Find(&application).
+		Error
+
+	if err != nil {
+		return nil, err
 	}
 
 	authentication := &m.Authentication{ResourceID: application.ID,
@@ -179,7 +196,11 @@ func (a *applicationDaoImpl) BulkMessage(resource util.Resource) (map[string]int
 }
 
 func (a *applicationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) (interface{}, error) {
-	result := DB.Debug().Model(&m.Application{ID: resource.ResourceID}).Updates(updateAttributes)
+	result := DB.Debug().
+		Model(&m.Application{}).
+		Where("id = ?", resource.ResourceID).
+		Updates(updateAttributes)
+
 	if result.RowsAffected == 0 {
 		return nil, fmt.Errorf("application not found %v", resource)
 	}
@@ -194,10 +215,16 @@ func (a *applicationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttr
 }
 
 func (a *applicationDaoImpl) FindWithTenant(id *int64) (*m.Application, error) {
-	app := &m.Application{ID: *id}
-	result := DB.Debug().Preload("Tenant").Find(&app)
+	var app m.Application
 
-	return app, result.Error
+	err := DB.Debug().
+		Model(&m.Application{}).
+		Where("id = ?", *id).
+		Preload("Tenant").
+		Find(&app).
+		Error
+
+	return &app, err
 }
 
 func (a *applicationDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -82,13 +82,19 @@ func (at *applicationTypeDaoImpl) List(limit, offset int, filters []util.Filter)
 }
 
 func (at *applicationTypeDaoImpl) GetById(id *int64) (*m.ApplicationType, error) {
-	appType := &m.ApplicationType{Id: *id}
-	result := DB.Debug().First(appType)
-	if result.Error != nil {
+	var appType m.ApplicationType
+
+	err := DB.Debug().
+		Model(&m.ApplicationType{}).
+		Where("id = ?", *id).
+		First(&appType).
+		Error
+
+	if err != nil {
 		return nil, util.NewErrNotFound("application type")
 	}
 
-	return appType, nil
+	return &appType, nil
 }
 
 func (at *applicationTypeDaoImpl) GetByName(name string) (*m.ApplicationType, error) {
@@ -116,9 +122,16 @@ func (at *applicationTypeDaoImpl) Delete(_ *int64) error {
 func (at *applicationTypeDaoImpl) ApplicationTypeCompatibleWithSource(typeId, sourceId int64) error {
 	// Looks up the source ID and then compare's the source-type's name with the
 	// application type's supported source types
-	source := m.Source{ID: sourceId}
-	result := DB.Debug().Preload("SourceType").Find(&source)
-	if result.Error != nil {
+	var source m.Source
+
+	err := DB.Debug().
+		Model(&m.Source{}).
+		Where("id = ?", sourceId).
+		Preload("SourceType").
+		Find(&source).
+		Error
+
+	if err != nil {
 		return fmt.Errorf("source not found")
 	}
 

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -73,13 +73,20 @@ func (md *metaDataDaoImpl) List(limit int, offset int, filters []util.Filter) ([
 }
 
 func (md *metaDataDaoImpl) GetById(id *int64) (*m.MetaData, error) {
-	metaData := &m.MetaData{ID: *id}
-	result := DB.Debug().First(&metaData)
-	if result.Error != nil {
+	var metaData m.MetaData
+
+	err := DB.
+		Debug().
+		Model(&m.MetaData{}).
+		Where("id = ?", *id).
+		First(&metaData).
+		Error
+
+	if err != nil {
 		return nil, util.NewErrNotFound("metadata")
 	}
 
-	return metaData, nil
+	return &metaData, nil
 }
 
 func (md *metaDataDaoImpl) GetSuperKeySteps(applicationTypeId int64) ([]m.MetaData, error) {

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -122,31 +122,43 @@ func (s *sourceDaoImpl) ListInternal(limit, offset int, filters []util.Filter) (
 }
 
 func (s *sourceDaoImpl) GetById(id *int64) (*m.Source, error) {
-	src := &m.Source{ID: *id}
-	result := DB.Debug().
+	var src m.Source
+
+	err := DB.Debug().
+		Model(&m.Source{}).
+		Where("id = ?", *id).
 		Where("tenant_id = ?", s.TenantID).
-		First(src)
-	if result.Error != nil {
+		First(&src).
+		Error
+
+	if err != nil {
 		return nil, util.NewErrNotFound("source")
 	}
 
-	return src, nil
+	return &src, nil
 }
 
-// Function that searches for a source and preloads any specified relations
+// GetByIdWithPreload searches for a source and preloads any specified relations.
 func (s *sourceDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error) {
-	src := &m.Source{ID: *id}
-	q := DB.Debug().Where("tenant_id = ?", s.TenantID)
+	q := DB.Debug().
+		Model(&m.Source{}).
+		Where("id = ?", *id).
+		Where("tenant_id = ?", s.TenantID)
 
 	for _, preload := range preloads {
 		q = q.Preload(preload)
 	}
 
-	result := q.First(&src)
-	if result.Error != nil {
+	var src m.Source
+	err := q.
+		First(&src).
+		Error
+
+	if err != nil {
 		return nil, util.NewErrNotFound("source")
 	}
-	return src, nil
+
+	return &src, nil
 }
 
 func (s *sourceDaoImpl) Create(src *m.Source) error {
@@ -186,11 +198,16 @@ func (s *sourceDaoImpl) Tenant() *int64 {
 }
 
 func (s *sourceDaoImpl) NameExistsInCurrentTenant(name string) bool {
-	src := &m.Source{Name: name}
-	result := DB.Debug().Where("name = ? AND tenant_id = ?", name, s.TenantID).First(src)
+	err := DB.
+		Debug().
+		Model(&m.Source{}).
+		Where("name = ?", name).
+		Where("tenant_id = ?", s.TenantID).
+		First(&m.Source{}).
+		Error
 
 	// If the name is found, GORM returns one row and no errors.
-	return result.Error == nil
+	return err == nil
 }
 
 func (s *sourceDaoImpl) IsSuperkey(id int64) bool {
@@ -209,18 +226,28 @@ func (s *sourceDaoImpl) IsSuperkey(id int64) bool {
 }
 
 func (s *sourceDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
-	src := m.Source{ID: resource.ResourceID}
-	result := DB.Debug().Find(&src)
-	if result.Error != nil {
-		return nil, result.Error
+	var src m.Source
+
+	err := DB.Debug().
+		Model(&m.Source{}).
+		Where("id = ?", resource.ResourceID).
+		Find(&src).
+		Error
+
+	if err != nil {
+		return nil, err
 	}
 
 	authentication := &m.Authentication{ResourceID: src.ID, ResourceType: "Source"}
+
 	return BulkMessageFromSource(&src, authentication)
 }
 
 func (s *sourceDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) (interface{}, error) {
-	result := DB.Debug().Model(&m.Source{ID: resource.ResourceID}).Updates(updateAttributes)
+	result := DB.Debug().
+		Model(&m.Source{}).
+		Where("id = ?", resource.ResourceID).
+		Updates(updateAttributes)
 
 	if result.RowsAffected == 0 {
 		return nil, fmt.Errorf("source not found %v", resource)
@@ -236,10 +263,16 @@ func (s *sourceDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttribute
 }
 
 func (s *sourceDaoImpl) FindWithTenant(id *int64) (*m.Source, error) {
-	src := &m.Source{ID: *id}
-	result := DB.Debug().Preload("Tenant").Find(&src)
+	var src m.Source
 
-	return src, result.Error
+	err := DB.Debug().
+		Model(&m.Source{}).
+		Where("id = ?", *id).
+		Preload("Tenant").
+		Find(&src).
+		Error
+
+	return &src, err
 }
 
 func (s *sourceDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -47,12 +47,19 @@ func (st *sourceTypeDaoImpl) List(limit, offset int, filters []util.Filter) ([]m
 }
 
 func (st *sourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
-	sourceType := &m.SourceType{Id: *id}
-	result := DB.Debug().First(sourceType)
-	if result.Error != nil {
+	var sourceType m.SourceType
+
+	err := DB.Debug().
+		Model(&m.SourceType{}).
+		Where("id = ?", *id).
+		First(&sourceType).
+		Error
+
+	if err != nil {
 		return nil, util.NewErrNotFound("source type")
 	}
-	return sourceType, nil
+
+	return &sourceType, nil
 }
 
 func (st *sourceTypeDaoImpl) GetByName(name string) (*m.SourceType, error) {


### PR DESCRIPTION
In order to avoid hitting the issue of selecting unexpected data due to
Gorm treating default values as "should not include as where condition",
this commit removes all the structs that were used in queries, and has
replaced them with explicit "where" conditions instead.

## Links

[[RHCLOUD-20441]](https://issues.redhat.com/browse/RHCLOUD-20441)