### PR TITLE
[RHCLOUD-20638] Add check if source exists into authentication create method for resource type = source

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -425,6 +425,46 @@ func TestAuthenticationCreateBadRequestInvalidResourceType(t *testing.T) {
 	templates.BadRequestTest(t, rec)
 }
 
+// TestAuthenticationCreateResourceNotFound tests that bad request is returned when
+// you try to create authentication for not existing resource
+func TestAuthenticationCreateResourceNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(1)
+
+	for _, resourceType := range []string{"Application", "Endpoint", "Source"} {
+
+		requestBody := m.AuthenticationCreateRequest{
+			Username:      util.StringRef("testUser"),
+			Password:      util.StringRef("123456"),
+			ResourceType:  resourceType,
+			ResourceIDRaw: 54321,
+		}
+
+		body, err := json.Marshal(requestBody)
+		if err != nil {
+			t.Error("Could not marshal JSON")
+		}
+
+		c, rec := request.CreateTestContext(
+			http.MethodPost,
+			"/api/sources/v3.1/authentications",
+			bytes.NewReader(body),
+			map[string]interface{}{
+				"tenantID": tenantId,
+			},
+		)
+		c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+
+		badRequestAuthenticationCreate := ErrorHandlingContext(AuthenticationCreate)
+		err = badRequestAuthenticationCreate(c)
+		if err != nil {
+			t.Error(err)
+		}
+
+		templates.BadRequestTest(t, rec)
+	}
+}
+
 func TestAuthenticationEdit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -256,7 +256,6 @@ func (add *authenticationDaoDbImpl) ListForEndpoint(endpointID int64, limit, off
 
 func (add *authenticationDaoDbImpl) Create(authentication *m.Authentication) error {
 	query := DB.Debug().
-		Select("source_id").
 		Where("tenant_id = ?", *add.TenantID)
 
 	switch strings.ToLower(authentication.ResourceType) {
@@ -287,6 +286,17 @@ func (add *authenticationDaoDbImpl) Create(authentication *m.Authentication) err
 
 		authentication.SourceID = endpoint.SourceID
 	case "source":
+		var source m.Source
+		err := query.
+			Model(&m.Source{}).
+			Where("id = ?", authentication.ResourceID).
+			First(&source).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("resource not found with type [%v], id [%v]", authentication.ResourceType, authentication.ResourceID)
+		}
+
 		authentication.SourceID = authentication.ResourceID
 	default:
 		return fmt.Errorf("bad resource type, supported types are [Application, Endpoint, Source]")


### PR DESCRIPTION
when we create new authentication for resource type = source, we need to check if the given source exists and if not, then we should return bad request (bad source id was provided)

until now it was possible to create an authentication with resource type = source even if the source didn't exist

for resource type = endpoint and application this works correctly

**JIRA:** [RHCLOUD-20638](https://issues.redhat.com/browse/RHCLOUD-20638)