### PR TITLE
Pass Request Context to all DAO Impl's

### DIFF
--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/RedHatInsights/sources-api-go/config"
@@ -17,14 +18,17 @@ var GetApplicationAuthenticationDao func(*RequestParams) ApplicationAuthenticati
 // getDefaultApplicationAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultApplicationAuthenticationDao(daoParams *RequestParams) ApplicationAuthenticationDao {
 	var tenantID, userID *int64
+	var ctx context.Context
 	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
 		userID = daoParams.UserID
+		ctx = daoParams.ctx
 	}
 
 	return &applicationAuthenticationDaoImpl{
 		TenantID: tenantID,
 		UserID:   userID,
+		ctx:      ctx,
 	}
 }
 
@@ -36,6 +40,7 @@ func init() {
 type applicationAuthenticationDaoImpl struct {
 	TenantID *int64
 	UserID   *int64
+	ctx      context.Context
 }
 
 func (a applicationAuthenticationDaoImpl) getDb() *gorm.DB {
@@ -43,7 +48,7 @@ func (a applicationAuthenticationDaoImpl) getDb() *gorm.DB {
 		panic("nil tenant found in applicationAuthentication db DAO")
 	}
 
-	query := DB.Debug()
+	query := DB.Debug().WithContext(a.ctx)
 	query = query.Where("tenant_id = ?", a.TenantID)
 
 	if a.UserID != nil {

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -18,14 +19,17 @@ var GetApplicationDao func(*RequestParams) ApplicationDao
 // getDefaultApplicationAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultApplicationDao(daoParams *RequestParams) ApplicationDao {
 	var tenantID, userID *int64
+	var ctx context.Context
 	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
 		userID = daoParams.UserID
+		ctx = daoParams.ctx
 	}
 
 	return &applicationDaoImpl{
 		TenantID: tenantID,
 		UserID:   userID,
+		ctx:      ctx,
 	}
 }
 
@@ -37,6 +41,7 @@ func init() {
 type applicationDaoImpl struct {
 	TenantID *int64
 	UserID   *int64
+	ctx      context.Context
 }
 
 func (a *applicationDaoImpl) getDbWithTable(query *gorm.DB, table string) *gorm.DB {
@@ -71,7 +76,7 @@ func (a *applicationDaoImpl) useUserForDB(query *gorm.DB, table string) *gorm.DB
 }
 
 func (a *applicationDaoImpl) getDb() *gorm.DB {
-	return a.getDbWithTable(DB.Debug(), "")
+	return a.getDbWithTable(DB.Debug().WithContext(a.ctx), "")
 }
 
 func (a *applicationDaoImpl) getDbWithModel() *gorm.DB {

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,20 +31,24 @@ var GetAuthenticationDao func(daoParams *RequestParams) AuthenticationDao
 // getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultAuthenticationDao(daoParams *RequestParams) AuthenticationDao {
 	var tenantID, userID *int64
+	var ctx context.Context
 	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
 		userID = daoParams.UserID
+		ctx = daoParams.ctx
 	}
 
 	if config.IsVaultOn() {
 		return &authenticationDaoImpl{
 			TenantID: tenantID,
 			UserID:   userID,
+			ctx:      ctx,
 		}
 	} else {
 		return &authenticationDaoDbImpl{
 			TenantID: tenantID,
 			UserID:   userID,
+			ctx:      ctx,
 		}
 	}
 }
@@ -56,6 +61,7 @@ func init() {
 type authenticationDaoImpl struct {
 	TenantID *int64
 	UserID   *int64
+	ctx      context.Context
 }
 
 /*

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -13,6 +14,7 @@ import (
 type authenticationDaoDbImpl struct {
 	TenantID *int64
 	UserID   *int64
+	ctx      context.Context
 }
 
 func (add *authenticationDaoDbImpl) getDb() *gorm.DB {
@@ -20,7 +22,8 @@ func (add *authenticationDaoDbImpl) getDb() *gorm.DB {
 		panic("nil tenant found in sourceDaoImpl DAO")
 	}
 
-	query := DB.Debug().Where("tenant_id = ?", add.TenantID)
+	query := DB.Debug().WithContext(add.ctx)
+	query = query.Where("tenant_id = ?", add.TenantID)
 
 	if add.UserID != nil {
 		query = query.Where("user_id IS NULL OR user_id = ?", add.UserID)

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -1,6 +1,7 @@
 package dao
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -18,14 +19,17 @@ var GetSourceDao func(*RequestParams) SourceDao
 // getDefaultRhcConnectionDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultSourceDao(daoParams *RequestParams) SourceDao {
 	var tenantID, userID *int64
+	var ctx context.Context
 	if daoParams != nil && daoParams.TenantID != nil {
 		tenantID = daoParams.TenantID
 		userID = daoParams.UserID
+		ctx = daoParams.ctx
 	}
 
 	return &sourceDaoImpl{
 		TenantID: tenantID,
 		UserID:   userID,
+		ctx:      ctx,
 	}
 }
 
@@ -37,6 +41,7 @@ func init() {
 type sourceDaoImpl struct {
 	TenantID *int64
 	UserID   *int64
+	ctx      context.Context
 }
 
 func (s *sourceDaoImpl) getDbWithTable(query *gorm.DB, table string) *gorm.DB {
@@ -71,7 +76,7 @@ func (s *sourceDaoImpl) useUserForDB(query *gorm.DB, table string) *gorm.DB {
 }
 
 func (s *sourceDaoImpl) getDb() *gorm.DB {
-	return s.getDbWithTable(DB.Debug(), "")
+	return s.getDbWithTable(DB.Debug().WithContext(s.ctx), "")
 }
 
 func (s *sourceDaoImpl) getDbWithModel() *gorm.DB {


### PR DESCRIPTION
Followup to #455 after most if not all dao implementations have a `getDb()` method.

Passing the context through all of them which is already present on the requestParams struct. This is what will allow the gorm logger to pick up all the fields we pass along!