### PR TITLE
[RHCLOUD-20398] App auth tenancy tests5

### DIFF
--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -782,6 +782,37 @@ func TestApplicationAuthenticationListAuthenticationsTenantNotExist(t *testing.T
 	templates.NotFoundTest(t, rec)
 }
 
+// TestApplicationAuthenticationListAuthenticationsInvalidTenant tests that not found
+// is returned for valid tenant who doesn't own the app auth
+func TestApplicationAuthenticationListAuthenticationsInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(2)
+	appAuthId := int64(2)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_authentications/2/authentications",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("application_authentication_id")
+	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
+
+	notFoundAppAuthListAuths := ErrorHandlingContext(ApplicationAuthenticationListAuthentications)
+	err := notFoundAppAuthListAuths(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestApplicationAuthenticationListAuthenticationsNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 

--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -751,6 +751,37 @@ func TestApplicationAuthenticationListAuthentications(t *testing.T) {
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
+// TestApplicationAuthenticationListAuthenticationsTenantNotExist tests that not found
+// is returned for not existing tenant
+func TestApplicationAuthenticationListAuthenticationsTenantNotExist(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := fixtures.NotExistingTenantId
+	appAuthId := int64(2)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_authentications/2/authentications",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("application_authentication_id")
+	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
+
+	notFoundAppAuthListAuths := ErrorHandlingContext(ApplicationAuthenticationListAuthentications)
+	err := notFoundAppAuthListAuths(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestApplicationAuthenticationListAuthenticationsNotFound(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 


### PR DESCRIPTION
tests update for application authentication handlers PART V.
(Part I. #423, Part II. #425, Part III. #431, Part IV. #432)
this PR covers:

- ApplicationAuthenticationListAuthentications()

**JIRA:** [RHCLOUD-20398](https://issues.redhat.com/browse/RHCLOUD-20398)