### PR TITLE
[RHCLOUD-20569] Authentication handlers tests update 2

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -257,6 +257,32 @@ func TestAuthenticationGet(t *testing.T) {
 	conf.SecretStore = originalSecretStore
 }
 
+func TestAuthenticationGetTenantNotExist(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := fixtures.NotExistingTenantId
+	uid := strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/authentications/"+uid,
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("uid")
+	c.SetParamValues(uid)
+
+	notFoundAuthenticationGet := ErrorHandlingContext(AuthenticationGet)
+	err := notFoundAuthenticationGet(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestAuthenticationGetNotFound(t *testing.T) {
 	uid := "abcdefg"
 

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -235,6 +235,23 @@ func TestAuthenticationGet(t *testing.T) {
 		if outAuthentication.ID != id {
 			t.Errorf(`wrong authentication fetched. Want "%s", got "%s"`, id, outAuthentication.ID)
 		}
+
+		// Check the tenancy of returned authentication
+		for _, a := range fixtures.TestAuthenticationData {
+			var fixturesAuthId string
+			if config.IsVaultOn() {
+				fixturesAuthId = a.ID
+			} else {
+				fixturesAuthId = strconv.FormatInt(a.DbID, 10)
+			}
+
+			if fixturesAuthId == id {
+				if a.TenantID != tenantId {
+					t.Error("ghosts infected the return")
+				}
+				break
+			}
+		}
 	}
 
 	conf.SecretStore = originalSecretStore


### PR DESCRIPTION
authentication handlers tests update PART II.
(part I. #465)

for handler:
- AuthenticationGet()

tests update for other handlers will be covered in next PR

main goal is to check the tenancy and add missing tests

I am avare about the TestAuthenticationGet() is updated to be working with secret store vault and database and rest of tests not -> I believe we can update all the authentication tests after we will know if we will support the Vault

**JIRA:** [RHCLOUD-20569](https://issues.redhat.com/browse/RHCLOUD-20569)