### PR TITLE
fix string formatting for errors

### DIFF
--- a/application_handlers.go
+++ b/application_handlers.go
@@ -97,7 +97,7 @@ func ApplicationCreate(c echo.Context) error {
 
 	err = service.ValidateApplicationCreateRequest(input)
 	if err != nil {
-		return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %s", err.Error()))
+		return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %v", err))
 	}
 
 	application := &m.Application{

--- a/model/events.go
+++ b/model/events.go
@@ -40,7 +40,7 @@ func UpdateMessage(eventObject EventModelDao, resource util.Resource, attributes
 
 	data, err := json.Marshal(updatedAttributes)
 	if err != nil {
-		return nil, fmt.Errorf("error in parsing update attributes: %s", err.Error())
+		return nil, fmt.Errorf("error in parsing update attributes: %v", err)
 	}
 
 	return data, nil

--- a/rhc_connection_handlers.go
+++ b/rhc_connection_handlers.go
@@ -82,7 +82,7 @@ func RhcConnectionCreate(c echo.Context) error {
 
 	err := service.ValidateRhcConnectionRequest(input)
 	if err != nil {
-		return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %s", err.Error()))
+		return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %v", err))
 	}
 
 	rhcConnection := &model.RhcConnection{

--- a/service/notifications.go
+++ b/service/notifications.go
@@ -106,7 +106,7 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(i
 	})
 
 	if err != nil {
-		l.Log.Warnf("Failed to add struct value as json to kafka message: %s", err.Error())
+		l.Log.Warnf("Failed to add struct value as json to kafka message: %v", err)
 		return err
 	}
 

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -103,7 +103,7 @@ func SourceCreate(c echo.Context) error {
 
 	err = service.ValidateSourceCreationRequest(sourcesDB, input)
 	if err != nil {
-		return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %s", err.Error()))
+		return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %v", err))
 	}
 
 	source := &m.Source{

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -48,7 +48,7 @@ func LoadJSONContentFrom(resourceType string, resourceID string, prefix string) 
 	fileContent, err := os.ReadFile(fileName)
 
 	if err != nil {
-		panic(fmt.Errorf("unable to read file %s because of %s", fileName, err.Error()))
+		panic(fmt.Errorf("unable to read file %s because of %v", fileName, err))
 	}
 
 	return fileContent
@@ -378,7 +378,7 @@ func (streamProducerSender *MockEventStreamSender) RaiseEvent(eventType string, 
 	}
 
 	if err != nil {
-		streamProducerSender.TestSuite.Errorf("error with parsing JSON: %s", err.Error())
+		streamProducerSender.TestSuite.Errorf("error with parsing JSON: %v", err)
 	}
 
 	return err


### PR DESCRIPTION
without JIRA ticket

just want to fix/improve format of err in strings from:
```
return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %s", err.Error()))
```
to:
```
return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %v", err))
```