### PR TITLE
Pass RequestParams to Get[Application|Authentication]Dao calls in GetFromResourceType

### DIFF
--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -189,7 +189,6 @@ func (a *applicationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttr
 		return nil, fmt.Errorf("application not found %v", resource)
 	}
 
-	a.TenantID = &resource.TenantID
 	application, err := a.GetByIdWithPreload(&resource.ResourceID, "Source")
 	if err != nil {
 		return nil, err

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -556,7 +556,6 @@ func (a *authenticationDaoImpl) BulkMessage(resource util.Resource) (map[string]
 }
 
 func (a *authenticationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) (interface{}, error) {
-	a.TenantID = &resource.TenantID
 	authentication, err := a.GetById(resource.ResourceUID)
 	if err != nil {
 		return nil, err

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -375,7 +375,6 @@ func (add *authenticationDaoDbImpl) BulkMessage(resource util.Resource) (map[str
 }
 
 func (add *authenticationDaoDbImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) (interface{}, error) {
-	add.TenantID = &resource.TenantID
 	authentication, err := add.GetById(resource.ResourceUID)
 	if err != nil {
 		return nil, err

--- a/dao/common.go
+++ b/dao/common.go
@@ -23,7 +23,7 @@ func GetFromResourceType(resourceType string, tenantID int64) (m.EventModelDao, 
 	case "application":
 		resource = GetApplicationDao(&RequestParams{TenantID: &tenantID})
 	case "authentication":
-		resource = GetAuthenticationDao(nil)
+		resource = GetAuthenticationDao(&RequestParams{TenantID: &tenantID})
 	default:
 		return nil, fmt.Errorf("invalid resource_type (%s) to get DAO instance", resourceType)
 	}

--- a/dao/common.go
+++ b/dao/common.go
@@ -21,7 +21,7 @@ func GetFromResourceType(resourceType string, tenantID int64) (m.EventModelDao, 
 	case "endpoint":
 		resource = GetEndpointDao(nil)
 	case "application":
-		resource = GetApplicationDao(nil)
+		resource = GetApplicationDao(&RequestParams{TenantID: &tenantID})
 	case "authentication":
 		resource = GetAuthenticationDao(nil)
 	default:


### PR DESCRIPTION
- similar to https://github.com/RedHatInsights/sources-api-go/pull/445

Pass RequestParams with tenant id to GetApplicationDao  and GetAuthentication Dao calls in GetFromResourceType and thanks that
applicationDao and authenticationDao is instantiated correctly and we don't need to populate tenant id later.


### Links
https://github.com/RedHatInsights/sources-api-go/issues/356

