### PR TITLE
Move around middleware to try and make it a bit less duplicative

### DIFF
--- a/middleware/id_validation.go
+++ b/middleware/id_validation.go
@@ -18,7 +18,7 @@ var idValidationRegex = regexp.MustCompile(`^\d+$`)
 func IdValidation(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		for _, param := range c.ParamNames() {
-			if strings.HasSuffix(param, "id") {
+			if strings.HasSuffix(param, "id") && param != "uid" {
 				err := validateId(c, param)
 				if err != nil {
 					return util.NewErrBadRequest(err)

--- a/routes.go
+++ b/routes.go
@@ -11,12 +11,11 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-var listMiddleware = []echo.MiddlewareFunc{
-	middleware.SortAndFilter, middleware.Pagination,
-}
+var listMiddleware = []echo.MiddlewareFunc{middleware.SortAndFilter, middleware.Pagination}
+var tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.UserCatcher}
 
-var tenancyWithListMiddleware = append([]echo.MiddlewareFunc{middleware.Tenancy, middleware.UserCatcher}, listMiddleware...)
-var permissionMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.UserCatcher, middleware.PermissionCheck, middleware.RaiseEvent}
+var tenancyWithListMiddleware = append(tenancyMiddleware, listMiddleware...)
+var permissionMiddleware = append(tenancyMiddleware, []echo.MiddlewareFunc{middleware.PermissionCheck, middleware.RaiseEvent}...)
 var permissionWithListMiddleware = append(listMiddleware, middleware.PermissionCheck)
 
 func setupRoutes(e *echo.Echo) {
@@ -32,7 +31,7 @@ func setupRoutes(e *echo.Echo) {
 
 	apiVersions := []string{"v1.0", "v2.0", "v3.0", "v3.1", "v1", "v2", "v3"}
 	for _, version := range apiVersions {
-		r := e.Group("/api/sources/"+version, middleware.Timing, middleware.HandleErrors, middleware.ParseHeaders, middleware.LoggerFields)
+		r := e.Group("/api/sources/"+version, middleware.Timing, middleware.HandleErrors, middleware.IdValidation, middleware.ParseHeaders, middleware.LoggerFields)
 
 		// openapi
 		r.GET("/openapi.json", PublicOpenApi(version))
@@ -42,28 +41,28 @@ func setupRoutes(e *echo.Echo) {
 
 		// Sources
 		r.GET("/sources", SourceList, tenancyWithListMiddleware...)
-		r.GET("/sources/:id", SourceGet, middleware.Tenancy, middleware.UserCatcher, middleware.IdValidation)
+		r.GET("/sources/:id", SourceGet, middleware.Tenancy, middleware.UserCatcher)
 		r.POST("/sources", SourceCreate, permissionMiddleware...)
-		r.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
-		r.DELETE("/sources/:id", SourceDelete, append(permissionMiddleware, middleware.SuperKeyDestroySource, middleware.IdValidation)...)
-		r.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy, middleware.IdValidation)
-		r.GET("/sources/:source_id/application_types", SourceListApplicationTypes, append(tenancyWithListMiddleware, middleware.IdValidation)...)
-		r.GET("/sources/:source_id/applications", SourceListApplications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
-		r.GET("/sources/:source_id/endpoints", SourceListEndpoint, append(tenancyWithListMiddleware, middleware.IdValidation)...)
-		r.GET("/sources/:source_id/authentications", SourceListAuthentications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
-		r.GET("/sources/:source_id/rhc_connections", SourcesRhcConnectionList, append(tenancyWithListMiddleware, middleware.IdValidation)...)
-		r.POST("/sources/:source_id/pause", SourcePause, middleware.Tenancy, middleware.UserCatcher, middleware.IdValidation)
-		r.POST("/sources/:source_id/unpause", SourceUnpause, middleware.Tenancy, middleware.UserCatcher, middleware.IdValidation)
+		r.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.Notifier)...)
+		r.DELETE("/sources/:id", SourceDelete, append(permissionMiddleware, middleware.SuperKeyDestroySource)...)
+		r.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy)
+		r.GET("/sources/:source_id/application_types", SourceListApplicationTypes, tenancyWithListMiddleware...)
+		r.GET("/sources/:source_id/applications", SourceListApplications, tenancyWithListMiddleware...)
+		r.GET("/sources/:source_id/endpoints", SourceListEndpoint, tenancyWithListMiddleware...)
+		r.GET("/sources/:source_id/authentications", SourceListAuthentications, tenancyWithListMiddleware...)
+		r.GET("/sources/:source_id/rhc_connections", SourcesRhcConnectionList, tenancyWithListMiddleware...)
+		r.POST("/sources/:source_id/pause", SourcePause, middleware.Tenancy, middleware.UserCatcher)
+		r.POST("/sources/:source_id/unpause", SourceUnpause, middleware.Tenancy, middleware.UserCatcher)
 
 		// Applications
 		r.GET("/applications", ApplicationList, tenancyWithListMiddleware...)
-		r.GET("/applications/:id", ApplicationGet, middleware.Tenancy, middleware.UserCatcher, middleware.IdValidation)
+		r.GET("/applications/:id", ApplicationGet, middleware.Tenancy, middleware.UserCatcher)
 		r.POST("/applications", ApplicationCreate, permissionMiddleware...)
-		r.PATCH("/applications/:id", ApplicationEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
-		r.DELETE("/applications/:id", ApplicationDelete, append(permissionMiddleware, middleware.SuperKeyDestroyApplication, middleware.IdValidation)...)
-		r.GET("/applications/:application_id/authentications", ApplicationListAuthentications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
-		r.POST("/applications/:id/pause", ApplicationPause, middleware.Tenancy, middleware.UserCatcher, middleware.IdValidation)
-		r.POST("/applications/:id/unpause", ApplicationUnpause, middleware.Tenancy, middleware.UserCatcher, middleware.IdValidation)
+		r.PATCH("/applications/:id", ApplicationEdit, append(permissionMiddleware, middleware.Notifier)...)
+		r.DELETE("/applications/:id", ApplicationDelete, append(permissionMiddleware, middleware.SuperKeyDestroyApplication)...)
+		r.GET("/applications/:application_id/authentications", ApplicationListAuthentications, tenancyWithListMiddleware...)
+		r.POST("/applications/:id/pause", ApplicationPause, middleware.Tenancy, middleware.UserCatcher)
+		r.POST("/applications/:id/unpause", ApplicationUnpause, middleware.Tenancy, middleware.UserCatcher)
 
 		// Authentications
 		r.GET("/authentications", AuthenticationList, tenancyWithListMiddleware...)
@@ -73,48 +72,48 @@ func setupRoutes(e *echo.Echo) {
 			r.PATCH("/authentications/:uid", AuthenticationEdit, append(permissionMiddleware, middleware.Notifier, middleware.UuidValidation)...)
 			r.DELETE("/authentications/:uid", AuthenticationDelete, append(permissionMiddleware, middleware.UuidValidation)...)
 		} else {
-			r.GET("/authentications/:uid", AuthenticationGet, middleware.Tenancy, middleware.UserCatcher, middleware.IdValidation)
-			r.PATCH("/authentications/:uid", AuthenticationEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
-			r.DELETE("/authentications/:uid", AuthenticationDelete, append(permissionMiddleware, middleware.IdValidation)...)
+			r.GET("/authentications/:uid", AuthenticationGet, middleware.Tenancy, middleware.UserCatcher)
+			r.PATCH("/authentications/:uid", AuthenticationEdit, append(permissionMiddleware, middleware.Notifier)...)
+			r.DELETE("/authentications/:uid", AuthenticationDelete, permissionMiddleware...)
 		}
 
 		// ApplicationTypes
 		r.GET("/application_types", ApplicationTypeList, listMiddleware...)
-		r.GET("/application_types/:id", ApplicationTypeGet, middleware.IdValidation)
-		r.GET("/application_types/:application_type_id/sources", ApplicationTypeListSource, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.GET("/application_types/:id", ApplicationTypeGet)
+		r.GET("/application_types/:application_type_id/sources", ApplicationTypeListSource, tenancyWithListMiddleware...)
 
 		// Endpoints
 		r.GET("/endpoints", EndpointList, tenancyWithListMiddleware...)
-		r.GET("/endpoints/:id", EndpointGet, middleware.Tenancy, middleware.IdValidation)
+		r.GET("/endpoints/:id", EndpointGet, middleware.Tenancy)
 		r.POST("/endpoints", EndpointCreate, permissionMiddleware...)
-		r.PATCH("/endpoints/:id", EndpointEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
-		r.DELETE("/endpoints/:id", EndpointDelete, append(permissionMiddleware, middleware.IdValidation)...)
-		r.GET("/endpoints/:endpoint_id/authentications", EndpointListAuthentications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.PATCH("/endpoints/:id", EndpointEdit, append(permissionMiddleware, middleware.Notifier)...)
+		r.DELETE("/endpoints/:id", EndpointDelete, permissionMiddleware...)
+		r.GET("/endpoints/:endpoint_id/authentications", EndpointListAuthentications, tenancyWithListMiddleware...)
 
 		// ApplicationAuthentications
 		r.GET("/application_authentications", ApplicationAuthenticationList, tenancyWithListMiddleware...)
-		r.GET("/application_authentications/:id", ApplicationAuthenticationGet, middleware.Tenancy, middleware.UserCatcher, middleware.IdValidation)
-		r.GET("/application_authentications/:application_authentication_id/authentications", ApplicationAuthenticationListAuthentications, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.GET("/application_authentications/:id", ApplicationAuthenticationGet, middleware.Tenancy, middleware.UserCatcher)
+		r.GET("/application_authentications/:application_authentication_id/authentications", ApplicationAuthenticationListAuthentications, tenancyWithListMiddleware...)
 		r.POST("/application_authentications", ApplicationAuthenticationCreate, permissionMiddleware...)
-		r.DELETE("/application_authentications/:id", ApplicationAuthenticationDelete, append(permissionMiddleware, middleware.IdValidation)...)
+		r.DELETE("/application_authentications/:id", ApplicationAuthenticationDelete, permissionMiddleware...)
 
 		// AppMetaData
 		r.GET("/app_meta_data", MetaDataList, listMiddleware...)
-		r.GET("/app_meta_data/:id", MetaDataGet, middleware.IdValidation)
-		r.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, append(listMiddleware, middleware.IdValidation)...)
+		r.GET("/app_meta_data/:id", MetaDataGet)
+		r.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, listMiddleware...)
 
 		// SourceTypes
 		r.GET("/source_types", SourceTypeList, listMiddleware...)
-		r.GET("/source_types/:id", SourceTypeGet, middleware.IdValidation)
-		r.GET("/source_types/:source_type_id/sources", SourceTypeListSource, append(tenancyWithListMiddleware, middleware.IdValidation)...)
+		r.GET("/source_types/:id", SourceTypeGet)
+		r.GET("/source_types/:source_type_id/sources", SourceTypeListSource, tenancyWithListMiddleware...)
 
 		// Red Hat Connector Connections
 		r.GET("/rhc_connections", RhcConnectionList, tenancyWithListMiddleware...)
-		r.GET("/rhc_connections/:id", RhcConnectionGetById, append(permissionMiddleware, middleware.IdValidation)...)
+		r.GET("/rhc_connections/:id", RhcConnectionGetById, permissionMiddleware...)
 		r.POST("/rhc_connections", RhcConnectionCreate, permissionMiddleware...)
-		r.PATCH("/rhc_connections/:id", RhcConnectionEdit, append(permissionMiddleware, middleware.Notifier, middleware.IdValidation)...)
-		r.DELETE("/rhc_connections/:id", RhcConnectionDelete, append(permissionMiddleware, middleware.IdValidation)...)
-		r.GET("/rhc_connections/:id/sources", RhcConnectionSourcesList, append(permissionWithListMiddleware, middleware.IdValidation)...)
+		r.PATCH("/rhc_connections/:id", RhcConnectionEdit, append(permissionMiddleware, middleware.Notifier)...)
+		r.DELETE("/rhc_connections/:id", RhcConnectionDelete, permissionMiddleware...)
+		r.GET("/rhc_connections/:id/sources", RhcConnectionSourcesList, permissionWithListMiddleware...)
 
 		// GraphQL
 		r.POST("/graphql", GraphQLQuery, middleware.Tenancy, middleware.UserCatcher)


### PR DESCRIPTION
#### First Commit
Just an idea - since the idvalidation is going to be ran basically everywhere we should always run it - involved a teeny change to make sure the param isn't `uid` but that allows us to skip where necessary. 

#### Second Commit
Moves `middleware.Tenancy` and `middleware.UserCatcher` into a group - this way we don't have to duplicate that everywhere. 
