### PR TITLE
[RHCLOUD-19948] Feature validate edit requests for "application"

### DIFF
--- a/application_handlers.go
+++ b/application_handlers.go
@@ -175,6 +175,11 @@ func ApplicationEdit(c echo.Context) error {
 		if err := c.Bind(input); err != nil {
 			return util.NewErrBadRequest(err)
 		}
+
+		if err := service.ValidateApplicationEditRequest(input); err != nil {
+			return util.NewErrBadRequest(fmt.Errorf(`invalid payload: %w`, err))
+		}
+
 		statusFromRequest = input.AvailabilityStatus
 		app.UpdateFromRequest(input)
 	}

--- a/model/availability_status.go
+++ b/model/availability_status.go
@@ -8,6 +8,15 @@ const (
 	Unavailable        string = "unavailable"
 )
 
+// ValidAvailabilityStatuses is a map containing the valid availability statuses. It has this form because a map is
+// faster for these lookups.
+var ValidAvailabilityStatuses = map[string]struct{}{
+	Available:          {},
+	InProgress:         {},
+	PartiallyAvailable: {},
+	Unavailable:        {},
+}
+
 // AvailabilityStatuses contains the possible valid values of the status of a source
 var AvailabilityStatuses = []string{
 	"",

--- a/model/paused_resource.go
+++ b/model/paused_resource.go
@@ -22,6 +22,10 @@ func (app *Application) UpdateFromRequestPaused(req *ResourceEditPausedRequest) 
 	lastCheckedAt := req.LastCheckedAt
 
 	if availabilityStatus != nil {
+		if _, ok := ValidAvailabilityStatuses[*req.AvailabilityStatus]; !ok {
+			return fmt.Errorf(`invalid availability status. Must be one of "available", "in_progress", "partially_available" or "unavailable"`)
+		}
+
 		app.AvailabilityStatus = *availabilityStatus
 	}
 

--- a/model/paused_resource.go
+++ b/model/paused_resource.go
@@ -22,7 +22,7 @@ func (app *Application) UpdateFromRequestPaused(req *ResourceEditPausedRequest) 
 	lastCheckedAt := req.LastCheckedAt
 
 	if availabilityStatus != nil {
-		if _, ok := ValidAvailabilityStatuses[*req.AvailabilityStatus]; !ok {
+		if _, ok := ValidAvailabilityStatuses[*availabilityStatus]; !ok {
 			return fmt.Errorf(`invalid availability status. Must be one of "available", "in_progress", "partially_available" or "unavailable"`)
 		}
 

--- a/service/application_validation.go
+++ b/service/application_validation.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
@@ -46,6 +47,19 @@ func ValidateApplicationCreateRequest(appReq *m.ApplicationCreateRequest) error 
 	err = AppTypeDao.ApplicationTypeCompatibleWithSource(appReq.ApplicationTypeID, appReq.SourceID)
 	if err != nil {
 		return fmt.Errorf("source type is not compatible with this application type")
+	}
+
+	return nil
+}
+
+// ValidateApplicationEditRequest validates that the edit request received for an application is valid.
+func ValidateApplicationEditRequest(editReq *m.ApplicationEditRequest) error {
+	// The availability status could be "nil" if the JSON is missing the key. But that's okay, since the user might be
+	// purposely omitting it because the availability status didn't change.
+	if editReq.AvailabilityStatus != nil {
+		if _, ok := m.ValidAvailabilityStatuses[*editReq.AvailabilityStatus]; !ok {
+			return errors.New(`availability status invalid. Must be one of "available", "in_progress", "partially_available" or "unavailable"`)
+		}
 	}
 
 	return nil

--- a/service/application_validation_test.go
+++ b/service/application_validation_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestValidApplicationRequest(t *testing.T) {
@@ -79,5 +80,119 @@ func TestMissingSourceId(t *testing.T) {
 	err := ValidateApplicationCreateRequest(&req)
 	if err == nil {
 		t.Errorf("No error when there should have been one")
+	}
+}
+
+// TestEditNilAvailabilityStatus tests that when a nil availability status is provided —simulating a JSON payload which
+// doesn't contain that key—, no error is received from the validation function.
+func TestEditNilAvailabilityStatus(t *testing.T) {
+	editRequest := m.ApplicationEditRequest{
+		AvailabilityStatus: nil,
+	}
+
+	err := ValidateApplicationEditRequest(&editRequest)
+
+	if err != nil {
+		t.Errorf(`unexpected error when validating an empty availability status for an application edit: %s`, err)
+	}
+}
+
+// TestEditInvalidAvailabilityStatuses tests that a proper error is returned when providing invalid availability
+// statuses.
+func TestEditInvalidAvailabilityStatuses(t *testing.T) {
+	testValues := []*string{
+		util.StringRef(""),
+		util.StringRef("availablel"),
+		util.StringRef("inprogress"),
+		util.StringRef("partial"),
+		util.StringRef("unavalialbe"),
+	}
+
+	want := `availability status invalid. Must be one of "available", "in_progress", "partially_available" or "unavailable"`
+	for _, tv := range testValues {
+		editRequest := m.ApplicationEditRequest{
+			AvailabilityStatus: tv,
+		}
+
+		err := ValidateApplicationEditRequest(&editRequest)
+
+		got := err.Error()
+		if want != got {
+			t.Errorf(`unexpected error when validating invalid availability statuses for an application edit. Want "%s", got "%s"`, want, got)
+		}
+	}
+}
+
+// TestEditValidAvailabilityStatuses tests that no error is returned when valid availability statuses are provided.
+func TestEditValidAvailabilityStatuses(t *testing.T) {
+	testValues := []*string{
+		util.StringRef(m.Available),
+		util.StringRef(m.InProgress),
+		util.StringRef(m.PartiallyAvailable),
+		util.StringRef(m.Unavailable),
+	}
+
+	for _, tv := range testValues {
+		editRequest := m.ApplicationEditRequest{
+			AvailabilityStatus: tv,
+		}
+
+		err := ValidateApplicationEditRequest(&editRequest)
+
+		if err != nil {
+			t.Errorf(`unexpected error when validating a valid availability status "%s" for an application edit: %s`, *tv, err)
+		}
+	}
+}
+
+// TestEditInvalidAvailabilityStatusPaused tests that an error is received when an invalid availability status is given
+// when updating a paused application.
+func TestEditInvalidAvailabilityStatusPaused(t *testing.T) {
+	testValues := []*string{
+		util.StringRef(""),
+		util.StringRef("availablel"),
+		util.StringRef("inprogress"),
+		util.StringRef("partial"),
+		util.StringRef("unavalialbe"),
+	}
+
+	want := `invalid availability status. Must be one of "available", "in_progress", "partially_available" or "unavailable"`
+	for _, tv := range testValues {
+
+		editRequest := m.ResourceEditPausedRequest{
+			AvailabilityStatus: tv,
+		}
+
+		app := m.Application{}
+		err := app.UpdateFromRequestPaused(&editRequest)
+
+		got := err.Error()
+		if want != got {
+			t.Errorf(`unexpected error received when updating a paused application. Want "%s", got "%s"`, want, got)
+		}
+	}
+}
+
+// TestEditValidAvailabilityStatusPaused tests that no error is returned when valid availability statuses are provided
+// when updating a paused application.
+func TestEditValidAvailabilityStatusPaused(t *testing.T) {
+	testValues := []*string{
+		util.StringRef(m.Available),
+		util.StringRef(m.InProgress),
+		util.StringRef(m.PartiallyAvailable),
+		util.StringRef(m.Unavailable),
+	}
+
+	for _, tv := range testValues {
+		editRequest := m.ResourceEditPausedRequest{
+			AvailabilityStatus: tv,
+		}
+
+		app := m.Application{}
+		err := app.UpdateFromRequestPaused(&editRequest)
+
+		if err != nil {
+			t.Errorf(`unexpected error when validating a valid availability status "%s" for a paused application edit: %s`, *tv, err)
+		}
 	}
 }


### PR DESCRIPTION
Makes sure that no application can be edited with an availability status set to empty or null.

## Links

[[RHCLOUD-19948]](https://issues.redhat.com/browse/RHCLOUD-19948)