### PR TITLE
[RHCLOUD-20548] chore: bump the "platform-go-middlewares" dependency version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/neko-neko/echo-logrus/v2 v2.0.1
 	github.com/prometheus/client_golang v1.12.1
 	github.com/redhatinsights/app-common-go v1.6.3
-	github.com/redhatinsights/platform-go-middlewares v0.12.0
+	github.com/redhatinsights/platform-go-middlewares v0.19.0
 	github.com/redhatinsights/sources-superkey-worker v0.0.0-20220110114734-d076299a7d68
 	github.com/segmentio/kafka-go v0.4.25
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -1216,6 +1216,8 @@ github.com/redhatinsights/platform-go-middlewares v0.8.1/go.mod h1:koDaxx4Ht3ZgX
 github.com/redhatinsights/platform-go-middlewares v0.10.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/redhatinsights/platform-go-middlewares v0.12.0 h1:gLFgsqupumRqAKDuYtvrYVNQr53iqfhQYc98VJ/cRUs=
 github.com/redhatinsights/platform-go-middlewares v0.12.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
+github.com/redhatinsights/platform-go-middlewares v0.19.0 h1:KEOVfDTOE0OpOKSb8HeEuYblFa2bpXvXpHRV/6706RM=
+github.com/redhatinsights/platform-go-middlewares v0.19.0/go.mod h1:i5gVDZJ/quCQhs5AW5CwkRPXlz1HfDBvyNtXHnlXZfM=
 github.com/redhatinsights/sources-superkey-worker v0.0.0-20220110114734-d076299a7d68 h1:YOKTWdW6poVAoL0ds7oB5yJSXNQOUIveCjqQRthzJ30=
 github.com/redhatinsights/sources-superkey-worker v0.0.0-20220110114734-d076299a7d68/go.mod h1:D74VLRhmYd+tGF1eid7+HLUKytgsm9L2dS9CoR+lxXM=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -114,7 +114,9 @@ func TestSystemClusterID(t *testing.T) {
 			"x-rh-identity": "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
-					System: map[string]interface{}{"cluster_id": "test_cluster"},
+					System: identity.System{
+						ClusterId: "test_cluster",
+					},
 				},
 			},
 		},
@@ -139,7 +141,9 @@ func TestSystemCN(t *testing.T) {
 			"x-rh-identity": "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
-					System: map[string]interface{}{"cn": "test_cert"},
+					System: identity.System{
+						CommonName: "test_cert",
+					},
 				},
 			},
 		},
@@ -164,7 +168,9 @@ func TestSystemPatch(t *testing.T) {
 			"x-rh-identity": "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
-					System: map[string]interface{}{"cn": "test_cert"},
+					System: identity.System{
+						CommonName: "test_cert",
+					},
 				},
 			},
 		},
@@ -189,7 +195,9 @@ func TestSystemDelete(t *testing.T) {
 			"x-rh-identity": "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
-					System: map[string]interface{}{"cn": "test_cert"},
+					System: identity.System{
+						CommonName: "test_cert",
+					},
 				},
 			},
 		},
@@ -214,7 +222,9 @@ func TestSystemDeleteSource(t *testing.T) {
 			"x-rh-identity": "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
-					System: map[string]interface{}{"cn": "test_cert"},
+					System: identity.System{
+						CommonName: "test_cert",
+					},
 				},
 			},
 		},
@@ -239,7 +249,9 @@ func TestSystemDeleteSourceVersioned(t *testing.T) {
 			"x-rh-identity": "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
-					System: map[string]interface{}{"cn": "test_cert"},
+					System: identity.System{
+						CommonName: "test_cert",
+					},
 				},
 			},
 		},

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -56,7 +56,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.PARSED_IDENTITY, xRhIdentity)
 
 			// store whether or not this a cert-auth based request
-			if xRhIdentity.Identity.System != nil && xRhIdentity.Identity.System["cn"] != nil {
+			if xRhIdentity.Identity.System.CommonName != "" {
 				c.Set("cert-auth", true)
 			}
 		} else {


### PR DESCRIPTION
Even thought we don't use the library's utility functions to parse and
process the identity header, we think it's a good idea to have it up to
date just in case, before the official "account number shutdown"
arrives.

## Links

[[RHCLOUD-20548]](https://issues.redhat.com/browse/RHCLOUD-20548)