### PR TITLE
Ensure statuslistener is listening on the clowder-provided topic

### DIFF
--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -17,19 +17,22 @@ import (
 )
 
 const (
-	sourcesStatusTopic      = "platform.sources.status"
-	groupID                 = "sources-api-status-worker"
-	eventAvailabilityStatus = "availability_status"
+	sourcesStatusRequestedTopic = "platform.sources.status"
+	groupID                     = "sources-api-status-worker"
+	eventAvailabilityStatus     = "availability_status"
 )
 
-var config = c.Get()
+var (
+	config             = c.Get()
+	sourcesStatusTopic = config.KafkaTopic(sourcesStatusRequestedTopic)
+)
 
 type AvailabilityStatusListener struct {
 	*events.EventStreamProducer
 }
 
 func Run(shutdown chan struct{}) {
-	l.Log.Infof("Starting Availability Status Listener on topic [%v]", config.KafkaTopic(sourcesStatusTopic))
+	l.Log.Infof("Starting Availability Status Listener on topic [%v]", sourcesStatusTopic)
 
 	avs := AvailabilityStatusListener{EventStreamProducer: NewEventStreamProducer()}
 	avs.subscribeToAvailabilityStatus(shutdown)


### PR DESCRIPTION
So after doing some more testing today it appeared the producers were working fine from sources-api (event-stream, satellite operations) and the satellite consumer was working, but both of our consumers were not working for superkey or availability status.

for the availability status listener I think I found the culprit - the log message showed the right topic but the actual reader was reading the requested one not the actual topic, so this should fix that. 