### PR TITLE
[RHCLOUD-19948] feature: not null constraint and default value for "availability_status"

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -863,7 +863,7 @@ func TestApplicationEdit(t *testing.T) {
 
 	emailNotificationInfo := &m.EmailNotificationInfo{ResourceDisplayName: "Application",
 		CurrentAvailabilityStatus:  "available",
-		PreviousAvailabilityStatus: "unknown",
+		PreviousAvailabilityStatus: "in_progress",
 		SourceName:                 src.Name,
 		SourceID:                   strconv.FormatInt(sourceID, 10),
 		TenantID:                   strconv.FormatInt(fixtures.TestSourceData[0].TenantID, 10),

--- a/db/migrations/20220905120000_availability_status_not_null_constraint_default_value.go
+++ b/db/migrations/20220905120000_availability_status_not_null_constraint_default_value.go
@@ -1,0 +1,103 @@
+package migrations
+
+import (
+	_ "embed"
+	"fmt"
+
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// AvailabilityStatusColumnsNotNullConstraintDefaultValue adds a NOT NULL constraint to the "availability_status"
+// columns from all the tables that have it, and it also adds a default value "in_progress" for new insertions. The
+// migration takes care of the NULL or empty values from those columns and sets them to "in_progress".
+func AvailabilityStatusColumnsNotNullConstraintDefaultValue() *gormigrate.Migration {
+	// tablesToBeUpdated holds all the table names which have an "availability_status" column which may have nil or
+	// empty values that need to be updated to the default value.
+	tablesToBeUpdated := []string{
+		"applications",
+		"authentications",
+		"endpoints",
+		"rhc_connections",
+		"sources",
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220905120000",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "remove empty or nil availability statuses" started`)
+			defer logging.Log.Info(`Migration "remove empty or nil availability statuses" ended`)
+
+			// Perform the migration.
+			err := db.Transaction(func(tx *gorm.DB) error {
+				for _, table := range tablesToBeUpdated {
+					// Update the NULL or empty availability status values.
+					err := tx.Debug().
+						Table(table).
+						Where(`availability_status IS NULL OR availability_status = ''`).
+						Update("availability_status", "in_progress").
+						Error
+
+					if err != nil {
+						return fmt.Errorf(`unable to set the NULL or empty availability statuses of table "%s" to "in_progress": %w`, table, err)
+					}
+
+					// Add a default value to the column.
+					defaultSql := fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "availability_status" SET DEFAULT 'in_progress'`, table)
+					err = tx.Debug().
+						Exec(defaultSql).
+						Error
+
+					if err != nil {
+						return fmt.Errorf(`unable to set a default value for the column "availability_status" of the table "%s": %w`, table, err)
+					}
+
+					// Add a NOT NULL constraint to the column.
+					notNullSql := fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "availability_status" SET NOT NULL`, table)
+					err = tx.Debug().
+						Exec(notNullSql).
+						Error
+
+					if err != nil {
+						return fmt.Errorf(`unable to set a NOT NULL constraint for the column "availability_status" of the table "%s": %w`, table, err)
+					}
+				}
+				return nil
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Transaction(func(tx *gorm.DB) error {
+				for _, table := range tablesToBeUpdated {
+					// Drop the NOT NULL constraint.
+					notNullSql := fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "availability_status" DROP NOT NULL`, table)
+
+					err := tx.Debug().
+						Exec(notNullSql).
+						Error
+
+					if err != nil {
+						return fmt.Errorf(`unable to drop the NOT NULL constraint from the "availability_status" column of the table "%s": %w`, table, err)
+					}
+
+					// Drop the default value.
+					defaultValueSql := fmt.Sprintf(`ALTER TABLE "%s" ALTER COLUMN "availability_status" DROP DEFAULT`, table)
+
+					err = tx.Debug().
+						Exec(defaultValueSql).
+						Error
+
+					if err != nil {
+						return fmt.Errorf(`unable to drop the default value from the "availability_status" column of the table "%s": %w`, table, err)
+					}
+				}
+
+				return nil
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -27,6 +27,7 @@ var MigrationsCollection = []*gormigrate.Migration{
 	RemoveOldMigrationsTable(),
 	RenameForeignKeysIndexes(),
 	RemoveProcessedDuplicatedTenants(),
+	AvailabilityStatusColumnsNotNullConstraintDefaultValue(),
 }
 
 var ctx = context.Background()

--- a/model/application.go
+++ b/model/application.go
@@ -15,7 +15,7 @@ type Application struct {
 	UpdatedAt time.Time  `json:"updated_at"`
 	PausedAt  *time.Time `json:"paused_at"`
 
-	AvailabilityStatus      string     `json:"availability_status,omitempty"`
+	AvailabilityStatus      string     `gorm:"default:in_progress;not null" json:"availability_status,omitempty"`
 	LastCheckedAt           *time.Time `json:"last_checked_at,omitempty"`
 	LastAvailableAt         *time.Time `json:"last_available_at,omitempty"`
 	AvailabilityStatusError string     `json:"availability_status_error,omitempty"`

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -26,7 +26,7 @@ type Authentication struct {
 	ExtraDb     datatypes.JSON         `gorm:"column:extra"`
 	Version     string                 `json:"version" gorm:"-"`
 
-	AvailabilityStatus      *string    `json:"availability_status,omitempty"`
+	AvailabilityStatus      *string    `gorm:"default:in_progress;not null" json:"availability_status,omitempty"`
 	LastCheckedAt           *time.Time `json:"last_checked_at,omitempty"`
 	LastAvailableAt         *time.Time `json:"last_available_at,omitempty"`
 	AvailabilityStatusError *string    `json:"availability_status_error,omitempty"`

--- a/model/endpoint.go
+++ b/model/endpoint.go
@@ -23,7 +23,7 @@ type Endpoint struct {
 	CertificateAuthority *string `json:"certificate_authority,omitempty"`
 	ReceptorNode         *string `json:"receptor_node,omitempty"`
 
-	AvailabilityStatus      string     `json:"availability_status,omitempty"`
+	AvailabilityStatus      string     `gorm:"default:in_progress;not null" json:"availability_status,omitempty"`
 	LastCheckedAt           *time.Time `json:"last_checked_at,omitempty"`
 	LastAvailableAt         *time.Time `json:"last_available_at,omitempty"`
 	AvailabilityStatusError *string    `json:"availability_status_error,omitempty"`

--- a/model/rhc_connection.go
+++ b/model/rhc_connection.go
@@ -13,7 +13,7 @@ type RhcConnection struct {
 	RhcId string         `json:"rhc_id"`
 	Extra datatypes.JSON `json:"extra,omitempty"`
 
-	AvailabilityStatus      string     `json:"availability_status,omitempty"`
+	AvailabilityStatus      string     `gorm:"default:in_progress;not null" json:"availability_status,omitempty"`
 	LastCheckedAt           *time.Time `json:"last_checked_at,omitempty"`
 	LastAvailableAt         *time.Time `json:"last_available_at,omitempty"`
 	AvailabilityStatusError string     `json:"availability_status_error,omitempty"`

--- a/model/source.go
+++ b/model/source.go
@@ -16,7 +16,7 @@ const (
 // Source struct that includes all of the fields on the table
 // used internally for business logic
 type Source struct {
-	AvailabilityStatus string     `json:"availability_status,omitempty"`
+	AvailabilityStatus string     `gorm:"default:in_progress;not null" json:"availability_status,omitempty"`
 	LastCheckedAt      *time.Time `json:"last_checked_at,omitempty"`
 	LastAvailableAt    *time.Time `json:"last_available_at,omitempty"`
 

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -423,7 +423,7 @@ func TestConsumeStatusMessage(t *testing.T) {
 	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	sourceTestData := TestData{StatusMessage: statusMessage, MessageHeaders: headers, RaiseEventCalled: true}
 
-	emailNotificationInfo := &m.EmailNotificationInfo{SourceID: "1", SourceName: "Source1", PreviousAvailabilityStatus: "unknown", CurrentAvailabilityStatus: "available", ResourceDisplayName: "Application", TenantID: "1"}
+	emailNotificationInfo := &m.EmailNotificationInfo{SourceID: "1", SourceName: "Source1", PreviousAvailabilityStatus: "in_progress", CurrentAvailabilityStatus: "available", ResourceDisplayName: "Application", TenantID: "1"}
 	statusMessageApplication := types.StatusMessage{ResourceType: "Application", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	applicationTestData := TestData{StatusMessage: statusMessageApplication, MessageHeaders: headers, RaiseEventCalled: true, ExpectedEmitAvailabilityStatusCallCounter: 1, EmailNotificationInfo: emailNotificationInfo}
 

--- a/statuslistener/test_data/bulk_message_Application_1.json
+++ b/statuslistener/test_data/bulk_message_Application_1.json
@@ -13,7 +13,7 @@
   "applications": [
     {
       "application_type_id": 2,
-      "availability_status": null,
+      "availability_status": "in_progress",
       "availability_status_error": null,
       "created_at": "2021-12-06 20:03:14 CET",
       "extra": {

--- a/statuslistener/test_data/bulk_message_Endpoint_1.json
+++ b/statuslistener/test_data/bulk_message_Endpoint_1.json
@@ -4,7 +4,7 @@
   "applications": [
     {
       "application_type_id": 2,
-      "availability_status": null,
+      "availability_status": "in_progress",
       "availability_status_error": null,
       "created_at": "2021-12-06 19:58:14 CET",
       "extra": {

--- a/statuslistener/test_data/bulk_message_Source_1.json
+++ b/statuslistener/test_data/bulk_message_Source_1.json
@@ -13,7 +13,7 @@
   "applications": [
     {
       "application_type_id": 1,
-      "availability_status": null,
+      "availability_status": "in_progress",
       "availability_status_error": null,
       "created_at": "2021-12-06 20:00:14 CET",
       "extra": {
@@ -30,7 +30,7 @@
     },
     {
       "application_type_id": 2,
-      "availability_status": null,
+      "availability_status": "in_progress",
       "availability_status_error": null,
       "created_at": "2021-12-06 20:00:14 CET",
       "extra": {


### PR DESCRIPTION
This migration adds a not null contraint and a default value for all the
tables which have an "availability_status" column. The default value is
"in_progress", a value that was agreed as the default one by the team.

It also takes care of all the current NULL or empty values and sets them
to the default value too.

## Links
[[RHCLOUD-19948]](https://issues.redhat.com/browse/RHCLOUD-19948)