### PR TITLE
Pass RequestParams to GetSourceDao in GetFromResourceType

### DIFF
--- a/dao/common.go
+++ b/dao/common.go
@@ -13,11 +13,11 @@ const (
 	DEFAULT_OFFSET = 0
 )
 
-func GetFromResourceType(resourceType string) (m.EventModelDao, error) {
+func GetFromResourceType(resourceType string, tenantID int64) (m.EventModelDao, error) {
 	var resource m.EventModelDao
 	switch strings.ToLower(resourceType) {
 	case "source":
-		resource = GetSourceDao(nil)
+		resource = GetSourceDao(&RequestParams{TenantID: &tenantID})
 	case "endpoint":
 		resource = GetEndpointDao(nil)
 	case "application":

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -221,7 +221,6 @@ func (s *sourceDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttribute
 		return nil, fmt.Errorf("source not found %v", resource)
 	}
 
-	s.TenantID = &resource.TenantID
 	source, err := s.GetById(&resource.ResourceID)
 	if err != nil {
 		return nil, err

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -101,13 +101,6 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		return
 	}
 
-	updateAttributes := avs.attributesForUpdate(statusMessage)
-	modelEventDao, err := dao.GetFromResourceType(statusMessage.ResourceType)
-	if err != nil {
-		l.Log.Error(err)
-		return
-	}
-
 	id, err := util.IdentityFromKafkaHeaders(headers)
 	if err != nil {
 		l.Log.Error(err)
@@ -116,6 +109,13 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 
 	tenantDao := dao.GetTenantDao()
 	tenant, err := tenantDao.TenantByIdentity(id)
+	if err != nil {
+		l.Log.Error(err)
+		return
+	}
+
+	updateAttributes := avs.attributesForUpdate(statusMessage)
+	modelEventDao, err := dao.GetFromResourceType(statusMessage.ResourceType, tenant.Id)
 	if err != nil {
 		l.Log.Error(err)
 		return


### PR DESCRIPTION
 Pass RequestParams with tenant id to GetSourceDao in GetFromResourceType and thanks that 
sourceDao is instantiated correctly and we don't need to populate tenant id later.

## Links
https://github.com/RedHatInsights/sources-api-go/pull/441
