### PR TITLE
[RHCLOUD-20689] fix: "schema_migrations" legacy table not being created on initial schema

### DIFF
--- a/db/migrations/sql/1_initial_schema.sql
+++ b/db/migrations/sql/1_initial_schema.sql
@@ -652,7 +652,7 @@ DO
 
 $$
 BEGIN
-    IF NOT "table_exists"('ar_internal_metadata') THEN
+    IF NOT "table_exists"('schema_migrations') THEN
         CREATE TABLE "schema_migrations" (
             "version" CHARACTER VARYING NOT NULL
         );


### PR DESCRIPTION
Apparently I copied and pasted the "IF NOT table exists" statement with
the "ar_internal_metadata" value instead of the legacy
"schema_migrations" value. This fixes that, although it doesn't affect
to the already populated databases or the new ones when running the
"delete the old active record table" migration.

## Links

[[RHCLOUD-20689]](https://issues.redhat.com/browse/RHCLOUD-20689)