### PR TITLE
[DISSCUSSION] feature: application user for the sources application

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,41 +18,43 @@ var parsedConfig *SourcesApiConfig
 
 // SourcesApiConfig is the struct for storing runtime configuration
 type SourcesApiConfig struct {
-	AppName                 string
-	Hostname                string
-	KafkaBrokerConfig       clowder.BrokerConfig
-	KafkaTopics             map[string]string
-	KafkaGroupID            string
-	MetricsPort             int
-	LogLevel                string
-	LogGroup                string
-	MarketplaceHost         string
-	AwsRegion               string
-	AwsAccessKeyID          string
-	AwsSecretAccessKey      string
-	DatabaseHost            string
-	DatabasePort            int
-	DatabaseUser            string
-	DatabasePassword        string
-	DatabaseName            string
-	FeatureFlagsEnvironment string
-	FeatureFlagsUrl         string
-	FeatureFlagsAPIToken    string
-	FeatureFlagsService     string
-	FeatureFlagsBearerToken string
-	CacheHost               string
-	CachePort               int
-	CachePassword           string
-	SlowSQLThreshold        int
-	Psks                    []string
-	BypassRbac              bool
-	StatusListener          bool
-	BackgroundWorker        bool
-	MigrationsSetup         bool
-	MigrationsReset         bool
-	SecretStore             string
-	TenantTranslatorUrl     string
-	ResourceOwnership       string
+	AppName                     string
+	Hostname                    string
+	KafkaBrokerConfig           clowder.BrokerConfig
+	KafkaTopics                 map[string]string
+	KafkaGroupID                string
+	MetricsPort                 int
+	LogLevel                    string
+	LogGroup                    string
+	MarketplaceHost             string
+	AwsRegion                   string
+	AwsAccessKeyID              string
+	AwsSecretAccessKey          string
+	DatabaseHost                string
+	DatabasePort                int
+	DatabaseUser                string
+	DatabaseUserApplication     string
+	DatabasePassword            string
+	DatabasePasswordApplication string
+	DatabaseName                string
+	FeatureFlagsEnvironment     string
+	FeatureFlagsUrl             string
+	FeatureFlagsAPIToken        string
+	FeatureFlagsService         string
+	FeatureFlagsBearerToken     string
+	CacheHost                   string
+	CachePort                   int
+	CachePassword               string
+	SlowSQLThreshold            int
+	Psks                        []string
+	BypassRbac                  bool
+	StatusListener              bool
+	BackgroundWorker            bool
+	MigrationsSetup             bool
+	MigrationsReset             bool
+	SecretStore                 string
+	TenantTranslatorUrl         string
+	ResourceOwnership           string
 }
 
 //String() returns a string that shows the settings in which the pod is running in
@@ -244,43 +246,49 @@ func Get() *SourcesApiConfig {
 		brokerConfig = bcRaw
 	}
 
