### PR TITLE
Switch to x-rh-insights-request-id instead of generating our own uuid

### DIFF
--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
@@ -24,7 +25,7 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 				message = util.ErrorDocWithoutLogging(err.Error(), "400")
 			default:
 				c.Logger().Error(err)
-				uuid, ok := c.Get("uuid").(string)
+				uuid, ok := c.Get(h.INSIGHTS_REQUEST_ID).(string)
 				if !ok {
 					uuid = ""
 				}

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -43,6 +43,10 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.PSK_USER, c.Request().Header.Get(h.PSK_USER))
 		}
 
+		if c.Request().Header.Get(h.INSIGHTS_REQUEST_ID) != "" {
+			c.Set(h.INSIGHTS_REQUEST_ID, c.Request().Header.Get(h.INSIGHTS_REQUEST_ID))
+		}
+
 		// id is the XrhId struct we will store in the context. The idea is: if no "x-rh-identity" header has been
 		// received, generate an identity struct from the given "OrgId" and "EBS account number". If the "x-rh-identity"
 		// header is present, simply decode it and use the decided identity.

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -1,12 +1,13 @@
 package headers
 
 const (
-	PSK             = "x-rh-sources-psk"
-	ACCOUNT_NUMBER  = "x-rh-sources-account-number"
-	ORGID           = "x-rh-sources-org-id"
-	PSK_USER        = "x-rh-sources-user-id"
-	XRHID           = "x-rh-identity"
-	PARSED_IDENTITY = "identity"
-	TENANTID        = "tenantID"
-	USERID          = "userID"
+	PSK                 = "x-rh-sources-psk"
+	ACCOUNT_NUMBER      = "x-rh-sources-account-number"
+	ORGID               = "x-rh-sources-org-id"
+	PSK_USER            = "x-rh-sources-user-id"
+	XRHID               = "x-rh-identity"
+	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"
+	PARSED_IDENTITY     = "identity"
+	TENANTID            = "tenantID"
+	USERID              = "userID"
 )

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -5,7 +5,6 @@ import (
 
 	l "github.com/RedHatInsights/sources-api-go/logger"
 	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
 )
@@ -17,7 +16,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		agent := c.Request().UserAgent()
 		acct := c.Get(h.ACCOUNT_NUMBER)
 		orgid := c.Get(h.ORGID)
-		uuid := uuid.New().String()
+		uuid := c.Get(h.INSIGHTS_REQUEST_ID)
 
 		baseFields := logrus.Fields{
 			"uri":            uri,
@@ -31,7 +30,6 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		baseLoggerEntry := l.Log.WithFields(baseFields)
 
 		c.Set("logger", baseLoggerEntry)
-		c.Set("uuid", uuid)
 		// holy cow echo makes this ugly. Setting a value on the actual net/http request's context
 		c.SetRequest(c.Request().WithContext(context.WithValue(c.Request().Context(), l.EchoLogger{}, baseLoggerEntry)))
 


### PR DESCRIPTION
I totally forgot that 3scale includes a request-id on each request. This way we can use that and follow it through the system more effectively. 