### PR TITLE
Add user based filtering for ApplicationAuthenticationDAO struct

### DIFF
--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -43,7 +43,14 @@ func (a applicationAuthenticationDaoImpl) getDb() *gorm.DB {
 		panic("nil tenant found in applicationAuthentication db DAO")
 	}
 
-	return DB.Debug()
+	query := DB.Debug()
+	query = query.Where("tenant_id = ?", a.TenantID)
+
+	if a.UserID != nil {
+		query = query.Where("user_id IS NULL OR user_id = ?", a.UserID)
+	}
+
+	return query
 }
 
 func (a applicationAuthenticationDaoImpl) getDbWithModel() *gorm.DB {

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -48,6 +48,8 @@ func (a applicationAuthenticationDaoImpl) getDb() *gorm.DB {
 
 	if a.UserID != nil {
 		query = query.Where("user_id IS NULL OR user_id = ?", a.UserID)
+	} else {
+		query = query.Where("user_id IS NULL")
 	}
 
 	return query

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -6,6 +6,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/config"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
@@ -37,6 +38,18 @@ type applicationAuthenticationDaoImpl struct {
 	UserID   *int64
 }
 
+func (a applicationAuthenticationDaoImpl) getDb() *gorm.DB {
+	if a.TenantID == nil {
+		panic("nil tenant found in applicationAuthentication db DAO")
+	}
+
+	return DB.Debug()
+}
+
+func (a applicationAuthenticationDaoImpl) getDbWithModel() *gorm.DB {
+	return a.getDb().Model(&m.ApplicationAuthentication{})
+}
+
 func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplications(applications []m.Application) ([]m.ApplicationAuthentication, error) {
 	var applicationAuthentications []m.ApplicationAuthentication
 
@@ -45,8 +58,7 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplicati
 		applicationIDs = append(applicationIDs, value.ID)
 	}
 
-	err := DB.
-		Debug().
+	err := a.getDb().
 		Preload("Tenant").
 		Where("application_id IN ?", applicationIDs).
 		Where("tenant_id = ?", a.TenantID).
@@ -63,9 +75,7 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplicati
 func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByAuthentications(authentications []m.Authentication) ([]m.ApplicationAuthentication, error) {
 	var applicationAuthentications []m.ApplicationAuthentication
 
-	query := DB.
-		Debug().
-		Preload("Tenant")
+	query := a.getDb().Preload("Tenant")
 
 	if config.IsVaultOn() {
 		authUuids := make([]string, len(authentications))
@@ -107,9 +117,7 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByResource(
 
 func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
 	appAuths := make([]m.ApplicationAuthentication, 0, limit)
-	query := DB.Debug().
-		Model(&m.ApplicationAuthentication{}).
-		Where("tenant_id = ?", a.TenantID)
+	query := a.getDbWithModel().Where("tenant_id = ?", a.TenantID)
 
 	query, err := applyFilters(query, filters)
 	if err != nil {
@@ -129,10 +137,8 @@ func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 func (a *applicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAuthentication, error) {
 	var appAuth m.ApplicationAuthentication
 
-	err := DB.Debug().
-		Model(&m.ApplicationAuthentication{}).
+	err := a.getDbWithModel().
 		Where("id = ?", *id).
-		Where("tenant_id = ?", a.TenantID).
 		First(&appAuth).
 		Error
 
@@ -153,15 +159,14 @@ func (a *applicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthenti
 }
 
 func (a *applicationAuthenticationDaoImpl) Update(appAuth *m.ApplicationAuthentication) error {
-	result := DB.Debug().Updates(appAuth)
+	result := a.getDb().Updates(appAuth)
 	return result.Error
 }
 
 func (a *applicationAuthenticationDaoImpl) Delete(id *int64) (*m.ApplicationAuthentication, error) {
 	var applicationAuthentication m.ApplicationAuthentication
 
-	result := DB.
-		Debug().
+	result := a.getDb().
 		Clauses(clause.Returning{}).
 		Where("id = ?", id).
 		Where("tenant_id = ?", a.TenantID).

--- a/dao/test_factories.go
+++ b/dao/test_factories.go
@@ -1,0 +1,134 @@
+package dao
+
+import (
+	"fmt"
+
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/google/uuid"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+func CreateTenantForAccountNumber(accountNumber string) (*int64, error) {
+	identityStruct := identity.Identity{
+		AccountNumber: accountNumber,
+	}
+
+	tenantDao := GetTenantDao()
+	tenantID, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	if err != nil {
+		return nil, fmt.Errorf("error getting or creating the tenant")
+	}
+
+	return &tenantID, nil
+}
+
+func CreateUserForUserID(userIDFromHeader string, tenantID int64) (*m.User, error) {
+	userDao := GetUserDao(&tenantID)
+	user, err := userDao.FindOrCreate(userIDFromHeader)
+	if err != nil {
+		return nil, fmt.Errorf("error getting or creating the user")
+	}
+
+	return user, nil
+}
+
+func CreateSource(sourceTypeID int64, tenantID int64, userID *int64) (*m.Source, error) {
+	uid := uuid.New().String()
+	name := uuid.New().String()
+	source := &m.Source{Name: name, UserID: userID, SourceTypeID: sourceTypeID, Uid: &uid}
+	requestParamsForCreate := &RequestParams{TenantID: &tenantID, UserID: userID}
+	sourceDaoForCreate := GetSourceDao(requestParamsForCreate)
+	err := sourceDaoForCreate.Create(source)
+	if err != nil {
+		return nil, fmt.Errorf("error creating the source")
+	}
+
+	return source, err
+}
+
+func CreateApplication(sourceID int64, applicationTypeID int64, tenantID int64, userID *int64) (*m.Application, error) {
+	app := &m.Application{UserID: userID, ApplicationTypeID: applicationTypeID, SourceID: sourceID}
+	requestParamsForCreate := &RequestParams{TenantID: &tenantID, UserID: userID}
+	appDaoForCreate := GetApplicationDao(requestParamsForCreate)
+	err := appDaoForCreate.Create(app)
+	if err != nil {
+		return nil, fmt.Errorf("error creating the application")
+	}
+
+	return app, err
+}
+
+func CreateAuthenticationFromApplication(appID int64, tenantID int64, userID *int64) (*m.Authentication, error) {
+	name := uuid.New().String()
+	auth := &m.Authentication{Name: &name, UserID: userID, ResourceType: "Application", ResourceID: appID}
+	requestParamsForCreate := &RequestParams{TenantID: &tenantID, UserID: userID}
+	authDaoForCreate := GetAuthenticationDao(requestParamsForCreate)
+	err := authDaoForCreate.Create(auth)
+	if err != nil {
+		return nil, fmt.Errorf("error creating the application")
+	}
+
+	return auth, err
+}
+
+func CreateApplicationAuthentication(authID int64, appID int64, hello int64, userID *int64) (*m.ApplicationAuthentication, error) {
+	aa := &m.ApplicationAuthentication{UserID: userID, ApplicationID: appID, AuthenticationID: authID}
+	requestParamsForCreate := &RequestParams{TenantID: &hello, UserID: userID}
+	appAuthDaoForCreate := GetApplicationAuthenticationDao(requestParamsForCreate)
+	err := appAuthDaoForCreate.Create(aa)
+	if err != nil {
+		return nil, fmt.Errorf("error creating the application")
+	}
+
+	return aa, err
+}
+
+func CreateSourceWithSubResources(sourceTypeID int64, applicationTypeID int64, accountNumber string, userIDFromHeader *string) (*m.BulkCreateOutput, *m.User, error) {
+	var bulkCreateOutput m.BulkCreateOutput
+
+	tenantID, err := CreateTenantForAccountNumber(accountNumber)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var userID *int64
+	var user *m.User
+
+	if userIDFromHeader != nil {
+		user, err = CreateUserForUserID(*userIDFromHeader, *tenantID)
+		if err != nil {
+			return nil, nil, err
+		}
+		userID = &user.Id
+	}
+
+	source, err := CreateSource(sourceTypeID, *tenantID, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bulkCreateOutput.Sources = []m.Source{*source}
+
+	app, err := CreateApplication(source.ID, applicationTypeID, *tenantID, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bulkCreateOutput.Applications = []m.Application{*app}
+
+	auth, err := CreateAuthenticationFromApplication(app.ID, *tenantID, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bulkCreateOutput.Authentications = []m.Authentication{*auth}
+
+	aa, err := CreateApplicationAuthentication(auth.DbID, app.ID, *tenantID, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bulkCreateOutput.ApplicationAuthentications = []m.ApplicationAuthentication{*aa}
+
+	return &bulkCreateOutput, user, nil
+}

--- a/internal/testutils/fixtures/tenant.go
+++ b/internal/testutils/fixtures/tenant.go
@@ -1,6 +1,8 @@
 package fixtures
 
-import m "github.com/RedHatInsights/sources-api-go/model"
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
 
 var NotExistingTenantId = int64(309832948930)
 


### PR DESCRIPTION
- Extract DB.Debug() to func in ApplicationAuthentication Dao struct
- Move tenancy condition to getDB()
- Add user filtering to applicationAuthenticationDAO

Reason why  getDb has parameter is that statement `.Model(&m.ApplicationAuthentication{}).` doesn't work for some usages like DB.Debug().Updates(...) - so it is reason why I leave it optional.

### Links

- issue: https://github.com/RedHatInsights/sources-api-go/issues/356