### PR TITLE
Log through availability status with fields

### DIFF
--- a/service/availability_check_test.go
+++ b/service/availability_check_test.go
@@ -1,10 +1,15 @@
 package service
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/kafka"
+	"github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/labstack/echo/v4"
+	kafkago "github.com/segmentio/kafka-go"
+	"github.com/sirupsen/logrus"
 )
 
 type dummyChecker struct {
@@ -13,88 +18,106 @@ type dummyChecker struct {
 	RhcConnectionCounter int
 }
 
+// validate that the dummy checker is implementing the interface properly
+var _ = (availabilityChecker)(&dummyChecker{})
+
+func (c dummyChecker) Logger() echo.Logger {
+	return logger.EchoLogger{Entry: logger.Log.WithFields(logrus.Fields{})}
+}
+
+// send out a http response per application
 func (c *dummyChecker) ApplicationAvailabilityCheck(source *m.Source) {
 	for i := 0; i < len(source.Applications); i++ {
-		c.ApplicationCounter++
+		c.httpAvailabilityRequest(source, &source.Applications[i], &url.URL{})
 	}
 }
 
+// send out a satellite kafka message per endpoint
 func (c *dummyChecker) EndpointAvailabilityCheck(source *m.Source) {
 	for i := 0; i < len(source.Endpoints); i++ {
-		c.EndpointCounter++
+		c.publishSatelliteMessage(&kafkago.Writer{}, source, &source.Endpoints[i])
 	}
 }
 
+// ping RHC for each RHC Connection
 func (c *dummyChecker) RhcConnectionAvailabilityCheck(source *m.Source, headers []kafka.Header) {
 	for i := 0; i < len(source.SourceRhcConnections); i++ {
-		c.RhcConnectionCounter++
+		c.pingRHC(source, &source.SourceRhcConnections[i].RhcConnection, headers)
 	}
+}
+
+// dummy methods making sure they're getting called.
+func (c *dummyChecker) httpAvailabilityRequest(source *m.Source, app *m.Application, uri *url.URL) {
+	c.ApplicationCounter++
+}
+func (c *dummyChecker) publishSatelliteMessage(writer *kafkago.Writer, source *m.Source, endpoint *m.Endpoint) {
+	c.EndpointCounter++
+}
+func (c *dummyChecker) pingRHC(source *m.Source, rhcConnection *m.RhcConnection, headers []kafka.Header) {
+	c.RhcConnectionCounter++
+}
+func (c *dummyChecker) updateRhcStatus(source *m.Source, status string, errstr string, rhcConnection *m.RhcConnection, headers []kafka.Header) {
 }
 
 func TestApplicationAvailability(t *testing.T) {
-	d := &dummyChecker{}
-	ac = d
-
-	RequestAvailabilityCheck(&m.Source{
+	var acr = &dummyChecker{}
+	acr.ApplicationAvailabilityCheck(&m.Source{
 		// 2 applications on this source.
 		Applications: []m.Application{{}, {}},
-	}, []kafka.Header{})
+	})
 
-	if d.ApplicationCounter != 2 {
-		t.Errorf("availability check not called for both applications, got %v expected %v", d.ApplicationCounter, 2)
+	if acr.ApplicationCounter != 2 {
+		t.Errorf("availability check not called for both applications, got %v expected %v", acr.ApplicationCounter, 2)
 	}
 }
 
 func TestEndpointAvailability(t *testing.T) {
-	d := &dummyChecker{}
-	ac = d
-
-	RequestAvailabilityCheck(&m.Source{
+	var acr = &dummyChecker{}
+	acr.EndpointAvailabilityCheck(&m.Source{
 		// 3 endpoints on this source.
 		Endpoints: []m.Endpoint{{}, {}, {}},
-	}, []kafka.Header{})
+	})
 
-	if d.EndpointCounter != 3 {
-		t.Errorf("availability check not called for all endpoints, got %v expected %v", d.EndpointCounter, 3)
+	if acr.EndpointCounter != 3 {
+		t.Errorf("availability check not called for all endpoints, got %v expected %v", acr.EndpointCounter, 3)
 	}
 }
 
 func TestRhcConnectionAvailability(t *testing.T) {
-	d := &dummyChecker{}
-	ac = d
-
-	RequestAvailabilityCheck(&m.Source{
+	var acr = &dummyChecker{}
+	acr.RhcConnectionAvailabilityCheck(&m.Source{
 		// 2 rhc connections!
 		SourceRhcConnections: []m.SourceRhcConnection{{RhcConnection: m.RhcConnection{RhcId: "asdf"}}, {RhcConnection: m.RhcConnection{RhcId: "qwerty"}}},
 	}, []kafka.Header{})
 
-	if d.RhcConnectionCounter != 2 {
-		t.Errorf("availability check not called for all rhc connections, got %v expected %v", d.RhcConnectionCounter, 2)
+	if acr.RhcConnectionCounter != 2 {
+		t.Errorf("availability check not called for all rhc connections, got %v expected %v", acr.RhcConnectionCounter, 2)
 	}
 }
 
 func TestAllAvailability(t *testing.T) {
-	d := &dummyChecker{}
-	ac = d
-
-	RequestAvailabilityCheck(&m.Source{
+	var acr = &dummyChecker{}
+	src := &m.Source{
 		// 2 applications on this source.
 		Applications: []m.Application{{}, {}, {}},
 		// 3 endpoints on this source.
 		Endpoints: []m.Endpoint{{}, {}, {}, {}},
 		// ...and 1 rhc connection
 		SourceRhcConnections: []m.SourceRhcConnection{{RhcConnection: m.RhcConnection{RhcId: "asdf"}}},
-	}, []kafka.Header{})
+	}
+	acr.ApplicationAvailabilityCheck(src)
+	acr.EndpointAvailabilityCheck(src)
+	acr.RhcConnectionAvailabilityCheck(src, []kafka.Header{})
 
-	if d.ApplicationCounter != 3 {
-		t.Errorf("availability check not called for both applications, got %v expected %v", d.ApplicationCounter, 3)
+	if acr.ApplicationCounter != 3 {
+		t.Errorf("availability check not called for both applications, got %v expected %v", acr.ApplicationCounter, 3)
 	}
 
-	if d.EndpointCounter != 4 {
-		t.Errorf("availability check not called for all endpoints, got %v expected %v", d.EndpointCounter, 4)
+	if acr.EndpointCounter != 4 {
+		t.Errorf("availability check not called for all endpoints, got %v expected %v", acr.EndpointCounter, 4)
 	}
 
-	if d.RhcConnectionCounter != 1 {
-		t.Errorf("availability check not called for all rhc connections, got %v expected %v", d.RhcConnectionCounter, 1)
+	if acr.RhcConnectionCounter != 1 {
+		t.Errorf("availability check not called for all rhc connections, got %v expected %v", acr.RhcConnectionCounter, 1)
 	}
 }

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -382,7 +382,7 @@ func SourceCheckAvailability(c echo.Context) error {
 			c.Logger().Warn(err)
 			return
 		}
-		service.RequestAvailabilityCheck(src, h)
+		service.RequestAvailabilityCheck(c, src, h)
 		cancel()
 	}()
 


### PR DESCRIPTION
Following up with logging all the way through availability status.

- ~Introducing a way to override the context that gets passed to the DAO if you set it on the echo context~ handled in #483 
- Making all the availability status functions -> methods so we can have a bit of state (the request's logger)

\# TODO:
- [x] add some tests. a bit tough since we're testing things like hitting external APIs and/or putting a message on a queue. 