### PR TITLE
Ensure event-stream/superkey-requests producers are using clowder-provided topic

### DIFF
--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -10,9 +10,12 @@ import (
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
-const EventStreamTopic = "platform.sources.event-stream"
+const eventStreamRequestedTopic = "platform.sources.event-stream"
 
-var config = c.Get()
+var (
+	config           = c.Get()
+	eventStreamTopic = config.KafkaTopic(eventStreamRequestedTopic)
+)
 
 type EventStreamProducer struct {
 	Sender
@@ -26,9 +29,9 @@ type EventStreamSender struct {
 }
 
 func (esp *EventStreamSender) RaiseEvent(eventType string, payload []byte, headers []kafka.Header) error {
-	logging.Log.Debugf("publishing message %v to topic %q...", eventType, EventStreamTopic)
+	logging.Log.Debugf("publishing message %v to topic %q...", eventType, eventStreamTopic)
 
-	kf, err := kafka.GetWriter(&config.KafkaBrokerConfig, EventStreamTopic)
+	kf, err := kafka.GetWriter(&config.KafkaBrokerConfig, eventStreamTopic)
 	if err != nil {
 		return fmt.Errorf(`unable to create a Kafka writer to raise an event: %w`, err)
 	}
@@ -51,7 +54,7 @@ func (esp *EventStreamSender) RaiseEvent(eventType string, payload []byte, heade
 		return err
 	}
 
-	logging.Log.Debugf("publishing message %v to topic %q...Complete", eventType, EventStreamTopic)
+	logging.Log.Debugf("publishing message %v to topic %q...Complete", eventType, eventStreamTopic)
 
 	return nil
 }

--- a/service/superkey.go
+++ b/service/superkey.go
@@ -12,7 +12,9 @@ import (
 	"github.com/redhatinsights/sources-superkey-worker/superkey"
 )
 
-const SUPERKEY_REQUEST_QUEUE = "platform.sources.superkey-requests"
+const superkeyRequestedTopic = "platform.sources.superkey-requests"
+
+var superkeyTopic = config.Get().KafkaTopic(superkeyRequestedTopic)
 
 func SendSuperKeyCreateRequest(application *m.Application, headers []kafka.Header) error {
 	// load up the app + associations from the db+vault
@@ -129,7 +131,7 @@ func SendSuperKeyDeleteRequest(application *m.Application, headers []kafka.Heade
 }
 
 func produceSuperkeyRequest(m *kafka.Message) error {
-	writer, err := kafka.GetWriter(&conf.KafkaBrokerConfig, SUPERKEY_REQUEST_QUEUE)
+	writer, err := kafka.GetWriter(&conf.KafkaBrokerConfig, superkeyTopic)
 	if err != nil {
 		return fmt.Errorf(`unable to create a Kafka writer to produce a superkey request: %w`, err)
 	}


### PR DESCRIPTION
Extremely similar to #468, it's way too easy to not use the actual name rather than the requested name. Whoops!

At least this explains why the superkey worker was probably listening on the right topic but we just weren't producing to it. For the event stream it appears those were going on the wrong topic as well during the test.