### PR TITLE
Remove GetFromResourceType call from RaiseEventForUpdate

### DIFF
--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	c "github.com/RedHatInsights/sources-api-go/config"
-	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
@@ -65,13 +64,8 @@ func (esp *EventStreamProducer) RaiseEventIf(allowed bool, eventType string, pay
 	return nil
 }
 
-func (esp *EventStreamProducer) RaiseEventForUpdate(resource util.Resource, updateAttributes []string, headers []kafka.Header) error {
+func (esp *EventStreamProducer) RaiseEventForUpdate(eventModelDao m.EventModelDao, resource util.Resource, updateAttributes []string, headers []kafka.Header) error {
 	allowed := esp.RaiseEventAllowed(resource.ResourceType, updateAttributes)
-	eventModelDao, err := dao.GetFromResourceType(resource.ResourceType)
-	if err != nil {
-		return err
-	}
-
 	resourceJSON, err := eventModelDao.ToEventJSON(resource)
 	if err != nil {
 		return err

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -170,7 +170,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 	}
 	sort.Strings(updateAttributeKeys)
 
-	err = avs.EventStreamProducer.RaiseEventForUpdate(*resource, updateAttributeKeys, headers)
+	err = avs.EventStreamProducer.RaiseEventForUpdate(modelEventDao, *resource, updateAttributeKeys, headers)
 
 	if err != nil {
 		l.Log.Errorf("Error in raising event for update: %s, resource: %s(%s)", err.Error(), statusMessage.ResourceType, statusMessage.ResourceID)


### PR DESCRIPTION
We don't need to call GetFromResourceType again here and we can pass it.
