### PR TITLE
[RHCLOUD-20681] Add OrgId to nofitication messsage in listener

### DIFF
--- a/service/notifications.go
+++ b/service/notifications.go
@@ -89,6 +89,10 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(i
 		return err
 	}
 
+	if id.OrgID == "" {
+		l.Log.Warnf("OrgID is not present, notification maybe not be processed in notification service for %v", statusEventType)
+	}
+
 	event := notificationEvent{Metadata: notificationMetadata{}, Payload: string(payload)}
 
 	msg := &kafka.Message{}

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -117,6 +117,10 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		return
 	}
 
+	if id.OrgID == "" {
+		id.OrgID = tenant.OrgID
+	}
+
 	updateAttributes := avs.attributesForUpdate(statusMessage)
 	modelEventDao, err := dao.GetFromResourceType(statusMessage.ResourceType, tenant.Id)
 	if err != nil {

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -4,8 +4,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
@@ -41,12 +43,16 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 			outputIdentity.AccountNumber = string(header.Value)
 		}
 
+		if header.Key == h.ORGID {
+			outputIdentity.OrgID = string(header.Value)
+		}
+
 		if header.Key == xrhIdentityKey {
 			xRhIdentity, err := ParseXRHIDHeader(string(header.Value))
 			if err != nil {
 				return nil, err
 			}
-			
+
 			outputIdentity = xRhIdentity.Identity
 		}
 	}

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/kafka"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
@@ -127,11 +128,15 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 		}
 	}
 
-	// Lastly test with the "x-rh-account-number" header.
+	// Lastly test with the "x-rh-account-number" and "x-rh-sources-org-id" header.
 	headers = []kafka.Header{
 		{
 			Key:   xrhAccountNumberKey,
 			Value: []byte(accountNumber),
+		},
+		{
+			Key:   h.ORGID,
+			Value: []byte(orgId),
 		},
 	}
 
@@ -145,6 +150,14 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 		got := id.AccountNumber
 		if want != got {
 			t.Errorf(`invalid account number extracted from identity. Want "%s", got "%s"`, want, got)
+		}
+	}
+
+	{
+		want := orgId
+		got := id.OrgID
+		if want != got {
+			t.Errorf(`invalid org id extracted from identity. Want "%s", got "%s"`, want, got)
 		}
 	}
 


### PR DESCRIPTION
This change allows to add OrgId to notification message in status listener.
OrgId is already present in notification messages which are emitted based on API request to sources server. (changing av.status by API)

Firstly I needed to reorganize `IdentityFromKafkaHeaders ` in order to catch OrgID from status Kafka message from its headers.
If there is no OrgID present in Kafka status message - OrgID is taken it from tenant record.

### Links
https://issues.redhat.com/browse/RHCLOUD-20681
