### PR TITLE
Add test for pause unpause

### DIFF
--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -390,7 +390,7 @@ func (s *sourceDaoImpl) Unpause(id int64) error {
 			return err
 		}
 
-		err = tx.Debug().
+		err = s.getDbWithTable(tx.Debug(), "").
 			Model(&m.Application{}).
 			Where("source_id = ?", id).
 			Where("tenant_id = ?", s.TenantID).

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -365,7 +365,7 @@ func (s *sourceDaoImpl) Pause(id int64) error {
 			return err
 		}
 
-		err = tx.Debug().
+		err = s.getDbWithTable(tx.Debug(), "").
 			Model(&m.Application{}).
 			Where("source_id = ?", id).
 			Where("tenant_id = ?", s.TenantID).

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -99,7 +99,7 @@ func TestPausingSourceWithOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("pause_unpause")
 
-	err := testSuiteForSourceWithOwnership(func(suiteData *SourceOwnershipDataTestSuite) error {
+	err := TestSuiteForSourceWithOwnership(func(suiteData *SourceOwnershipDataTestSuite) error {
 		/*
 		 Test 1 - UserA tries to pause source for userA - expected result: success
 		*/
@@ -190,7 +190,7 @@ func TestUnpauseSourceWithOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("pause_unpause")
 
-	err := testSuiteForSourceWithOwnership(func(suiteData *SourceOwnershipDataTestSuite) error {
+	err := TestSuiteForSourceWithOwnership(func(suiteData *SourceOwnershipDataTestSuite) error {
 		/*
 		 Test 1 - UserA tries to unpause source for userA - expected result: success
 		*/


### PR DESCRIPTION
Add tests for pause/unpause source DAO functions.

There is also fix which adds userid condition to query where applications are updated in pause/unpause source DAO functions.


### Links
https://github.com/RedHatInsights/sources-api-go/issues/356
- [x] Required PR https://github.com/RedHatInsights/sources-api-go/pull/504