### PR TITLE
Always store account number + orgID on context

### DIFF
--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -55,6 +55,10 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			// store the parsed header for later usage.
 			c.Set(h.PARSED_IDENTITY, xRhIdentity)
 
+			// store the account number + org_id for easy usage later
+			c.Set(h.ACCOUNT_NUMBER, xRhIdentity.Identity.AccountNumber)
+			c.Set(h.ORGID, xRhIdentity.Identity.OrgID)
+
 			// store whether or not this a cert-auth based request
 			if xRhIdentity.Identity.System.CommonName != "" {
 				c.Set("cert-auth", true)

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -26,9 +26,9 @@ func TestParseAll(t *testing.T) {
 
 	c.Request().Header.Set(h.XRHID, xrhid)
 	c.Request().Header.Set(h.PSK, "1234")
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "1a2b3c4d5e")
+	c.Request().Header.Set(h.ACCOUNT_NUMBER, emptyIdentity.Identity.AccountNumber)
 	c.Request().Header.Set(h.PSK_USER, "55555")
-	c.Request().Header.Set(h.ORGID, "abcde")
+	c.Request().Header.Set(h.ORGID, emptyIdentity.Identity.OrgID)
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -43,15 +43,15 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get(h.PSK).(string), "1234")
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "1a2b3c4d5e" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+	if c.Get(h.ACCOUNT_NUMBER).(string) != "12345" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "12345")
 	}
 
 	if c.Get(h.PSK_USER).(string) != "55555" {
 		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "55555")
 	}
 
-	if c.Get(h.ORGID).(string) != "abcde" {
+	if c.Get(h.ORGID).(string) != "23456" {
 		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.ORGID).(string))
 	}
 

--- a/middleware/main_test.go
+++ b/middleware/main_test.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	xrhid         string
-	emptyIdentity = identity.XRHID{Identity: identity.Identity{AccountNumber: "12345"}}
+	emptyIdentity = identity.XRHID{Identity: identity.Identity{AccountNumber: "12345", OrgID: "23456"}}
 )
 
 func TestMain(t *testing.M) {


### PR DESCRIPTION
Followup to #455, I thought we were already doing this so that was a bad assumption on my part. 

This way we always have those fields on the context no matter what. 