### PR TITLE
[RHCLOUD-19948] feature: validate "edit source" requests

### DIFF
--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -74,7 +74,7 @@ func IdentityHeaderForUser(testUserId string) *identity.XRHID {
 }
 
 func SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType string) *model.BulkCreateRequest {
-	sourceCreateRequest := model.SourceCreateRequest{Name: &nameSource}
+	sourceCreateRequest := model.SourceCreateRequest{Name: &nameSource, AvailabilityStatus: model.Available}
 	bulkCreateSource := model.BulkCreateSource{SourceCreateRequest: sourceCreateRequest, SourceTypeName: sourceTypeName}
 
 	bulkCreateApplication := model.BulkCreateApplication{SourceName: nameSource, ApplicationTypeName: applicationTypeName}

--- a/model/source_http.go
+++ b/model/source_http.go
@@ -109,6 +109,10 @@ func (src *Source) UpdateFromRequestPaused(update *SourcePausedEditRequest) erro
 	lastCheckedAt := update.LastCheckedAt
 
 	if availabilityStatus != nil {
+		if _, ok := ValidAvailabilityStatuses[*update.AvailabilityStatus]; !ok {
+			return fmt.Errorf(`invalid availability status. Must be one of "available", "in_progress", "partially_available" or "unavailable"`)
+		}
+
 		src.AvailabilityStatus = *availabilityStatus
 	}
 

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -165,9 +165,7 @@ func SourceEdit(c echo.Context) error {
 			return err
 		}
 
-		err := service.ValidateEditSourceNameRequest(sourcesDB, input)
-
-		if err != nil {
+		if err := service.ValidateSourceEditRequest(sourcesDB, input); err != nil {
 			return util.NewErrBadRequest(err)
 		}
 


### PR DESCRIPTION
Makes sure that no source can be edited with an availability status set to empty or null.

## Links

[[RHCLOUD-19948]](https://issues.redhat.com/browse/RHCLOUD-19948)