### PR TITLE
[RHCLOUD-20569] Authentication handlers tests update 6

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -730,6 +731,12 @@ func TestAuthenticationDelete(t *testing.T) {
 
 	if rec.Body.Len() != 0 {
 		t.Errorf("Response body is not nil")
+	}
+
+	// Check that the authentication is deleted
+	_, err = authenticationDao.GetById(uid)
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf("expected 'authentication not found', got %s", err)
 	}
 
 	// Delete created source

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -746,6 +746,40 @@ func TestAuthenticationDelete(t *testing.T) {
 	}
 }
 
+// TestAuthenticationDeleteInvalidTenant tests that not found is returned
+// for tenant who doesn't own the authentication
+func TestAuthenticationDeleteInvalidTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(2)
+	var uid string
+	if config.IsVaultOn() {
+		uid = fixtures.TestAuthenticationData[0].ID
+	} else {
+		uid = strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
+	}
+
+	c, rec := request.CreateTestContext(
+		http.MethodDelete,
+		"/api/sources/v3.1/authentications/1",
+		nil,
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("uid")
+	c.SetParamValues(uid)
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	notFoundAuthenticationDelete := ErrorHandlingContext(AuthenticationDelete)
+	err := notFoundAuthenticationDelete(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.NotFoundTest(t, rec)
+}
+
 func TestAuthenticationDeleteNotFound(t *testing.T) {
 	c, rec := request.CreateTestContext(
 		http.MethodDelete,

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -663,23 +663,25 @@ func TestAuthenticationEditBadRequest(t *testing.T) {
 }
 
 func TestAuthenticationDelete(t *testing.T) {
+	tenantId := int64(1)
+	var uid string
+	if config.IsVaultOn() {
+		uid = fixtures.TestAuthenticationData[0].ID
+	} else {
+		uid = strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
+	}
+
 	c, rec := request.CreateTestContext(
 		http.MethodDelete,
 		"/api/sources/v3.1/authentications/1",
 		nil,
 		map[string]interface{}{
-			"tenantID": int64(1),
+			"tenantID": tenantId,
 		},
 	)
 
 	c.SetParamNames("uid")
-
-	if config.IsVaultOn() {
-		c.SetParamValues(fixtures.TestAuthenticationData[0].ID)
-	} else {
-		id := strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
-		c.SetParamValues(id)
-	}
+	c.SetParamValues(uid)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	err := AuthenticationDelete(c)


### PR DESCRIPTION
authentication handlers tests update PART VI.
(part I. #465, part II. #471, part III. #474, part IV. #477, part V. #488)

for handler:
- AuthenticationDelete()

this PR contains:
- refactor of TestAuthenticationDelete()
- new test for invalid tenant

**JIRA:** [RHCLOUD-20569](https://issues.redhat.com/browse/RHCLOUD-20569)