### PR TITLE
Pass instance of RequestParams to GetApplicationDao(..) calls

### DIFF
--- a/application_handlers.go
+++ b/application_handlers.go
@@ -23,7 +23,7 @@ func getApplicationDaoWithTenant(c echo.Context) (dao.ApplicationDao, error) {
 		return nil, err
 	}
 
-	return dao.GetApplicationDao(&tenantId), nil
+	return dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId}), nil
 }
 
 func ApplicationList(c echo.Context) error {

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -752,7 +752,7 @@ func TestApplicationEdit(t *testing.T) {
 
 	sourceID := fixtureSource.ID
 
-	applicationDao := dao.GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	fixtureApp := m.Application{
 		ApplicationTypeID:  fixtures.TestApplicationTypeData[0].Id,
 		SourceID:           sourceID,
@@ -994,7 +994,7 @@ func TestApplicationDelete(t *testing.T) {
 	}
 
 	// Create an application
-	applicationDao := dao.GetApplicationDao(&tenantID)
+	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantID})
 
 	app := m.Application{
 		SourceID:          src.ID,
@@ -1415,7 +1415,7 @@ func TestPauseApplication(t *testing.T) {
 	}
 
 	// Check that the application is paused
-	applicationDao := dao.GetApplicationDao(&tenantId)
+	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
 	app, err := applicationDao.GetById(&appId)
 	if err != nil {
 		t.Error(err)
@@ -1546,7 +1546,7 @@ func TestUnpauseApplication(t *testing.T) {
 	appId := int64(1)
 
 	// Test data preparation = pause the application
-	applicationDao := dao.GetApplicationDao(&tenantId)
+	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
 	err := applicationDao.Pause(appId)
 	if err != nil {
 		t.Error(err)

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -62,7 +62,7 @@ func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 
 	// Get all the DAOs we are going to work with.
 	authDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
-	appDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	appDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
 
 	// Maximum of resources to create.

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -13,12 +13,17 @@ import (
 
 // GetApplicationDao is a function definition that can be replaced in runtime in case some other DAO
 // provider is needed.
-var GetApplicationDao func(*int64) ApplicationDao
+var GetApplicationDao func(*RequestParams) ApplicationDao
 
 // getDefaultApplicationAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
-func getDefaultApplicationDao(tenantId *int64) ApplicationDao {
+func getDefaultApplicationDao(daoParams *RequestParams) ApplicationDao {
+	var tenantID *int64
+	if daoParams != nil && daoParams.TenantID != nil {
+		tenantID = daoParams.TenantID
+	}
+
 	return &applicationDaoImpl{
-		TenantID: tenantId,
+		TenantID: tenantID,
 	}
 }
 

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -22,7 +22,7 @@ func TestPausingApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("pause_unpause")
 
-	applicationDao := GetApplicationDao(&fixtures.TestSourceData[0].TenantID)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	err := applicationDao.Pause(testApplication.ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -46,7 +46,7 @@ func TestResumeApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("pause_unpause")
 
-	applicationDao := GetApplicationDao(&testApplication.TenantID)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &testApplication.TenantID})
 	err := applicationDao.Unpause(testApplication.ID)
 
 	if err != nil {
@@ -71,7 +71,7 @@ func TestDeleteApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	applicationDao := GetApplicationDao(&fixtures.TestSourceData[0].TenantID)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestSourceData[0].TenantID})
 
 	application := fixtures.TestApplicationData[0]
 	// Set the ID to 0 to let GORM know it should insert a new application and not update an existing one.
@@ -117,7 +117,7 @@ func TestDeleteApplicationNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	applicationDao := GetApplicationDao(&fixtures.TestSourceData[0].TenantID)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	nonExistentId := int64(12345)
 	_, err := applicationDao.Delete(&nonExistentId)
@@ -134,7 +134,7 @@ func TestApplicationDeleteCascade(t *testing.T) {
 	SwitchSchema("delete")
 
 	// Create a new application on the database to cleanly test the function under test.
-	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	fixtureApp := m.Application{
 		ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
 		SourceID:          fixtures.TestSourceData[0].ID,
@@ -287,7 +287,7 @@ func TestApplicationExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("exists")
 
-	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	got, err := applicationDao.Exists(fixtures.TestApplicationData[0].ID)
 	if err != nil {
@@ -306,7 +306,7 @@ func TestApplicationNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("exists")
 
-	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	got, err := applicationDao.Exists(12345)
 	if err != nil {
@@ -326,7 +326,7 @@ func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")
 
-	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	sourceId := fixtures.TestSourceData[0].ID
 
 	var wantCount int64
@@ -368,7 +368,7 @@ func TestApplicationListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")
 
-	applicationDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	wantCount := int64(len(fixtures.TestApplicationData))
 
 	for _, d := range fixtures.TestDataOffsetLimit {

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -125,7 +125,7 @@ func (a *authenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []util
 
 func (a *authenticationDaoImpl) ListForApplication(applicationID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	// checking if application exists first
-	_, err := GetApplicationDao(a.TenantID).GetById(&applicationID)
+	_, err := GetApplicationDao(&RequestParams{TenantID: a.TenantID}).GetById(&applicationID)
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("application")
 	}

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -371,7 +371,7 @@ func TestListForApplication(t *testing.T) {
 	}
 
 	// Create an application fixture.
-	applicationDao := GetApplicationDao(&fixtures.TestTenantData[1].Id)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	application := model.Application{
 		ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
 		SourceID:          source.ID,
@@ -470,7 +470,7 @@ func TestListForApplicationAuthentication(t *testing.T) {
 	}
 
 	// Create an application fixture.
-	applicationDao := GetApplicationDao(&fixtures.TestTenantData[1].Id)
+	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	application := model.Application{
 		ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
 		SourceID:          source.ID,

--- a/dao/common.go
+++ b/dao/common.go
@@ -58,7 +58,7 @@ func GetAvailabilityStatusFromStatusMessage(tenantID int64, resourceID string, r
 		if err != nil {
 			return "", err
 		}
-		resource, err := GetApplicationDao(&tenantID).GetById(&recordID)
+		resource, err := GetApplicationDao(&RequestParams{TenantID: &tenantID}).GetById(&recordID)
 		if err != nil {
 			return "", err
 		}

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -270,7 +270,7 @@ func TestDeleteCascade(t *testing.T) {
 
 	// Grab the DAOs which we will use to create the subresources.
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
-	applicationsDao := GetApplicationDao(&fixtures.TestTenantData[0].Id)
+	applicationsDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	authDaoParams := RequestParams{TenantID: &fixtures.TestTenantData[0].Id}
 	authenticationDao := GetAuthenticationDao(&authDaoParams)
 	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)

--- a/graph/types.go
+++ b/graph/types.go
@@ -48,7 +48,7 @@ func (rd *RequestData) EnsureApplicationsAreLoaded() error {
 	// again due to the fact that multiple threads might have locked this the
 	// first time
 	if rd.applicationMap == nil {
-		apps, _, err := dao.GetApplicationDao(&rd.TenantID).List(defaultLimit, 0, []util.Filter{{Name: "source_id", Value: *rd.sourceIdList}})
+		apps, _, err := dao.GetApplicationDao(&dao.RequestParams{TenantID: &rd.TenantID}).List(defaultLimit, 0, []util.Filter{{Name: "source_id", Value: *rd.sourceIdList}})
 		if err != nil {
 			return err
 		}

--- a/jobs/retry_create.go
+++ b/jobs/retry_create.go
@@ -98,7 +98,7 @@ func resendCreateMessages(applicationId, applicationTypeId, tenantId int64) {
 	}
 
 	// if we're good, load up the required fields
-	app, err := dao.GetApplicationDao(&tenantId).GetByIdWithPreload(&applicationId, "Source", "Tenant", "ApplicationAuthentications")
+	app, err := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId}).GetByIdWithPreload(&applicationId, "Source", "Tenant", "ApplicationAuthentications")
 	if err != nil {
 		l.Log.Warnf("Error fetching application %v from db: %v", applicationId, err)
 		return

--- a/jobs/superkey.go
+++ b/jobs/superkey.go
@@ -57,7 +57,7 @@ func (sk SuperkeyDestroyJob) Run() error {
 func (sk SuperkeyDestroyJob) sendForSource(id int64) error {
 	l.Log.Infof("Sending SuperKey Delete request for source %v", sk.Id)
 
-	a := dao.GetApplicationDao(&sk.Tenant)
+	a := dao.GetApplicationDao(&dao.RequestParams{TenantID: &sk.Tenant})
 
 	apps, _, err := a.SubCollectionList(m.Source{ID: id}, 100, 0, make([]util.Filter, 0))
 	if err != nil {

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -73,7 +73,7 @@ func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 			return util.NewErrBadRequest(err)
 		}
 
-		a := dao.GetApplicationDao(&tenantId)
+		a := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
 
 		if a.IsSuperkey(id) {
 			xrhid, ok := c.Get(h.XRHID).(string)

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -321,7 +321,7 @@ func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput,
 					continue
 				}
 			case "application":
-				_, err = dao.GetApplicationDao(&tenant.Id).GetById(&id)
+				_, err = dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenant.Id}).GetById(&id)
 				if err == nil {
 					l.Log.Debugf("Found existing Application with id %v, adding to list and continuing", id)
 					a.ResourceID = id

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -105,7 +105,7 @@ func DeleteCascade(tenantId *int64, resourceType string, resourceId int64, heade
 		}
 
 	case "Application":
-		applicationsDao := dao.GetApplicationDao(tenantId)
+		applicationsDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: tenantId})
 		applicationAuthentications, application, err := applicationsDao.DeleteCascade(resourceId)
 		if err != nil {
 			return fmt.Errorf(`could not completely delete the application: %s`, err)

--- a/service/superkey_helpers.go
+++ b/service/superkey_helpers.go
@@ -14,7 +14,7 @@ import (
 // loads up the application as well as the associates we need for the superkey
 // request
 func loadApplication(application *m.Application) (*m.Application, error) {
-	appDao := dao.GetApplicationDao(&application.TenantID)
+	appDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &application.TenantID})
 
 	// re-pulling it from the db to make sure we have the full-version, as well
 	// as preloading any relations necessary.

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1355,7 +1355,7 @@ func TestSourceDelete(t *testing.T) {
 	auths = append(auths, auth)
 
 	// Create an application
-	applicationDao := dao.GetApplicationDao(&tenantID)
+	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantID})
 
 	app := m.Application{
 		SourceID:          src.ID,
@@ -1928,7 +1928,7 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 	}
 
 	// Check that relation applications are paused and belongs to desired tenant
-	appDao := dao.GetApplicationDao(&tenantId)
+	appDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
 	apps, _, err := appDao.SubCollectionList(m.Source{ID: sourceId}, 100, 0, nil)
 	if err != nil {
 		t.Error(err)
@@ -2103,7 +2103,7 @@ func TestUnpauseSourceAndItsApplications(t *testing.T) {
 	}
 
 	// Check that related applications are not paused and belongs to the desired tenant
-	appDao := dao.GetApplicationDao(&tenantId)
+	appDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
 	apps, _, err := appDao.SubCollectionList(m.Source{ID: sourceId}, 100, 0, nil)
 	if err != nil {
 		t.Error(err)

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -137,7 +137,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 
 	if previousStatus != statusMessage.Status {
 		if statusMessage.ResourceType == "Application" {
-			appDao := dao.GetApplicationDao(&tenant.Id)
+			appDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenant.Id})
 			app, err := appDao.GetById(&resource.ResourceID)
 			if err != nil {
 				l.Log.Errorf("[tenant_id: %d][application_id: %d] unable to fetch application: %s", tenant.Id, resource.ResourceID, err)


### PR DESCRIPTION
This change is required to be able pass userid to `GetApplicationDao(..)` calls through RequestParams struct.


### Links
- Issue https://github.com/RedHatInsights/sources-api-go/issues/356
- Similar to https://github.com/RedHatInsights/sources-api-go/pull/357 and https://github.com/RedHatInsights/sources-api-go/pull/397