### PR TITLE
Update clowdapp to expose "sources" as apiPath

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -90,6 +90,7 @@ objects:
       webServices:
         public:
           enabled: true
+          apiPath: sources
       podSpec:
         image: ${IMAGE}:${IMAGE_TAG}
         env:


### PR DESCRIPTION
By default, the route exposes `sources-api-svc` since Clowder publishes the service name as the route termination point. We can override this with `apiPath: sources`. This will fix an issue where the sources frontend is reaching out to the wrong endpoint since `sources-api-svc/version/graphql` isn't valid.