### PR TITLE
[RHCLOUD-20569] Authentication handlers tests update 3

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/RedHatInsights/sources-api-go/dao"
-	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"io"
 	"net/http"
 	"strconv"
@@ -13,9 +11,11 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/mocks"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	"github.com/RedHatInsights/sources-api-go/middleware"
@@ -393,14 +393,12 @@ func TestAuthenticationCreate(t *testing.T) {
 	}
 }
 
-func TestAuthenticationCreateBadRequest(t *testing.T) {
+func TestAuthenticationCreateBadRequestInvalidResourceType(t *testing.T) {
 	requestBody := m.AuthenticationCreateRequest{
-		Name:         util.StringRef("TestRequest"),
-		AuthType:     "test",
-		Username:     util.StringRef("testUser"),
-		Password:     util.StringRef("123456"),
-		ResourceType: "InvalidType",
-		ResourceID:   1,
+		Username:      util.StringRef("testUser"),
+		Password:      util.StringRef("123456"),
+		ResourceType:  "InvalidType",
+		ResourceIDRaw: 1,
 	}
 
 	body, err := json.Marshal(requestBody)


### PR DESCRIPTION
authentication handlers tests update PART III.
(part I. #465, part II. #471)

for handler:
- AuthenticationCreate()

tests update for other handlers will be covered in next PR

main goal is to check the tenancy and add missing tests

**JIRA:** [RHCLOUD-20569](https://issues.redhat.com/browse/RHCLOUD-20569)