### PR TITLE
[RHCLOUD-20615] fix: return status 400 on user error on Bulk Create

### DIFF
--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
@@ -50,7 +51,7 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 	c.Set(h.USERID, user.Id)
 
 	err = BulkCreate(c)
-	if err.Error() != "no source type present, need either [source_type_name] or [source_type_id]" {
+	if !strings.Contains(err.Error(), "no source type present, need either [source_type_name] or [source_type_id]") {
 		t.Error(err)
 	}
 

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -111,7 +111,12 @@ func Produce(writer *kafka.Writer, message *Message) error {
 		)
 
 		if err != nil {
-			return fmt.Errorf(`could not produce Kafka message "%v": %w`, message, err)
+			headersMap := make(map[string]string)
+			for _, h := range message.Headers {
+				headersMap[h.Key] = string(h.Value)
+			}
+
+			return fmt.Errorf(`could not produce Kafka message. Headers: %s, content: "%s": %w`, headersMap, string(message.Value), err)
 		}
 	}
 


### PR DESCRIPTION
Until now most of the errors were returned as 500s, even if it was an
error related with an invalid input from the user. This commit fixes
that.

## Links

[[RHCLOUD-20615]](https://issues.redhat.com/browse/RHCLOUD-20615)