### PR TITLE
[RHCLOUD-18655] feature: add tenant translation endpoints

### DIFF
--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -172,6 +172,15 @@ type TenantDao interface {
 	// TenantByIdentity returns the tenant associated to the given identity. It tries to fetch the tenant by its OrgId,
 	// and if it is not preset, by its EBS account number.
 	TenantByIdentity(identity *identity.Identity) (*m.Tenant, error)
+	// GetUntranslatedTenants returns a list of tenants which only have an EBS account number and not a corresponding
+	// OrgId.
+	GetUntranslatedTenants() ([]m.Tenant, error)
+	// TranslateTenants attempts to translate tenants which only have an EBS account number. It takes batches of 100
+	// tenants and tries to get an "org_id" translation for the "external_tenant" number.
+	//
+	// Returns the total number of translatable tenants, number of translated tenants, untranslated tenants and each
+	// translation operation's results. It doesn't error when a tenant cannot be translated.
+	TranslateTenants() (int64, uint64, uint64, []m.TenantTranslation, error)
 }
 
 type UserDao interface {

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -113,7 +113,7 @@ func (t *tenantDaoImpl) GetUntranslatedTenants() ([]m.Tenant, error) {
 
 	err := DB.Debug().
 		Model(&m.Tenant{}).
-		Where(`("external_tenant" IS NOT NULL OR "external_tenant" = '') AND ("org_id" IS NULL OR "org_id" = '')`).
+		Where(`("external_tenant" IS NOT NULL OR "external_tenant" != '') AND ("org_id" IS NULL OR "org_id" = '')`).
 		Find(&tenants).
 		Error
 
@@ -126,7 +126,7 @@ func (t *tenantDaoImpl) GetUntranslatedTenants() ([]m.Tenant, error) {
 
 func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTranslation, error) {
 	// The where condition to fetch only the untranslated tenants.
-	untranslatedTenantsWhereCondition := `("external_tenant" IS NOT NULL OR "external_tenant" = '') AND ("org_id" IS NULL OR "org_id" = '')`
+	untranslatedTenantsWhereCondition := `("external_tenant" IS NOT NULL OR "external_tenant" != '') AND ("org_id" IS NULL OR "org_id" = '')`
 
 	// Count the total number of translatable tenants.
 	var translatableTenants int64

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -212,8 +212,8 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 					continue
 				}
 
-				if err != nil {
-					translationError := fmt.Errorf(`could no translate to "org_id": %w`, err)
+				if dbResult.Error != nil {
+					translationError := fmt.Errorf(`could no translate to "org_id": %w`, dbResult.Error)
 
 					logger.Log.WithField("external_tenant", *result.EAN).WithField("org_id", result.OrgID).Error(translationError)
 

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -225,7 +225,9 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 					continue
 				}
 
-				logger.Log.WithField("external_tenant", *result.EAN).WithField("org_id", result.OrgID).Info("successful tenant translation")
+				logger.Log.WithFields(
+					logrus.Fields{"external_tenant": *result.EAN, "org_id": result.OrgID, "tenant_id": tenant.Id},
+				).Info("successful tenant translation")
 
 				tenantTranslation.Id = tenant.Id
 				tenantTranslation.ExternalTenant = *result.EAN

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -199,6 +199,19 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 						"org_id": result.OrgID,
 					})
 
+				if dbResult.Error != nil {
+					translationError := fmt.Errorf(`could no translate to "org_id": %w`, dbResult.Error)
+
+					logger.Log.WithField("external_tenant", *result.EAN).WithField("org_id", result.OrgID).Error(translationError)
+
+					tenantTranslation.ExternalTenant = *result.EAN
+					tenantTranslation.OrgId = result.OrgID
+					tenantTranslations = append(tenantTranslations, tenantTranslation)
+
+					untranslatedTenants++
+					continue
+				}
+
 				// If the update yielded 0 affected rows that means that no tenant could be found with that
 				// "external_tenant".
 				if dbResult.RowsAffected == 0 {
@@ -208,19 +221,6 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 
 					tenantTranslation.ExternalTenant = *result.EAN
 					tenantTranslation.Error = translationError
-					tenantTranslations = append(tenantTranslations, tenantTranslation)
-
-					untranslatedTenants++
-					continue
-				}
-
-				if dbResult.Error != nil {
-					translationError := fmt.Errorf(`could no translate to "org_id": %w`, dbResult.Error)
-
-					logger.Log.WithField("external_tenant", *result.EAN).WithField("org_id", result.OrgID).Error(translationError)
-
-					tenantTranslation.ExternalTenant = *result.EAN
-					tenantTranslation.OrgId = result.OrgID
 					tenantTranslations = append(tenantTranslations, tenantTranslation)
 
 					untranslatedTenants++

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -16,6 +16,10 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// untranslatedTenantsWhereCondition is the condition required for the "get tenants" and "update tenants" member
+// functions to grab the tenants that are translatable.
+const untranslatedTenantsWhereCondition = `("external_tenant" IS NOT NULL OR "external_tenant" != '') AND ("org_id" IS NULL OR "org_id" = '')`
+
 // GetTenantDao is a function definition that can be replaced in runtime in case some other DAO provider is
 // needed.
 var GetTenantDao func() TenantDao
@@ -113,7 +117,7 @@ func (t *tenantDaoImpl) GetUntranslatedTenants() ([]m.Tenant, error) {
 
 	err := DB.Debug().
 		Model(&m.Tenant{}).
-		Where(`("external_tenant" IS NOT NULL OR "external_tenant" != '') AND ("org_id" IS NULL OR "org_id" = '')`).
+		Where(untranslatedTenantsWhereCondition).
 		Find(&tenants).
 		Error
 
@@ -125,9 +129,6 @@ func (t *tenantDaoImpl) GetUntranslatedTenants() ([]m.Tenant, error) {
 }
 
 func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTranslation, error) {
-	// The where condition to fetch only the untranslated tenants.
-	untranslatedTenantsWhereCondition := `("external_tenant" IS NOT NULL OR "external_tenant" != '') AND ("org_id" IS NULL OR "org_id" = '')`
-
 	// Count the total number of translatable tenants.
 	var translatableTenants int64
 	// Count the translation operations.

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -159,6 +159,7 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 				Where(untranslatedTenantsWhereCondition).
 				Pluck("external_tenant", &ebsAccountNumbers).
 				Offset(int(i)).
+				Order(clause.OrderByColumn{Column: clause.Column{Name: "external_tenant"}, Desc: false}).
 				Limit(100).
 				Error
 

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -158,6 +158,7 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 				Where(untranslatedTenantsWhereCondition).
 				Pluck("external_tenant", &ebsAccountNumbers).
 				Offset(int(i)).
+				Limit(100).
 				Error
 
 			if err != nil {

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -1,15 +1,19 @@
 package dao
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/RedHatInsights/tenant-utils/pkg/tenantid"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GetTenantDao is a function definition that can be replaced in runtime in case some other DAO provider is
@@ -102,4 +106,142 @@ func (t *tenantDaoImpl) TenantByIdentity(id *identity.Identity) (*m.Tenant, erro
 	}
 
 	return &tenant, nil
+}
+
+func (t *tenantDaoImpl) GetUntranslatedTenants() ([]m.Tenant, error) {
+	var tenants []m.Tenant
+
+	err := DB.Debug().
+		Model(&m.Tenant{}).
+		Where(`("external_tenant" IS NOT NULL OR "external_tenant" = '') AND ("org_id" IS NULL OR "org_id" = '')`).
+		Find(&tenants).
+		Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tenants, err
+}
+
+func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTranslation, error) {
+	// The where condition to fetch only the untranslated tenants.
+	untranslatedTenantsWhereCondition := `("external_tenant" IS NOT NULL OR "external_tenant" = '') AND ("org_id" IS NULL OR "org_id" = '')`
+
+	// Count the total number of translatable tenants.
+	var translatableTenants int64
+	// Count the translation operations.
+	var translatedTenants, untranslatedTenants uint64
+	// Keep track of each of the tenant translations.
+	var tenantTranslations []m.TenantTranslation
+
+	// Run everything inside a transaction to avoid inconsistencies. This way if new tenants are added/removed while
+	// the translation is in progress, all the counts and the results will still match.
+	err := DB.Debug().Transaction(func(tx *gorm.DB) error {
+		// Get the count to be able to process the tenants in batches of 100 tenants.
+		err := DB.Debug().
+			Model(&m.Tenant{}).
+			Where(untranslatedTenantsWhereCondition).
+			Count(&translatableTenants).
+			Error
+
+		if err != nil {
+			return fmt.Errorf("unable to count untranslated tenants: %w", err)
+		}
+
+		translator := tenantid.NewTranslator(config.Get().TenantTranslatorUrl)
+		for i := int64(0); i < translatableTenants; i += 100 {
+			// Grab all the EBS account numbers to be processed.
+			var ebsAccountNumbers []string
+			err := DB.
+				Debug().
+				Model(&m.Tenant{}).
+				Where(untranslatedTenantsWhereCondition).
+				Pluck("external_tenant", &ebsAccountNumbers).
+				Offset(int(i)).
+				Error
+
+			if err != nil {
+				return fmt.Errorf("unable to fetch the tenants to translate them: %w", err)
+			}
+
+			// Batch process 100 EBS account numbers.
+			results, err := translator.EANsToOrgIDs(context.Background(), ebsAccountNumbers)
+			if err != nil {
+				return fmt.Errorf("error when calling the translation service: %w", err)
+			}
+
+			for _, result := range results {
+				var tenantTranslation = m.TenantTranslation{}
+
+				// Did the translation service return an error?
+				if result.Err != nil {
+					logger.Log.WithField("external_tenant", *result.EAN).Errorf(`could not translate to "org_id": %s`, err)
+
+					tenantTranslation.ExternalTenant = *result.EAN
+					tenantTranslation.Error = err
+					tenantTranslations = append(tenantTranslations, tenantTranslation)
+
+					untranslatedTenants++
+					continue
+				}
+
+				// Grab the updated tenant for the "translated tenant" struct.
+				var tenant m.Tenant
+				// Update the tenant with the translated "orgId".
+				dbResult := DB.Debug().
+					Model(&tenant).
+					Clauses(clause.Returning{Columns: []clause.Column{{Name: "id"}}}).
+					Where("external_tenant = ?", result.EAN).
+					Updates(map[string]interface{}{
+						"org_id": result.OrgID,
+					})
+
+				// If the update yielded 0 affected rows that means that no tenant could be found with that
+				// "external_tenant".
+				if dbResult.RowsAffected == 0 {
+					translationError := errors.New(`could not translate to "org_id": external tenant not found`)
+
+					logger.Log.WithField("external_tenant", *result.EAN).Error(translationError)
+
+					tenantTranslation.ExternalTenant = *result.EAN
+					tenantTranslation.Error = translationError
+					tenantTranslations = append(tenantTranslations, tenantTranslation)
+
+					untranslatedTenants++
+					continue
+				}
+
+				if err != nil {
+					translationError := fmt.Errorf(`could no translate to "org_id": %w`, err)
+
+					logger.Log.WithField("external_tenant", *result.EAN).WithField("org_id", result.OrgID).Error(translationError)
+
+					tenantTranslation.ExternalTenant = *result.EAN
+					tenantTranslation.OrgId = result.OrgID
+					tenantTranslations = append(tenantTranslations, tenantTranslation)
+
+					untranslatedTenants++
+					continue
+				}
+
+				logger.Log.WithField("external_tenant", *result.EAN).WithField("org_id", result.OrgID).Info("successful tenant translation")
+
+				tenantTranslation.Id = tenant.Id
+				tenantTranslation.ExternalTenant = *result.EAN
+				tenantTranslation.OrgId = result.OrgID
+				tenantTranslations = append(tenantTranslations, tenantTranslation)
+
+				translatedTenants++
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return 0, 0, 0, nil, err
+	}
+
+	return translatableTenants, translatedTenants, untranslatedTenants, tenantTranslations, nil
 }

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -29,9 +29,19 @@ func (mtd mockTenantDao) GetOrCreateTenant(_ *identity.Identity) (*m.Tenant, err
 	return &tenant, nil
 }
 
+// GetUntranslatedTenants is unimplemented since we are not using it in the tests.
+func (_ mockTenantDao) GetUntranslatedTenants() ([]m.Tenant, error) {
+	return nil, nil
+}
+
 // TenantByIdentity is unimplemented since we are not using it in the tests.
 func (_ mockTenantDao) TenantByIdentity(_ *identity.Identity) (*m.Tenant, error) {
 	return nil, nil
+}
+
+// GetUntranslatedTenants is unimplemented since we are not using it in the tests.
+func (_ mockTenantDao) TranslateTenants() (int64, uint64, uint64, []m.TenantTranslation, error) {
+	return 0, 0, 0, nil, nil
 }
 
 // TestTenancySetsAllTenancyVariables tests that even if we simply receive one of the two "EBS account number" and

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -32,3 +32,11 @@ func (t Tenant) GetHeaders() []kafka.Header {
 		{Key: h.ORGID, Value: []byte(t.OrgID)},
 	}
 }
+
+// TenantTranslation is a struct which represents a tenant translation from "EBS account number" to "OrgId".
+type TenantTranslation struct {
+	Id             int64  `json:"id"`
+	ExternalTenant string `json:"external_tenant"`
+	OrgId          string `json:"org_id"`
+	Error          error  `json:"error,omitempty"`
+}

--- a/routes.go
+++ b/routes.go
@@ -142,5 +142,8 @@ func setupRoutes(e *echo.Echo) {
 		r.GET("/authentications/:uuid", InternalAuthenticationGet, permissionMiddleware...)
 		// Sources
 		r.GET("/sources", InternalSourceList, permissionWithListMiddleware...)
+		// Tenant translation endpoints.
+		r.GET("/untranslated-tenants", GetUntranslatedTenants)
+		r.POST("/translate-tenants", TranslateTenants)
 	}
 }


### PR DESCRIPTION
We were initially going to perform another migration to translate the
leftover tenants which don't have an associated "OrgId" value, but after
a stand up meeting we decided upon creating a couple of endpoints to be
able to do it on demand.

These endpoints will help at:

1. Fetching all the "translatable" tenants.
2. Initiating the "EBS account number to OrgId" process.

Of course, these endpoints go on the internal routes, so they will only
be able to be hit from inside the cluster.

## Links

[[RHCLOUD-18655]](https://issues.redhat.com/browse/RHCLOUD-18655)