+	// Grab the database's low privilege user and password.
+	options.SetDefault("DatabaseUserApplication", os.Getenv("DATABASE_APPLICATION_USERNAME"))
+	options.SetDefault("DatabasePasswordApplication", os.Getenv("DATABASE_APPLICATION_PASSWORD"))
+
 	options.AutomaticEnv()
 	parsedConfig = &SourcesApiConfig{
-		AppName:                 options.GetString("AppName"),
-		Hostname:                options.GetString("Hostname"),
-		KafkaBrokerConfig:       brokerConfig,
-		KafkaTopics:             options.GetStringMapString("KafkaTopics"),
-		KafkaGroupID:            options.GetString("KafkaGroupID"),
-		MetricsPort:             options.GetInt("MetricsPort"),
-		LogLevel:                options.GetString("LogLevel"),
-		SlowSQLThreshold:        options.GetInt("SlowSQLThreshold"),
-		LogGroup:                options.GetString("LogGroup"),
-		MarketplaceHost:         options.GetString("MarketplaceHost"),
-		AwsRegion:               options.GetString("AwsRegion"),
-		AwsAccessKeyID:          options.GetString("AwsAccessKeyID"),
-		AwsSecretAccessKey:      options.GetString("AwsSecretAccessKey"),
-		DatabaseHost:            options.GetString("DatabaseHost"),
-		DatabasePort:            options.GetInt("DatabasePort"),
-		DatabaseUser:            options.GetString("DatabaseUser"),
-		DatabasePassword:        options.GetString("DatabasePassword"),
-		DatabaseName:            options.GetString("DatabaseName"),
-		FeatureFlagsEnvironment: options.GetString("FeatureFlagsEnvironment"),
-		FeatureFlagsUrl:         options.GetString("FeatureFlagsUrl"),
-		FeatureFlagsAPIToken:    options.GetString("FeatureFlagsAPIToken"),
-		FeatureFlagsBearerToken: options.GetString("FeatureFlagsBearerToken"),
-		FeatureFlagsService:     options.GetString("FeatureFlagsService"),
-		CacheHost:               options.GetString("CacheHost"),
-		CachePort:               options.GetInt("CachePort"),
-		CachePassword:           options.GetString("CachePassword"),
-		Psks:                    options.GetStringSlice("psks"),
-		BypassRbac:              options.GetBool("BypassRbac"),
-		StatusListener:          options.GetBool("StatusListener"),
-		BackgroundWorker:        options.GetBool("BackgroundWorker"),
-		MigrationsSetup:         options.GetBool("MigrationsSetup"),
-		MigrationsReset:         options.GetBool("MigrationsReset"),
-		SecretStore:             options.GetString("SecretStore"),
-		TenantTranslatorUrl:     options.GetString("TenantTranslatorUrl"),
-		ResourceOwnership:       options.GetString("ResourceOwnership"),
+		AppName:                     options.GetString("AppName"),
+		Hostname:                    options.GetString("Hostname"),
+		KafkaBrokerConfig:           brokerConfig,
+		KafkaTopics:                 options.GetStringMapString("KafkaTopics"),
+		KafkaGroupID:                options.GetString("KafkaGroupID"),
+		MetricsPort:                 options.GetInt("MetricsPort"),
+		LogLevel:                    options.GetString("LogLevel"),
+		SlowSQLThreshold:            options.GetInt("SlowSQLThreshold"),
+		LogGroup:                    options.GetString("LogGroup"),
+		MarketplaceHost:             options.GetString("MarketplaceHost"),
+		AwsRegion:                   options.GetString("AwsRegion"),
+		AwsAccessKeyID:              options.GetString("AwsAccessKeyID"),
+		AwsSecretAccessKey:          options.GetString("AwsSecretAccessKey"),
+		DatabaseHost:                options.GetString("DatabaseHost"),
+		DatabasePort:                options.GetInt("DatabasePort"),
+		DatabaseUser:                options.GetString("DatabaseUser"),
+		DatabaseUserApplication:     options.GetString("DatabaseUserApplication"),
+		DatabasePassword:            options.GetString("DatabasePassword"),
+		DatabasePasswordApplication: options.GetString("DatabasePasswordApplication"),
+		DatabaseName:                options.GetString("DatabaseName"),
+		FeatureFlagsEnvironment:     options.GetString("FeatureFlagsEnvironment"),
+		FeatureFlagsUrl:             options.GetString("FeatureFlagsUrl"),
+		FeatureFlagsAPIToken:        options.GetString("FeatureFlagsAPIToken"),
+		FeatureFlagsBearerToken:     options.GetString("FeatureFlagsBearerToken"),
+		FeatureFlagsService:         options.GetString("FeatureFlagsService"),
+		CacheHost:                   options.GetString("CacheHost"),
+		CachePort:                   options.GetInt("CachePort"),
+		CachePassword:               options.GetString("CachePassword"),
+		Psks:                        options.GetStringSlice("psks"),
+		BypassRbac:                  options.GetBool("BypassRbac"),
+		StatusListener:              options.GetBool("StatusListener"),
+		BackgroundWorker:            options.GetBool("BackgroundWorker"),
+		MigrationsSetup:             options.GetBool("MigrationsSetup"),
+		MigrationsReset:             options.GetBool("MigrationsReset"),
+		SecretStore:                 options.GetString("SecretStore"),
+		TenantTranslatorUrl:         options.GetString("TenantTranslatorUrl"),
+		ResourceOwnership:           options.GetString("ResourceOwnership"),
 	}
 
 	return parsedConfig

