### PR TITLE
Add identification for notification messages

### DIFF
--- a/internal/testutils/mocks/mock_notification_producer.go
+++ b/internal/testutils/mocks/mock_notification_producer.go
@@ -12,7 +12,7 @@ type MockAvailabilityStatusNotificationProducer struct {
 	EmailNotificationInfo             *m.EmailNotificationInfo
 }
 
-func (producer *MockAvailabilityStatusNotificationProducer) EmitAvailabilityStatusNotification(id *identity.Identity, emailNotificationInfo *m.EmailNotificationInfo) error {
+func (producer *MockAvailabilityStatusNotificationProducer) EmitAvailabilityStatusNotification(id *identity.Identity, emailNotificationInfo *m.EmailNotificationInfo, guidPrefix string) error {
 	producer.EmitAvailabilityStatusCallCounter++
 	producer.EmailNotificationInfo = emailNotificationInfo
 	producer.AccountNumber = id.AccountNumber

--- a/middleware/notifier.go
+++ b/middleware/notifier.go
@@ -27,7 +27,7 @@ func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		if emailNotificationInfo.PreviousAvailabilityStatus != emailNotificationInfo.CurrentAvailabilityStatus {
-			return service.EmitAvailabilityStatusNotification(&xRhIdentity.Identity, emailNotificationInfo)
+			return service.EmitAvailabilityStatusNotification(&xRhIdentity.Identity, emailNotificationInfo, "notifier-middleware")
 		}
 
 		return nil

--- a/service/notifications.go
+++ b/service/notifications.go
@@ -67,6 +67,7 @@ type notificationMessage struct {
 	Context     string                   `json:"context"`
 	Events      []notificationEvent      `json:"events"`
 	Recipients  []notificationRecipients `json:"recipients"`
+	ID          string                   `json:"id"`
 }
 
 func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(id *identity.Identity, emailNotificationInfo *m.EmailNotificationInfo) error {

--- a/service/notifications.go
+++ b/service/notifications.go
@@ -84,12 +84,11 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(i
 		notificationMessageGuid = fmt.Sprintf("%s-%s", guidPrefix, notificationMessageGuid)
 	}
 
-	l.Log.Infof("[tenant_id: %s][source_id: %s] Publishing notification status message, status %s changed from: %s to %s",
+	l.Log.WithField("notification-guid", notificationMessageGuid).Infof(`[tenant_id: %s][source_id: %s] Publishing notification status message, status changed from '%s' to '%s'`,
 		emailNotificationInfo.TenantID,
 		emailNotificationInfo.SourceID,
 		emailNotificationInfo.PreviousAvailabilityStatus,
-		emailNotificationInfo.CurrentAvailabilityStatus,
-		notificationMessageGuid)
+		emailNotificationInfo.CurrentAvailabilityStatus)
 
 	context, err := json.Marshal(emailNotificationInfo)
 	if err != nil {

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -163,7 +163,7 @@ func (avs *AvailabilityStatusListener) processEvent(statusMessage types.StatusMe
 		}
 
 		if emailInfo != nil {
-			err = service.EmitAvailabilityStatusNotification(id, emailInfo.ToEmail(previousStatus))
+			err = service.EmitAvailabilityStatusNotification(id, emailInfo.ToEmail(previousStatus), "status-listener")
 			if err != nil {
 				l.Log.Errorf("[tenant_id: %d][resource_type: %s][resource_id: %d][resource_uuid: %s] unable to emit notification: %v", resource.TenantID, resource.ResourceType, resource.ResourceID, resource.ResourceUID, err)
 			}


### PR DESCRIPTION
This PR adds change about populating id in notification Kafka message.
Point 14 here - https://core-platform-apps.pages.redhat.com/notifications-docs/dev/user-guide/send-notification.html#_kafka.

With this change it is possible to identify better source where was notification message sent from - this guid will be displayed also in log of notification service.




