### PR TITLE
Add Model to ApplicationDao.IsSuperkey(int64) + Log message on failure

### DIFF
--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -209,12 +209,14 @@ func (a *applicationDaoImpl) IsSuperkey(id int64) bool {
 	var valid bool
 
 	result := a.getDbWithTable(DB.Debug(), "applications").
+		Model(&m.Application{}).
 		Select(`"Source".app_creation_workflow = ?`, m.AccountAuth).
 		Where("applications.id = ?", id).
 		Joins("Source").
 		First(&valid)
 
 	if result.Error != nil {
+		DB.Logger.Warn(a.ctx, "Failed to determine if app %v is superkey: %v", id, result.Error)
 		return false
 	}
 

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -486,3 +486,73 @@ func TestApplicationListUserOwnership(t *testing.T) {
 
 	DropSchema(schema)
 }
+
+func TestApplicationIsSuperkeyTrue(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("application_superkey_true")
+	defer DropSchema("application_superkey_true")
+
+	src := m.Source{
+		Name:                "Superkey",
+		Uid:                 util.StringRef("asdf"),
+		SourceTypeID:        fixtures.TestSourceTypeData[0].Id,
+		AppCreationWorkflow: m.AccountAuth,
+		TenantID:            fixtures.TestTenantData[0].Id,
+	}
+	srcDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+	err := srcDao.Create(&src)
+	if err != nil {
+		t.Error(err)
+	}
+
+	app := m.Application{
+		SourceID:          src.ID,
+		ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
+		TenantID:          fixtures.TestTenantData[0].Id,
+	}
+	appDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+	err = appDao.Create(&app)
+	if err != nil {
+		t.Error(err)
+	}
+
+	superkey := appDao.IsSuperkey(app.ID)
+	if !superkey {
+		t.Errorf("application should have been superkey but came back as false")
+	}
+}
+
+func TestApplicationIsSuperkeyFalse(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("application_superkey_false")
+	defer DropSchema("application_superkey_false")
+
+	src := m.Source{
+		Name:                "NotSuperkey",
+		Uid:                 util.StringRef("asdf"),
+		SourceTypeID:        fixtures.TestSourceTypeData[0].Id,
+		AppCreationWorkflow: m.ManualConfig,
+		TenantID:            fixtures.TestTenantData[0].Id,
+	}
+	srcDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+	err := srcDao.Create(&src)
+	if err != nil {
+		t.Error(err)
+	}
+
+	app := m.Application{
+		SourceID:          src.ID,
+		ApplicationTypeID: fixtures.TestApplicationTypeData[0].Id,
+		TenantID:          fixtures.TestTenantData[0].Id,
+	}
+	appDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+	err = appDao.Create(&app)
+	if err != nil {
+		t.Error(err)
+	}
+
+	superkey := appDao.IsSuperkey(app.ID)
+	if superkey {
+		t.Errorf("application should have been NOT superkey but came back as true")
+	}
+}


### PR DESCRIPTION
So this is why superkey creation for cost was failing, basically this method is used to determine whether an app is superkey or not and by returning false on error it didn't tell us what was going on it just silently failed.

---

The background is that the superkey process introduces a bit of async into the app - we sent out the initial `Source.create` event but then _wait_ to send the `(Application|Authentication|ApplicationAuthentication).create` messages until superkey worker posts back. 

So basically the change that happened was since the superkey lookup was failing we were sending `Application.update` instead of `Application.create`, which is weird because this is happening on a PATCH, but that's what we get for introducing async. 

---

_Coincidentally this was the first real reason to flesh out the Gorm Logger's methods which take a context, so we can effectively log failures better from the DAOs now!_

EDIT: also added a test for it.