### PR TITLE
Pass instance of RequestParams to GetApplicationAuthenticationDao(..) calls

### DIFF
--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -22,7 +22,7 @@ func getApplicationAuthenticationDaoWithTenant(c echo.Context) (dao.ApplicationA
 		return nil, err
 	}
 
-	return dao.GetApplicationAuthenticationDao(&tenantId), nil
+	return dao.GetApplicationAuthenticationDao(&dao.RequestParams{TenantID: &tenantId}), nil
 }
 
 func ApplicationAuthenticationList(c echo.Context) error {

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1025,7 +1025,7 @@ func TestApplicationDelete(t *testing.T) {
 	}
 
 	// Create an application authentication
-	appAuthDao := dao.GetApplicationAuthenticationDao(&tenantID)
+	appAuthDao := dao.GetApplicationAuthenticationDao(&dao.RequestParams{TenantID: &tenantID})
 	appAuth := m.ApplicationAuthentication{
 		ApplicationID:    app.ID,
 		AuthenticationID: auth.DbID,

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -11,12 +11,17 @@ import (
 
 // GetApplicationAuthenticationDao is a function definition that can be replaced in runtime in case some other DAO
 // provider is needed.
-var GetApplicationAuthenticationDao func(*int64) ApplicationAuthenticationDao
+var GetApplicationAuthenticationDao func(*RequestParams) ApplicationAuthenticationDao
 
 // getDefaultApplicationAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
-func getDefaultApplicationAuthenticationDao(tenantId *int64) ApplicationAuthenticationDao {
+func getDefaultApplicationAuthenticationDao(daoParams *RequestParams) ApplicationAuthenticationDao {
+	var tenantID *int64
+	if daoParams != nil && daoParams.TenantID != nil {
+		tenantID = daoParams.TenantID
+	}
+
 	return &applicationAuthenticationDaoImpl{
-		TenantID: tenantId,
+		TenantID: tenantID,
 	}
 }
 

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -16,7 +16,7 @@ func TestDeleteApplicationAuthentication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestSourceData[0].TenantID)
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	deletedApplicationAuthentication, err := applicationAuthenticationDao.Delete(&fixtures.TestApplicationAuthenticationData[0].ID)
 	if err != nil {
@@ -41,7 +41,7 @@ func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestSourceData[0].TenantID)
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	nonExistentId := int64(12345)
 	_, err := applicationAuthenticationDao.Delete(&nonExistentId)
@@ -63,7 +63,7 @@ func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 	// Get all the DAOs we are going to work with.
 	authDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	appDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
-	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	appAuthDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Maximum of resources to create.
 	maxCreatedResources := 5
@@ -159,7 +159,7 @@ func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
 
 	// Get all the DAOs we are going to work with.
 	authDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
-	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	appAuthDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Maximum of authentications to create.
 	maxCreatedAuths := 5
@@ -241,7 +241,7 @@ func TestApplicationAuthenticationListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
 	SwitchSchema("offset_limit")
 
-	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	appAuthDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	wantCount := int64(len(fixtures.TestApplicationAuthenticationData))
 
 	for _, d := range fixtures.TestDataOffsetLimit {

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -149,7 +149,7 @@ func TestApplicationDeleteCascade(t *testing.T) {
 	// Create the authentications and the application authentications. The former are needed to avoid the foreign key
 	// constraints.
 	authenticationDao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
-	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	// Set the maximum amount of authentications we will create.
 	maxAuthenticationsCreated := 5

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -497,7 +497,7 @@ func TestListForApplicationAuthentication(t *testing.T) {
 	}
 
 	// Create the application authentication.
-	appAuthDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[1].Id)
+	appAuthDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
 	appAuth := model.ApplicationAuthentication{
 		TenantID:         fixtures.TestTenantData[1].Id,
 		ApplicationID:    application.ID,

--- a/dao/common.go
+++ b/dao/common.go
@@ -122,7 +122,7 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 		authentications[i] = authenticationsByResource[i].ToEvent()
 	}
 
-	applicationAuthenticationDao := GetApplicationAuthenticationDao(&source.TenantID)
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &source.TenantID})
 	applicationAuthenticationsFromResource, err := applicationAuthenticationDao.ApplicationAuthenticationsByResource(authentication.ResourceType, source.Applications, authenticationsByResource)
 
 	if err != nil {

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -268,9 +268,10 @@ func TestDeleteCascade(t *testing.T) {
 		t.Errorf(`error creating a fixture source: %s`, err)
 	}
 
-	// Grab the DAOs which we will use to create the subresources.
-	applicationAuthenticationDao := GetApplicationAuthenticationDao(&fixtures.TestTenantData[0].Id)
+	// Grab the DAOs which we will use to create the subresources
+	applicationAuthenticationDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	applicationsDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	authDaoParams := RequestParams{TenantID: &fixtures.TestTenantData[0].Id}
 	authenticationDao := GetAuthenticationDao(&authDaoParams)
 	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1386,7 +1386,7 @@ func TestSourceDelete(t *testing.T) {
 	auths = append(auths, auth)
 
 	// Create an application authentication
-	appAuthDao := dao.GetApplicationAuthenticationDao(&tenantID)
+	appAuthDao := dao.GetApplicationAuthenticationDao(&dao.RequestParams{TenantID: &tenantID})
 	appAuth := m.ApplicationAuthentication{
 		ApplicationID:    app.ID,
 		AuthenticationID: auth.DbID,


### PR DESCRIPTION
This change is required to be able pass userid to `GetApplicationAuthenticationDao(..)` calls through RequestParams struct.


### Links
- Issue https://github.com/RedHatInsights/sources-api-go/issues/356
- Similar to https://github.com/RedHatInsights/sources-api-go/pull/357 and https://github.com/RedHatInsights/sources-api-go/pull/397 and https://github.com/RedHatInsights/sources-api-go/pull/435