### PR TITLE
[RHCLOUD-20565] feature: return "OrgId" when internally listing the sources

### DIFF
--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -95,7 +95,7 @@ func (s *sourceDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.Sour
 func (s *sourceDaoImpl) ListInternal(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	query := DB.Debug().
 		Model(&m.Source{}).
-		Select(`sources.id, sources.availability_status, "Tenant".external_tenant`)
+		Select(`sources.id, sources.availability_status, "Tenant".external_tenant, "Tenant".org_id`)
 
 	query, err := applyFilters(query, filters)
 	if err != nil {

--- a/internal_handlers_test.go
+++ b/internal_handlers_test.go
@@ -67,6 +67,7 @@ func TestSourceListInternal(t *testing.T) {
 		}
 
 		responseExternalTenant := s["tenant"].(string)
+		responseOrgId := s["org_id"].(string)
 		responseAvailabilityStatus := s["availability_status"].(string)
 
 		// Check that the expected source data and the received data are the same
@@ -76,6 +77,10 @@ func TestSourceListInternal(t *testing.T) {
 
 		if want := fixtures.TestTenantData[0].ExternalTenant; want != responseExternalTenant {
 			t.Errorf("Tenants don't match. Want %#v, got %#v", want, responseExternalTenant)
+		}
+
+		if want := fixtures.TestTenantData[0].OrgID; want != responseOrgId {
+			t.Errorf("Org Ids don't match. Want %#v, got %#v", want, responseOrgId)
 		}
 
 		if want := fixtures.TestSourceData[i].AvailabilityStatus; want != responseAvailabilityStatus {

--- a/model/source.go
+++ b/model/source.go
@@ -101,6 +101,7 @@ func (src *Source) ToInternalResponse() *SourceInternalResponse {
 		Id:                 &id,
 		AvailabilityStatus: &src.AvailabilityStatus,
 		ExternalTenant:     &src.Tenant.ExternalTenant,
+		OrgId:              &src.Tenant.OrgID,
 	}
 
 	return source

--- a/model/source_http.go
+++ b/model/source_http.go
@@ -72,6 +72,7 @@ type SourceInternalResponse struct {
 	Id                 *string `json:"id"`
 	AvailabilityStatus *string `json:"availability_status"`
 	ExternalTenant     *string `json:"tenant"`
+	OrgId              *string `json:"org_id"`
 }
 
 func (src *Source) UpdateFromRequest(update *SourceEditRequest) {


### PR DESCRIPTION
The "sources monitor" will start using "OrgId"s for availability status
checks, and for that to work, it also needs to retrieve those "OrgId"s
when fetching the sources internally.

## Links

[[RHCLOUD-20565]](https://issues.redhat.com/browse/RHCLOUD-20565)