### PR TITLE
[RHCLOUD-19924] Change sql query in GetByName methods in app_type/source_type dao

### DIFF
--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -112,7 +112,6 @@ func (at *applicationTypeDaoImpl) GetByName(name string) (*m.ApplicationType, er
 		return nil, util.NewErrNotFound("application type")
 	}
 	return &appTypes[0], nil
-
 }
 
 func (at *applicationTypeDaoImpl) Create(_ *m.ApplicationType) error {

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -98,13 +98,21 @@ func (at *applicationTypeDaoImpl) GetById(id *int64) (*m.ApplicationType, error)
 }
 
 func (at *applicationTypeDaoImpl) GetByName(name string) (*m.ApplicationType, error) {
-	appType := &m.ApplicationType{}
-	result := DB.Debug().Where("name LIKE ?", "%"+name+"%").First(&appType)
+	appTypes := make([]m.ApplicationType, 0)
+	result := DB.Debug().
+		Where("name LIKE ?", "%"+name+"%").
+		Find(&appTypes)
+
 	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected > int64(1) {
+		return nil, util.NewErrBadRequest("Found more than one of the same application type name")
+	} else if result.RowsAffected == int64(0) {
 		return nil, util.NewErrNotFound("application type")
 	}
+	return &appTypes[0], nil
 
-	return appType, nil
 }
 
 func (at *applicationTypeDaoImpl) Create(_ *m.ApplicationType) error {

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -91,11 +91,10 @@ func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
 func TestApplicationTypeGetByName(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("app_type_by_name")
-	wantAppType := fixtures.TestApplicationTypeData[0]
+	wantAppType := fixtures.TestApplicationTypeData[1]
 
 	tenantId := int64(1)
 	appTypeDao := GetApplicationTypeDao(&tenantId)
-
 	gotAppType, err := appTypeDao.GetByName(wantAppType.Name)
 	if err != nil {
 		t.Error(err)
@@ -123,6 +122,24 @@ func TestApplicationTypeGetByNameNotFound(t *testing.T) {
 
 	if !errors.Is(err, util.ErrNotFoundEmpty) {
 		t.Errorf("want not found err, got '%v'", err)
+	}
+
+	DropSchema("app_type_by_name")
+}
+func TestApplicationTypeGetByNameBadRequest(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_type_by_name")
+	wantAppType := m.ApplicationType{Name: "app type"}
+	tenantId := int64(1)
+	appTypeDao := GetApplicationTypeDao(&tenantId)
+
+	gotAppType, err := appTypeDao.GetByName(wantAppType.Name)
+	if gotAppType != nil {
+		t.Error("got application type object, want nil")
+	}
+
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("want bad request err, got '%v'", err)
 	}
 
 	DropSchema("app_type_by_name")

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -63,12 +63,20 @@ func (st *sourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
 }
 
 func (st *sourceTypeDaoImpl) GetByName(name string) (*m.SourceType, error) {
-	sourceType := &m.SourceType{}
-	result := DB.Debug().Where("name LIKE ?", "%"+name+"%").First(sourceType)
+	sourceTypes := make([]m.SourceType, 0)
+	result := DB.Debug().
+		Where("name LIKE ?", "%"+name+"%").
+		Find(&sourceTypes)
+
 	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected > int64(1) {
+		return nil, util.NewErrBadRequest("Found more than one of the same source type name")
+	} else if result.RowsAffected == int64(0) {
 		return nil, util.NewErrNotFound("source type")
 	}
-	return sourceType, nil
+	return &sourceTypes[0], nil
 }
 
 func (st *sourceTypeDaoImpl) Create(_ *m.SourceType) error {

--- a/dao/source_type_dao_test.go
+++ b/dao/source_type_dao_test.go
@@ -80,23 +80,6 @@ func TestSourceTypeGetByNameNotFound(t *testing.T) {
 
 	DropSchema("source_type_by_name")
 }
-func TestSourceTypeGetByDifferentName(t *testing.T) {
-	testutils.SkipIfNotRunningIntegrationTests(t)
-	SwitchSchema("source_type_by_name")
-	wantSourceType := m.SourceType{Name: "amazon"}
-
-	sourceTypeDao := GetSourceTypeDao()
-	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
-	if gotSourceType != nil {
-		t.Error("got source type object, want nil")
-	}
-
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
-		t.Errorf("want bad request err, got '%v'", err)
-	}
-
-	DropSchema("source_type_by_name")
-}
 
 func TestSourceTypeGetByNameBadRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)

--- a/dao/source_type_dao_test.go
+++ b/dao/source_type_dao_test.go
@@ -48,7 +48,7 @@ func TestSourceTypeListOffsetAndLimit(t *testing.T) {
 func TestSourceTypeGetByName(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("source_type_by_name")
-	wantSourceType := fixtures.TestSourceTypeData[0]
+	wantSourceType := fixtures.TestSourceTypeData[1]
 
 	sourceTypeDao := GetSourceTypeDao()
 	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
@@ -76,6 +76,41 @@ func TestSourceTypeGetByNameNotFound(t *testing.T) {
 
 	if !errors.Is(err, util.ErrNotFoundEmpty) {
 		t.Errorf("want not found err, got '%v'", err)
+	}
+
+	DropSchema("source_type_by_name")
+}
+func TestSourceTypeGetByDifferentName(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("source_type_by_name")
+	wantSourceType := m.SourceType{Name: "amazon"}
+
+	sourceTypeDao := GetSourceTypeDao()
+	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
+	if gotSourceType != nil {
+		t.Error("got source type object, want nil")
+	}
+
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("want bad request err, got '%v'", err)
+	}
+
+	DropSchema("source_type_by_name")
+}
+
+func TestSourceTypeGetByNameBadRequest(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("source_type_by_name")
+	wantSourceType := m.SourceType{Name: "amazon"}
+
+	sourceTypeDao := GetSourceTypeDao()
+	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
+	if gotSourceType != nil {
+		t.Error("got source type object, want nil")
+	}
+
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("want bad request err, got '%v'", err)
 	}
 
 	DropSchema("source_type_by_name")

--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -18,6 +18,11 @@ var TestApplicationTypeData = []m.ApplicationType{
 		DisplayName: "second test app type",
 	},
 	{
+		Id:          5,
+		Name:        "app type one123",
+		DisplayName: "test app type",
+	},
+	{
 		Id:          100,
 		DisplayName: "app type without related sources",
 	},

--- a/internal/testutils/fixtures/source_type.go
+++ b/internal/testutils/fixtures/source_type.go
@@ -16,6 +16,10 @@ var TestSourceTypeData = []m.SourceType{
 		Name: "bitbucket",
 	},
 	{
+		Id:   4,
+		Name: "amazon123",
+	},
+	{
 		Id:   100,
 		Name: "source type without sources in fixtures",
 	},


### PR DESCRIPTION
What: Within source_type_dao.go and application_type_dao.go, changed the sql query in GetByName methods and return a bad request error if more than one application type or source type name is found. 
Why: in certain cases the desired app or source type may not be selected if there are multiple rows with the same name. 

JIRA: [RHCLOUD-19924](https://issues.redhat.com/browse/RHCLOUD-19924)