### PR TITLE
[RH-CLOUD-20026] add check if source's name is unique into edit source handler

### DIFF
--- a/service/source_validation.go
+++ b/service/source_validation.go
@@ -55,8 +55,8 @@ func ValidateSourceCreationRequest(dao dao.SourceDao, req *model.SourceCreateReq
 
 	return nil
 }
-func ValidateEditSourceNameRequest(dao dao.SourceDao, req *model.SourceEditRequest) error {
 
+func ValidateEditSourceNameRequest(dao dao.SourceDao, req *model.SourceEditRequest) error {
 	if req.Name == nil || *req.Name == "" {
 		return fmt.Errorf("name cannot be empty")
 	}

--- a/service/source_validation.go
+++ b/service/source_validation.go
@@ -55,3 +55,15 @@ func ValidateSourceCreationRequest(dao dao.SourceDao, req *model.SourceCreateReq
 
 	return nil
 }
+func ValidateEditSourceNameRequest(dao dao.SourceDao, req *model.SourceEditRequest) error {
+
+	if req.Name == nil || *req.Name == "" {
+		return fmt.Errorf("name cannot be empty")
+	}
+
+	if dao.NameExistsInCurrentTenant(*req.Name) {
+		return fmt.Errorf("source name already exists in same tenant")
+	}
+
+	return nil
+}

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -164,6 +164,10 @@ func SourceEdit(c echo.Context) error {
 		if err := c.Bind(input); err != nil {
 			return err
 		}
+		err := service.ValidateEditSourceNameRequest(sourcesDB, input)
+		if err != nil {
+			return util.NewErrBadRequest(err)
+		}
 
 		s.UpdateFromRequest(input)
 	}

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -164,7 +164,9 @@ func SourceEdit(c echo.Context) error {
 		if err := c.Bind(input); err != nil {
 			return err
 		}
+
 		err := service.ValidateEditSourceNameRequest(sourcesDB, input)
+
 		if err != nil {
 			return util.NewErrBadRequest(err)
 		}


### PR DESCRIPTION
Created ValidateEditSourceNameRequest() within service/source_validation.go and implemented function within source_handlers.go in order to return a bad request if a source is edited to have the same name as another source within the same tenant.

In service/source_validation_test.go, created test to see if bad request is returned once source name is edited to have the same name as another source within same tenant.

JIRA: [https://issues.redhat.com/browse/RHCLOUD-20026](url)