### PR TITLE
[RHCLOUD-20512] App type handlers tests2

### DIFF
--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -306,6 +306,32 @@ func TestApplicationTypeList(t *testing.T) {
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
+// TestApplicationTypeListWithTenant tests that list of application types is returned
+// even when tenant is provided (this request doesn't need a tenant)
+func TestApplicationTypeListWithTenant(t *testing.T) {
+	tenantId := int64(1)
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types",
+		nil,
+		map[string]interface{}{
+			"limit":   100,
+			"offset":  0,
+			"filters": []util.Filter{},
+			"tenant": tenantId,
+		},
+	)
+
+	err := ApplicationTypeList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 200 {
+		t.Error("Did not return 200")
+	}
+}
+
 func TestApplicationTypeListBadRequestInvalidFilter(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -307,7 +307,7 @@ func TestApplicationTypeList(t *testing.T) {
 }
 
 // TestApplicationTypeListWithTenant tests that list of application types is returned
-// even when tenant is provided (this request doesn't need a tenant)
+// even when tenant is provided (the request usually doesn't need a tenant)
 func TestApplicationTypeListWithTenant(t *testing.T) {
 	tenantId := int64(1)
 	c, rec := request.CreateTestContext(
@@ -318,7 +318,7 @@ func TestApplicationTypeListWithTenant(t *testing.T) {
 			"limit":   100,
 			"offset":  0,
 			"filters": []util.Filter{},
-			"tenant": tenantId,
+			"tenant":  tenantId,
 		},
 	)
 
@@ -363,6 +363,42 @@ func TestApplicationTypeGet(t *testing.T) {
 		"/api/sources/v3.1/application_types/1",
 		nil,
 		nil,
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+
+	err := ApplicationTypeGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 200 {
+		t.Error("Did not return 200")
+	}
+
+	var outAppType m.ApplicationTypeResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &outAppType)
+	if err != nil {
+		t.Error("Failed unmarshaling output")
+	}
+
+	if outAppType.DisplayName != "test app type" {
+		t.Error("ghosts infected the return")
+	}
+}
+
+// TestApplicationTypeGetWithTenant tests that application type is returned
+// even when tenant is provided (the request usually doesn't need a tenant)
+func TestApplicationTypeGetWithTenant(t *testing.T) {
+	tenantId := int64(1)
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types/1",
+		nil,
+		map[string]interface{}{
+			"tenant": tenantId,
+		},
 	)
 
 	c.SetParamNames("id")


### PR DESCRIPTION
test update for application type handlers PART II. (Part I. #437)

for handlers:
- ApplicationTypeList()
- ApplicationTypeGet()

 **JIRA:** [RHCLOUD-20512](https://issues.redhat.com/browse/RHCLOUD-20512)