### PR TITLE
[RHCLOUD-19948] feature: validate "endpoint edit" requests

### DIFF
--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -201,6 +201,10 @@ func EndpointEdit(c echo.Context) error {
 			return util.NewErrBadRequest(err)
 		}
 
+		if err = service.ValidateEndpointEditRequest(endpointDao, endpoint.SourceID, input); err != nil {
+			return util.NewErrBadRequest(err)
+		}
+
 		endpoint.UpdateFromRequest(input)
 	}
 

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -698,7 +698,7 @@ func TestEndpointEdit(t *testing.T) {
 		ReceptorNode:            util.StringRef("receptor_node"),
 		Role:                    util.StringRef("role"),
 		Scheme:                  util.StringRef("scheme"),
-		Host:                    util.StringRef("host"),
+		Host:                    util.StringRef("example.com"),
 		Path:                    util.StringRef("path"),
 		CertificateAuthority:    util.StringRef("cert"),
 		AvailabilityStatus:      util.StringRef("available"),
@@ -773,7 +773,7 @@ func TestEndpointEdit(t *testing.T) {
 		t.Errorf("Wrong scheme, wanted %v got %v", "available", *endpointOut.AvailabilityStatus)
 	}
 
-	if *endpointOut.Host != "host" {
+	if *endpointOut.Host != "example.com" {
 		t.Errorf("Wrong host, wanted %v got %v", "available", *endpointOut.AvailabilityStatus)
 	}
 

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -82,7 +82,7 @@ func SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationType
 	authenticationCreateRequest := model.AuthenticationCreateRequest{ResourceType: authenticationResourceType}
 	bulkCreateAuthentication := model.BulkCreateAuthentication{AuthenticationCreateRequest: authenticationCreateRequest, ResourceName: applicationTypeName}
 
-	endpointCreateRequest := model.EndpointCreateRequest{}
+	endpointCreateRequest := model.EndpointCreateRequest{AvailabilityStatus: model.Unavailable}
 	bulkCreateEndpoints := model.BulkCreateEndpoint{EndpointCreateRequest: endpointCreateRequest, SourceName: nameSource}
 
 	return &model.BulkCreateRequest{Sources: []model.BulkCreateSource{bulkCreateSource},

--- a/model/availability_status.go
+++ b/model/availability_status.go
@@ -17,6 +17,13 @@ var ValidAvailabilityStatuses = map[string]struct{}{
 	Unavailable:        {},
 }
 
+// ValidEndpointAvailabilityStatuses is a map containing the valid availability statuses for the endpoints. It has this
+// form because a map is faster for these lookups.
+var ValidEndpointAvailabilityStatuses = map[string]struct{}{
+	Available:   {},
+	Unavailable: {},
+}
+
 // AvailabilityStatuses contains the possible valid values of the status of a source
 var AvailabilityStatuses = []string{
 	"",

--- a/model/paused_resource.go
+++ b/model/paused_resource.go
@@ -65,6 +65,10 @@ func (endpoint *Endpoint) UpdateFromRequestPaused(req *ResourceEditPausedRequest
 	lastCheckedAt := req.LastCheckedAt
 
 	if availabilityStatus != nil {
+		if _, ok := ValidEndpointAvailabilityStatuses[*req.AvailabilityStatus]; !ok {
+			return fmt.Errorf(`invalid availability status. Must be either "available" or "unavailable"`)
+		}
+
 		endpoint.AvailabilityStatus = *availabilityStatus
 	}
 

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -100,7 +100,7 @@ func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreat
 	if ecr.AvailabilityStatus == "" {
 		ecr.AvailabilityStatus = model.InProgress
 	} else {
-		if _, ok := model.ValidAvailabilityStatuses[ecr.AvailabilityStatus]; !ok {
+		if _, ok := model.ValidEndpointAvailabilityStatuses[ecr.AvailabilityStatus]; !ok {
 			return fmt.Errorf("invalid availability status")
 		}
 	}
@@ -157,7 +157,7 @@ func ValidateEndpointEditRequest(dao dao.EndpointDao, sourceId int64, editReques
 	}
 
 	if editRequest.AvailabilityStatus != nil {
-		if _, ok := model.ValidAvailabilityStatuses[*editRequest.AvailabilityStatus]; !ok {
+		if _, ok := model.ValidEndpointAvailabilityStatuses[*editRequest.AvailabilityStatus]; !ok {
 			return fmt.Errorf("invalid availability status")
 		}
 	}

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -64,8 +64,7 @@ func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreat
 	}
 
 	if ecr.Scheme == nil || !schemeRegexp.MatchString(*ecr.Scheme) {
-		tmp := defaultScheme
-		ecr.Scheme = &tmp
+		ecr.Scheme = util.StringRef(defaultScheme)
 	}
 
 	if ecr.Host != "" {
@@ -126,8 +125,7 @@ func ValidateEndpointEditRequest(dao dao.EndpointDao, sourceId int64, editReques
 	}
 
 	if editRequest.Scheme == nil || (editRequest.Scheme != nil && !schemeRegexp.MatchString(*editRequest.Scheme)) {
-		tmp := defaultScheme
-		editRequest.Scheme = &tmp
+		editRequest.Scheme = util.StringRef(defaultScheme)
 	}
 
 	if editRequest.Host != nil && *editRequest.Host != "" {

--- a/service/endpoint_validation.go
+++ b/service/endpoint_validation.go
@@ -23,13 +23,6 @@ var fqdnRegexp = regexp.MustCompile(`^(?:[a-zA-Z\d](?:[a-zA-Z\d-]*[a-zA-Z\d])?\.
 // schemeRegexp matches a valid scheme, as per RFC 3986
 var schemeRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z\d+\-.]*$`)
 
-// validAvailabilityStatuses is a map containing the valid availability statuses. It has this form because a map is
-// faster for these lookups.
-var validAvailabilityStatuses = map[string]struct{}{
-	model.Available:   {},
-	model.Unavailable: {},
-}
-
 const (
 	defaultScheme    = "https"
 	defaultPort      = 443
@@ -107,7 +100,7 @@ func ValidateEndpointCreateRequest(dao dao.EndpointDao, ecr *model.EndpointCreat
 	if ecr.AvailabilityStatus == "" {
 		ecr.AvailabilityStatus = model.InProgress
 	} else {
-		if _, ok := validAvailabilityStatuses[ecr.AvailabilityStatus]; !ok {
+		if _, ok := model.ValidAvailabilityStatuses[ecr.AvailabilityStatus]; !ok {
 			return fmt.Errorf("invalid availability status")
 		}
 	}
@@ -164,7 +157,7 @@ func ValidateEndpointEditRequest(dao dao.EndpointDao, sourceId int64, editReques
 	}
 
 	if editRequest.AvailabilityStatus != nil {
-		if _, ok := validAvailabilityStatuses[*editRequest.AvailabilityStatus]; !ok {
+		if _, ok := model.ValidAvailabilityStatuses[*editRequest.AvailabilityStatus]; !ok {
 			return fmt.Errorf("invalid availability status")
 		}
 	}

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func setUpEndpointCreateRequest() model.EndpointCreateRequest {
@@ -31,6 +32,33 @@ func setUpEndpointCreateRequest() model.EndpointCreateRequest {
 		AvailabilityStatus:   model.Available,
 		SourceIDRaw:          sourceId,
 	}
+}
+
+// setUpEndpointEditRequest returns a valid "EndpointEditRequest" and an associated source ID to be able to validate it.
+func setUpEndpointEditRequest() (model.EndpointEditRequest, int64) {
+	defaultValue := false
+	receptorNode := "receptorNode"
+	role := "role"
+	scheme := "https"
+	host := "example.com"
+	port := 443
+	path := "/example"
+	verifySsl := true
+	certificateAuthority := "letsEncrypt"
+
+	return model.EndpointEditRequest{
+			Default:              &defaultValue,
+			ReceptorNode:         &receptorNode,
+			Role:                 &role,
+			Scheme:               &scheme,
+			Host:                 &host,
+			Port:                 &port,
+			Path:                 &path,
+			VerifySsl:            &verifySsl,
+			CertificateAuthority: &certificateAuthority,
+			AvailabilityStatus:   util.StringRef(model.Available),
+		},
+		fixtures.TestSourceData[0].ID
 }
 
 // TestValidateEndpointCreateRequest tests that when a proper EndpointCreateRequest is given, the validator doesn't
@@ -388,7 +416,7 @@ func TestValidAvailabilityStatuses(t *testing.T) {
 
 	ecr := setUpEndpointCreateRequest()
 
-	testValues := []string{"", model.Available, model.Unavailable}
+	testValues := []string{model.Available, model.Unavailable}
 	for _, tt := range testValues {
 		ecr.AvailabilityStatus = tt
 
@@ -397,6 +425,27 @@ func TestValidAvailabilityStatuses(t *testing.T) {
 			t.Errorf("want no error, got '%s'", err)
 		}
 	}
+}
+
+// TestDefaultAvailabilityStatus tests that a default value is set for the availability status when it comes empty.
+func TestDefaultAvailabilityStatus(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	ecr := setUpEndpointCreateRequest()
+	ecr.AvailabilityStatus = ""
+
+	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
+	if err != nil {
+		t.Errorf("unexpected error when checking for a default value on the availability status member of an endpoint: %s", err)
+	}
+
+	want := model.InProgress
+	got := ecr.AvailabilityStatus
+
+	if want != got {
+		t.Errorf(`unexpected default value for an endpoint when the availability status comes empty. Want "%s", got "%s"`, want, got)
+	}
+
 }
 
 // TestInvalidAvailabilityStatuses tests if an error is returned when passing invalid availability statuses.
@@ -413,6 +462,400 @@ func TestInvalidAvailabilityStatuses(t *testing.T) {
 		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 		if err.Error() != want {
 			t.Errorf("want '%s', got '%s'", want, err)
+		}
+	}
+}
+
+// TestValidateEndpointEditRequest tests that when a proper EndpointEditRequest is given, the validator doesn't
+// complain.
+func TestValidateEndpointEditRequest(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+	if err != nil {
+		t.Errorf(`unexpected error when validating a valid "edit endpoint" payload: %s`, err)
+	}
+}
+
+// TestEditDefaultEndpointAlreadyExists tests if an error is returned when the provided endpoint is marked as default
+// when the also provided source already has a default one. Tested on an "edit endpoint" payload.
+func TestEditDefaultEndpointAlreadyExists(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+	tmp := true
+	editRequest.Default = &tmp
+
+	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+	want := "a default endpoint already exists for the provided source"
+	got := err.Error()
+
+	if want != got {
+		t.Errorf(`unexpected error when marking an endpoint as the default one when there's another default endpoint for the source. Want "%s" error, got "%s"`, want, got)
+	}
+}
+
+// TestEditNonUniqueRole tests if an error is returned when a role already exists for a source. Tested on an "edit
+// endpoint" payload.
+func TestEditNonUniqueRole(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	role := "myRole"
+	newEndpoint := fixtures.TestEndpointData[0]
+	newEndpoint.ID = 0 // set it as zero to avoid hitting
+	newEndpoint.Role = &role
+
+	err := endpointDao.Create(&newEndpoint)
+	if err != nil {
+		t.Errorf("unexpected error when inserting a new endpoint for the test: %s", err)
+	}
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+	editRequest.Role = &role
+
+	err = ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+	want := "the role already exists for the given source"
+	got := err.Error()
+
+	if want != got {
+		t.Errorf(`unexpected error when modifying an endpoint's role to an already existing one. Want "%s", got "%s"`, want, got)
+	}
+}
+
+// TestEditSchemeGetsDefaulted tests if the scheme gets properly defaulted when an invalid or missing scheme is
+// provided. Tested on an "edit endpoint" payload.
+func TestEditSchemeGetsDefaulted(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	editRequest.Scheme = nil
+
+	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+	if err != nil {
+		t.Errorf("unexpected error when validating a nil scheme for an endpoint edit: %s", err)
+	}
+
+	if *editRequest.Scheme != defaultScheme {
+		t.Errorf(`unexpected scheme returned when editing an endpoint and not providing an scheme. Want "%s", got "%s"`, defaultScheme, *editRequest.Scheme)
+	}
+
+	invalidScheme := "/invalid"
+	editRequest.Scheme = &invalidScheme
+
+	err = ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+	if err != nil {
+		t.Errorf("unexpected error when editing an endpoint and giving it an invalid scheme: %s", err)
+	}
+
+	if *editRequest.Scheme != defaultScheme {
+		t.Errorf(`unexpected scheme set when editing an endpoint with an invalid scheme value. Want "%s", got "%s"`, defaultScheme, *editRequest.Scheme)
+	}
+}
+
+// TestEditEmptyHost tests if no error is returned even when an empty host is given. Tested on an "edit endpoint"
+// payload.
+func TestEditEmptyHost(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+	tmp := ""
+	editRequest.Host = &tmp
+
+	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+	if err != nil {
+		t.Errorf("unexpected error when editing an endpoint and giving it an empty host: %s", err)
+	}
+}
+
+// TestEditHostFqdnTooLong tests if an error is returned when a host which is too long is given. Tested on an "edit
+// endpoint" payload.
+func TestEditHostFqdnTooLong(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	// The "longHostname" variable holds a 256 char hostname
+	tmp := `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
+		aaaaaa
+	`
+	editRequest.Host = &tmp
+
+	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+	want := "the provided host is longer than 255 characters"
+	got := err.Error()
+
+	if want != got {
+		t.Errorf(`unexpected error when editing an endpoint and giving it a hostname that is too long. Want "%s" got "%s"`, want, got)
+	}
+}
+
+// TestEditValidHosts tests if the validation succeeds when valid hosts are given. Tested on an "edit endpoint"
+// payload.
+func TestEditValidHosts(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	testValues := []string{
+		"redhat.com",
+		"elpmaxe.example.com",
+		"exa.mp-le.com",
+		"123456789.org",
+		"123ab-ba321.org",
+		"a.org",
+		"5.com",
+		"example.xn--whatever",
+	}
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	for _, tt := range testValues {
+		editRequest.Host = &tt
+
+		err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+		if err != nil {
+			t.Errorf(`unexpected error when editing an endpoint and giving it valid hostnames: %s for %#v`, err, tt)
+		}
+	}
+}
+
+// TestEditInvalidHosts tests if an error is returned on invalid hosts. Tested on an "edit endpoint" payload.
+func TestEditInvalidHosts(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	testValues := []string{
+		"-example.com",
+		"example-.com",
+		"example.xn--",
+		"example.--xn",
+	}
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	want := "the provided host is not valid"
+	for _, tt := range testValues {
+		editRequest.Host = &tt
+
+		err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+		if err == nil {
+			t.Errorf(`unexpected error when editing an endpoint and giving it invalid hostnames: want "%s", got no error for %#v`, want, tt)
+		}
+	}
+}
+
+// TestEditLabelNamesTooLong tests if an error is returned when the provided labels are longer than permitted. Tested
+// on an "edit endpoint" payload.
+func TestEditLabelNamesTooLong(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	// The first label is 64 characters long
+	tmp := `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg.example.org`
+	editRequest.Host = &tmp
+
+	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+	want := fmt.Sprintf(`the label '%s' is greater than %d characters`, "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffgggg", maxLabelLength)
+	got := err.Error()
+
+	if want != got {
+		t.Errorf(`unexpected error when editing an endpoint and giving it a label with is too long. Want "%s", got "%s"`, want, err)
+	}
+}
+
+// TestEditDefaultingPortWhenMissingOrLessThanZero test if the port is given a default value if it's missing or if it
+// has been given a value equal or lower than zero. Tested on an "edit endpoint" payload.
+func TestEditDefaultingPortWhenMissingOrLessThanZero(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	minusOne := -1
+	zero := 0
+	testValues := []struct {
+		value *int
+	}{
+		{nil},
+		{&minusOne},
+		{&zero},
+	}
+
+	for _, tt := range testValues {
+		editRequest.Port = tt.value
+		err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+		if err != nil {
+			t.Errorf("unexpected error when editing an endpoint and giving it invalid port values: %s", err)
+		}
+
+		if *editRequest.Port != defaultPort {
+			t.Errorf(`unexpected value when editing an endpoint and giving it invalid port avlues. Want "%d" as the resulting default port, got "%d"`, defaultPort, *editRequest.Port)
+		}
+	}
+}
+
+// TestEditPortLargeValue tests if an error is returned when a port that is greater than the maximum allowed port is
+// given. Tested on an "edit endpoint" payload.
+func TestEditPortLargeValue(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+	largePort := 999999
+	editRequest.Port = &largePort
+
+	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+	want := "invalid port number"
+	got := err.Error()
+
+	if want != got {
+		t.Errorf(`unexpected error when editing an endpoint and giving it a port which is too high. Want "%s", got "%s"`, want, err)
+	}
+}
+
+// TestEditDefaultVerifySsl tests if the default value is set when no "VerifySSL" value is provided. Tested on an "edit
+// endpoint" payload.
+func TestEditDefaultVerifySsl(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+	editRequest.VerifySsl = nil
+
+	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+	if err != nil {
+		t.Errorf(`unexpected error when editing an endpoint and giving it a nil "verifySSL" value: %s`, err)
+	}
+
+	if *editRequest.VerifySsl != defaultVerifySsl {
+		t.Errorf(`unexpected error when editing an endpoint and giving it a nil "verifySSL" value. Want "%t" as the default value, got "%t"`, defaultVerifySsl, *editRequest.VerifySsl)
+	}
+}
+
+// TestEditEmptyCertificateAuthority tests if an error is returned when ssl verification is turned on but no certificate
+// authority is given. Tested on an "edit endpoint" payload.
+func TestEditEmptyCertificateAuthority(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	emptyString := ""
+	testValues := []struct {
+		value *string
+	}{
+		{nil},
+		{&emptyString},
+	}
+
+	want := "the certificate authority cannot be empty"
+	for _, tt := range testValues {
+		editRequest.CertificateAuthority = tt.value
+
+		err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+		got := err.Error()
+		if want != got {
+			t.Errorf(`unexpected error when editing an endpoint and giving it an empty certificate authority. Want "%s", got "%s"`, want, got)
+		}
+	}
+}
+
+// TestEditEndpointValidAvailabilityStatuses tests if no error is returned when valid availability statuses are given.
+// Tested on an "edit endpoint" payload.
+func TestEditEndpointValidAvailabilityStatuses(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	testValues := []string{model.Available, model.Unavailable}
+	for _, tt := range testValues {
+		editRequest.AvailabilityStatus = &tt
+
+		err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+		if err != nil {
+			t.Errorf("unexpected error when editing an endpoint and giving it valid availability status values: %s", err)
+		}
+	}
+}
+
+// TestEditEndpointInvalidAvailabilityStatuses tests if an error is returned when passing invalid availability statuses.
+// Tested on an "edit endpoint" payload.
+func TestEditEndpointInvalidAvailabilityStatuses(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	editRequest, sourceId := setUpEndpointEditRequest()
+
+	invalidValues := []string{"hello", "world", "almost", "passes", "validation"}
+	want := "invalid availability status"
+	for _, tt := range invalidValues {
+		editRequest.AvailabilityStatus = &tt
+
+		err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
+
+		got := err.Error()
+		if want != got {
+			t.Errorf(`unexpected error when editing an endpoint and giving it invalid availability status values. Want "%s", got "%s"`, want, got)
+		}
+	}
+}
+
+// TestEditEndpointInvalidAvailabilityStatusPaused tests that an error is received when an invalid availability status
+// is given when updating a paused endpoint.
+func TestEditEndpointInvalidAvailabilityStatusPaused(t *testing.T) {
+	testValues := []*string{
+		util.StringRef(""),
+		util.StringRef("availablel"),
+		util.StringRef("inprogress"),
+		util.StringRef("partial"),
+		util.StringRef("unavalialbe"),
+		util.StringRef(model.InProgress),
+		util.StringRef(model.PartiallyAvailable),
+	}
+
+	want := `invalid availability status. Must be either "available" or "unavailable"`
+	for _, tv := range testValues {
+
+		editRequest := model.ResourceEditPausedRequest{
+			AvailabilityStatus: tv,
+		}
+
+		endpoint := model.Endpoint{}
+		err := endpoint.UpdateFromRequestPaused(&editRequest)
+
+		got := err.Error()
+		if want != got {
+			t.Errorf(`unexpected error received when updating a paused endpoint with an invalid availability status. Want "%s", got "%s"`, want, got)
+		}
+	}
+}
+
+// TestEditEndpointValidAvailabilityStatusPaused tests that no error is returned when valid availability statuses are
+// provided when updating a paused endpoint.
+func TestEditEndpointValidAvailabilityStatusPaused(t *testing.T) {
+	testValues := []*string{
+		util.StringRef(model.Available),
+		util.StringRef(model.Unavailable),
+	}
+
+	for _, tv := range testValues {
+		editRequest := model.ResourceEditPausedRequest{
+			AvailabilityStatus: tv,
+		}
+
+		endpoint := model.Endpoint{}
+		err := endpoint.UpdateFromRequestPaused(&editRequest)
+
+		if err != nil {
+			t.Errorf(`unexpected error when validating a valid availability status "%s" for a paused endpoint edit: %s`, *tv, err)
 		}
 	}
 }

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
@@ -226,13 +227,7 @@ func TestHostFqdnTooLong(t *testing.T) {
 	ecr := setUpEndpointCreateRequest()
 
 	// The "longHostname" variable holds a 256 char hostname
-	ecr.Host = `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaa
-	`
+	ecr.Host = strings.Repeat("a", 256)
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 	if err == nil {
@@ -582,14 +577,7 @@ func TestEditHostFqdnTooLong(t *testing.T) {
 	editRequest, sourceId := setUpEndpointEditRequest()
 
 	// The "longHostname" variable holds a 256 char hostname
-	tmp := `aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee
-		aaaaaa
-	`
-	editRequest.Host = &tmp
+	editRequest.Host = util.StringRef(strings.Repeat("a", 256))
 
 	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
 

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -560,8 +560,7 @@ func TestEditEmptyHost(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	editRequest, sourceId := setUpEndpointEditRequest()
-	tmp := ""
-	editRequest.Host = &tmp
+	editRequest.Host = util.StringRef("")
 
 	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
 	if err != nil {


### PR DESCRIPTION
Makes sure that no endpoint can be edited with an availability status set to empty or null.

## Links

[[RHCLOUD-19948]](https://issues.redhat.com/browse/RHCLOUD-19948)