--- a/db/migrations/20220809120000_row_level_security_user.go
+++ b/db/migrations/20220809120000_row_level_security_user.go
@@ -1,0 +1,179 @@
+package migrations
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/RedHatInsights/sources-api-go/config"
+	logging "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+// RowLevelSecurityUser creates a new user on the database. The idea is to have a full privileged user which is the one
+// who runs the migrations, and then another one which will just "use" the database. That is why this second user only
+// has a limited set of permissions for each of the database's tables.
+func RowLevelSecurityUser() *gormigrate.Migration {
+	// Temporarily store the configuration.
+	sourcesConfig := config.Get()
+
+	user := sourcesConfig.DatabaseUserApplication
+	password := sourcesConfig.DatabasePasswordApplication
+	database := sourcesConfig.DatabaseName
+
+	// Permissions is a struct that defines the set of permissions the application user will have on each table.
+	permissions := []struct {
+		Table              string
+		Permissions        []string
+		SequencePermission bool
+	}{
+		{
+			Table:              "application_authentications",
+			Permissions:        []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+			SequencePermission: true,
+		},
+		{
+			Table:       "application_types",
+			Permissions: []string{"SELECT"},
+		},
+		{
+			Table:              "applications",
+			Permissions:        []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+			SequencePermission: true,
+		},
+		{
+			Table:              "authentications",
+			Permissions:        []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+			SequencePermission: true,
+		},
+		{
+			Table:              "endpoints",
+			Permissions:        []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+			SequencePermission: true,
+		},
+		{
+			Table:       "meta_data",
+			Permissions: []string{"SELECT"},
+		},
+		{
+			Table:              "rhc_connections",
+			Permissions:        []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+			SequencePermission: true,
+		},
+		{
+			Table:       "source_rhc_connections",
+			Permissions: []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+		},
+		{
+			Table:       "source_types",
+			Permissions: []string{"SELECT"},
+		},
+		{
+			Table:              "sources",
+			Permissions:        []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+			SequencePermission: true,
+		},
+		{
+			Table:              "tenants",
+			Permissions:        []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+			SequencePermission: true,
+		},
+		{
+			Table:              "users",
+			Permissions:        []string{"SELECT", "INSERT", "UPDATE", "DELETE"},
+			SequencePermission: true,
+		},
+	}
+
+	return &gormigrate.Migration{
+		ID: "20220809120000",
+		Migrate: func(db *gorm.DB) error {
+			logging.Log.Info(`Migration "create a user for row level security settings" started`)
+			defer logging.Log.Info(`Migration "create a user for row level security settings" ended`)
+
+			err := db.Transaction(func(tx *gorm.DB) error {
+				createUserSql := fmt.Sprintf(`CREATE USER %s WITH PASSWORD '%s'`, user, password)
+				err := tx.Debug().Exec(createUserSql).Error
+				if err != nil {
+					return fmt.Errorf("unable to create application user for the database: %w", err)
+				}
+
+				connectUserSql := fmt.Sprintf(`GRANT CONNECT ON DATABASE %s TO %s`, database, user)
+				err = tx.Debug().Exec(connectUserSql).Error
+				if err != nil {
+					return fmt.Errorf(`unable to grant the "connect to database" privilege to user "%s" on database "%s": %w`, user, database, err)
+				}
+
+				grantUsageSql := fmt.Sprintf(`GRANT USAGE ON SCHEMA "public" TO %s`, user)
+				err = tx.Debug().Exec(grantUsageSql).Error
+				if err != nil {
+					return fmt.Errorf(`unable to grant "USAGE" permission to the low privileged user "%s": %w`, user, err)
+				}
+
+				for _, perm := range permissions {
+					grantPermissionsTableSql := fmt.Sprintf(`GRANT %s ON %s TO %s`, strings.Join(perm.Permissions, ", "), perm.Table, user)
+					err := tx.Debug().Exec(grantPermissionsTableSql).Error
+					if err != nil {
+						return fmt.Errorf(`unable to grant "%s" permissions to user "%s" on table "%s": %w`, perm.Permissions, user, perm.Table, err)
+					}
+
+					// The user must be granted access to the sequence of the table if it has an "INSERT" permission
+					// granted.
+					if perm.SequencePermission {
+						grantSequenceSql := fmt.Sprintf(`GRANT USAGE, SELECT ON SEQUENCE %s_id_seq TO %s`, perm.Table, user)
+						err := tx.Debug().Exec(grantSequenceSql).Error
+						if err != nil {
+							return fmt.Errorf(`unable to grant "%s" usage and select permissions on sequence "%s_id_seq" on table "%s": %w`, user, perm.Table, perm.Table, err)
+						}
+					}
+				}
+
+				return nil
+			})
+
+			return err
+		},
+		Rollback: func(db *gorm.DB) error {
+			err := db.Transaction(func(tx *gorm.DB) error {
+				for _, perm := range permissions {
+					dropGrantsSql := fmt.Sprintf("REVOKE ALL PRIVILEGES ON %s FROM %s", perm.Table, user)
+					err := tx.Debug().Exec(dropGrantsSql).Error
+					if err != nil {
+						return fmt.Errorf(`unable to revoke all privileges on table "%s" from user "%s": %w`, perm.Table, user, err)
+					}
+
+					// Revoke the sequence permissions too from the table.
+					if perm.SequencePermission {
+						grantSequenceSql := fmt.Sprintf(`REVOKE USAGE, SELECT ON SEQUENCE %s_id_seq TO %s`, perm.Table, user)
+						err := tx.Debug().Exec(grantSequenceSql).Error
+						if err != nil {
+							return fmt.Errorf(`unable to revoke "%s" usage and select permissions on sequence "%s_id_seq" on table "%s": %w`, user, perm.Table, perm.Table, err)
+						}
+					}
+				}
+
+				revokeUsageSchemaSql := fmt.Sprintf(`REVOKE USAGE ON SCHEMA "public" FROM %s`, user)
+				err := tx.Debug().Exec(revokeUsageSchemaSql).Error
+				if err != nil {
+					return fmt.Errorf(`unable to revoke the usage privilege on schema "public" from user "%s": %w`, user, err)
+				}
+
+				revokeConnectDatabaseSql := fmt.Sprintf("REVOKE CONNECT ON DATABASE %s FROM %s", database, user)
+				err = tx.Debug().Exec(revokeConnectDatabaseSql).Error
+				if err != nil {
+					return fmt.Errorf(`unable to revoke the connect privilege on database "%s" to user "%s": %w`, database, user, err)
+				}
+
+				dropUserSql := fmt.Sprintf("DROP USER %s", user)
+				err = tx.Debug().Exec(dropUserSql).Error
+				if err != nil {
+					return fmt.Errorf(`unable to drop user "%s" from database: %w`, user, err)
+				}
+
+				return nil
+			})
+
+			return err
+		},
+	}
+}

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -26,6 +26,7 @@ var MigrationsCollection = []*gormigrate.Migration{
 	AddApplicationConstraint(),
 	RemoveOldMigrationsTable(),
 	RenameForeignKeysIndexes(),
+	RowLevelSecurityUser(),
 }
 
 var ctx = context.Background()

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -10,6 +10,8 @@ objects:
     labels:
       app: sources-api
   stringData:
