### PR TITLE
GET, PATCH and subcollection tests for user based sources

### DIFF
--- a/dao/test_factories.go
+++ b/dao/test_factories.go
@@ -159,12 +159,35 @@ func (s *SourceOwnershipDataTestSuite) SourceUserA() *m.Source {
 	return &s.resourcesUserA.Sources[0]
 }
 
+func (s *SourceOwnershipDataTestSuite) SourceIDsUserA() []int64 {
+	var sourcesIDs []int64
+	for _, source := range s.resourcesUserA.Sources {
+		sourcesIDs = append(sourcesIDs, source.ID)
+	}
+
+	for _, source := range s.resourcesNoUser.Sources {
+		sourcesIDs = append(sourcesIDs, source.ID)
+	}
+
+	return sourcesIDs
+}
+
 func (s *SourceOwnershipDataTestSuite) SourceUserB() *m.Source {
 	return &s.resourcesUserB.Sources[0]
 }
 
 func (s *SourceOwnershipDataTestSuite) SourceNoUser() *m.Source {
 	return &s.resourcesNoUser.Sources[0]
+}
+
+func (s *SourceOwnershipDataTestSuite) SourceIDsNoUser() []int64 {
+	var sourcesIDs []int64
+
+	for _, source := range s.resourcesNoUser.Sources {
+		sourcesIDs = append(sourcesIDs, source.ID)
+	}
+
+	return sourcesIDs
 }
 
 func testSuiteForSourceWithOwnership(performTest func(suiteData *SourceOwnershipDataTestSuite) error) error {


### PR DESCRIPTION
This PR adds tests for user based sources at DAO level:
- GetBytID
- Update
- SubcollectionList + ListForRhcConnection

- I added function `testSuiteForSourceWithOwnership` which is creating resources for testing - most likely it will be used on all models - it is designed to test 3 main scenarios.

Example:
Test 1 - UserA tries to update source for userA - expected result: success (usually some records listed)
Test 2 - UserA tries to update source without user - expected result: success  (usually  some records listed)
Test 3 - User without any ownership records tries to update userA's source - expected result: failure  (usually no records listed)

Note: this not all test for sources endpoint - check issue https://github.com/RedHatInsights/sources-api-go/issues/356 track progress

### Links
https://github.com/RedHatInsights/sources-api-go/issues/356

