### PR TITLE
[RHCLOUD-19948] feature: validate "edit authentication" requests

### DIFF
--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -156,6 +156,11 @@ func AuthenticationEdit(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
+	err = service.ValidateAuthenticationEditRequest(updateRequest)
+	if err != nil {
+		return util.NewErrBadRequest(err)
+	}
+
 	auth, err := authDao.GetById(c.Param("uid"))
 	if err != nil {
 		return err

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -479,7 +479,7 @@ func TestAuthenticationEdit(t *testing.T) {
 	backupNotificationProducer := service.NotificationProducer
 	service.NotificationProducer = &mocks.MockAvailabilityStatusNotificationProducer{}
 
-	newAvailabilityStatus := "new status"
+	newAvailabilityStatus := m.Unavailable
 
 	requestBody := m.AuthenticationEditRequest{
 		AvailabilityStatus: &newAvailabilityStatus,
@@ -566,7 +566,7 @@ func TestAuthenticationEditInvalidTenant(t *testing.T) {
 	uid := "1"
 
 	requestBody := m.AuthenticationEditRequest{
-		AvailabilityStatus: util.StringRef("new status"),
+		AvailabilityStatus: util.StringRef(m.InProgress),
 	}
 
 	body, err := json.Marshal(requestBody)
@@ -597,7 +597,7 @@ func TestAuthenticationEditInvalidTenant(t *testing.T) {
 }
 
 func TestAuthenticationEditNotFound(t *testing.T) {
-	newAvailabilityStatus := "new status"
+	newAvailabilityStatus := m.Available
 
 	requestBody := m.AuthenticationEditRequest{
 		AvailabilityStatus: &newAvailabilityStatus,

--- a/service/authentication_validation.go
+++ b/service/authentication_validation.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -30,6 +31,16 @@ func ValidateAuthenticationCreationRequest(auth *model.AuthenticationCreateReque
 
 	// capitalize it so it's always the same format.
 	auth.ResourceType = util.Capitalize(auth.ResourceType)
+
+	return nil
+}
+
+func ValidateAuthenticationEditRequest(auth *model.AuthenticationEditRequest) error {
+	if auth.AvailabilityStatus != nil {
+		if _, ok := model.ValidAvailabilityStatuses[*auth.AvailabilityStatus]; !ok {
+			return errors.New(`availability status invalid. Must be one of "available", "in_progress", "partially_available" or "unavailable"`)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
Makes sure that no authentication can be edited with an availability status set to empty or null.

## Links

[[RHCLOUD-19948]](https://issues.redhat.com/browse/RHCLOUD-19948)