+    database-application-username: "${DATABASE_APPLICATION_USERNAME}"
+    database-application-password: "${DATABASE_APPLICATION_PASSWORD}"
     encryption-key: "${ENCRYPTION_KEY}"
     secret-key: "${SECRET_KEY}"
     psks: "thisMustBeEphemeralOrMinikube"
@@ -78,6 +80,18 @@ objects:
             secretKeyRef:
               name: sources-api-secrets
               key: encryption-key
+        - name: DATABASE_APPLICATION_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-secrets
+              key: database-application-username
+              optional: false
+        - name: DATABASE_APPLICATION_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-secrets
+              key: database-application-password
+              optional: false
         resources:
           limits:
             cpu: ${AVAILABILITY_LISTENER_CPU_LIMIT}
@@ -106,6 +120,18 @@ objects:
           value: ${SOURCES_ENV}
         - name: MARKETPLACE_HOST
           value: ${MARKETPLACE_HOST}
+        - name: DATABASE_APPLICATION_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-secrets
+              key: database-application-username
+              optional: false
+        - name: DATABASE_APPLICATION_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sources-api-secrets
+              key: database-application-password
+              optional: false
         - name: SOURCES_PSKS
           valueFrom:
             secretKeyRef:
@@ -342,3 +368,9 @@ parameters:
 - description: Specify any application_types to not seed into the database
   name: APPLICATION_TYPE_SKIP_LIST
   value: ''
+- description: (ephemeral environment only) Specify a database username for the application user of sources
+  name: DATABASE_APPLICATION_USERNAME
+  value: sources_application_user
+- description: (Ephemeral environment only) Specify a user password for the application user of sources
+  name: DATABASE_APPLICATION_PASSWORD
+  value: sources_application_password


### PR DESCRIPTION
The idea is to have two users in the sources application: a fully
privileged one, which will solely be used to perform database migrations
and the seeding.

The application user, on the other hand, is granted just the required
CRUD permissions on the tables for the application to work.

There are two goals:

* Restrict what the database user can do when operating normally.
* Pave the way to enable row level security via session variables in a
  future update.
  
  ## Note

I'm still waiting on AppSre's response according to what they think about having another user on the database. Also, this is just a draft to see what you think about this approach.

The idea would be to store the secrets on Vault, and to pull them from it to access the database. Although since these are database credentials, should they also go in a file on the pod's filesystem? :thinking: 
