### PR TITLE
[RHCLOUD-20860] Refactor set OrgIds and EBS account numbers from the database

### DIFF
--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -166,9 +166,9 @@ type RhcConnectionDao interface {
 }
 
 type TenantDao interface {
-	// GetOrCreateTenantID returns the ID of the tenant associated with the provided identity. It tries to fetch the
-	// tenant by its OrgId, and if it is not present, by its EBS account number.
-	GetOrCreateTenantID(identity *identity.Identity) (int64, error)
+	// GetOrCreateTenant returns the tenant associated with the provided identity. It tries to fetch the tenant by its
+	// OrgId, and if it is not present, by its EBS account number.
+	GetOrCreateTenant(identity *identity.Identity) (*m.Tenant, error)
 	// TenantByIdentity returns the tenant associated to the given identity. It tries to fetch the tenant by its OrgId,
 	// and if it is not preset, by its EBS account number.
 	TenantByIdentity(identity *identity.Identity) (*m.Tenant, error)

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -1,6 +1,8 @@
 package dao
 
 import (
+	"fmt"
+
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -22,7 +24,7 @@ func init() {
 
 type tenantDaoImpl struct{}
 
-func (t *tenantDaoImpl) GetOrCreateTenantID(identity *identity.Identity) (int64, error) {
+func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenant, error) {
 	// Try to find the tenant.
 	var tenant m.Tenant
 	err := DB.
@@ -33,7 +35,7 @@ func (t *tenantDaoImpl) GetOrCreateTenantID(identity *identity.Identity) (int64,
 		First(&tenant).
 		Error
 
-	// Looks like we didn't find it, create it and return the ID.
+	// Looks like we didn't find the tenant: create it and return it.
 	if err != nil {
 		tenant.ExternalTenant = identity.AccountNumber
 		tenant.OrgID = identity.OrgID
@@ -44,11 +46,11 @@ func (t *tenantDaoImpl) GetOrCreateTenantID(identity *identity.Identity) (int64,
 			Error
 
 		if err != nil {
-			return 0, err
+			return nil, fmt.Errorf("unable to create the tenant: %w", err)
 		}
 	}
 
-	return tenant.Id, nil
+	return &tenant, nil
 }
 
 func (t *tenantDaoImpl) TenantByIdentity(id *identity.Identity) (*m.Tenant, error) {

--- a/dao/tenant_dao_test.go
+++ b/dao/tenant_dao_test.go
@@ -24,7 +24,7 @@ func TestGetOrCreateTenantIDEbsNumberCreate(t *testing.T) {
 
 	tenantDao := GetTenantDao()
 
-	id, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	dbTenant, err := tenantDao.GetOrCreateTenant(&identityStruct)
 	if err != nil {
 		t.Errorf(`Error getting or creating the tenant. Want nil error, got "%s"`, err)
 	}
@@ -33,7 +33,7 @@ func TestGetOrCreateTenantIDEbsNumberCreate(t *testing.T) {
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
-		Where(`id = ?`, id).
+		Where(`id = ?`, dbTenant.Id).
 		First(&tenant).
 		Error
 
@@ -63,7 +63,7 @@ func TestGetOrCreateTenantIDEbsNumberFind(t *testing.T) {
 
 	tenantDao := GetTenantDao()
 
-	id, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	dbTenant, err := tenantDao.GetOrCreateTenant(&identityStruct)
 	if err != nil {
 		t.Errorf(`Error getting or creating the tenant. Want nil error, got "%s"`, err)
 	}
@@ -72,7 +72,7 @@ func TestGetOrCreateTenantIDEbsNumberFind(t *testing.T) {
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
-		Where(`id = ?`, id).
+		Where(`id = ?`, dbTenant.Id).
 		First(&tenant).
 		Error
 
@@ -102,7 +102,7 @@ func TestGetOrCreateTenantIDOrgIdCreate(t *testing.T) {
 
 	tenantDao := GetTenantDao()
 
-	id, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	dbTenant, err := tenantDao.GetOrCreateTenant(&identityStruct)
 	if err != nil {
 		t.Errorf(`Error getting or creating the tenant. Want nil error, got "%s"`, err)
 	}
@@ -111,7 +111,7 @@ func TestGetOrCreateTenantIDOrgIdCreate(t *testing.T) {
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
-		Where(`id = ?`, id).
+		Where(`id = ?`, dbTenant.Id).
 		First(&tenant).
 		Error
 
@@ -140,7 +140,7 @@ func TestGetOrCreateTenantIDOrgIdFind(t *testing.T) {
 
 	tenantDao := GetTenantDao()
 
-	id, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	dbTenant, err := tenantDao.GetOrCreateTenant(&identityStruct)
 	if err != nil {
 		t.Errorf(`Error getting or creating the tenant. Want nil error, got "%s"`, err)
 	}
@@ -149,7 +149,7 @@ func TestGetOrCreateTenantIDOrgIdFind(t *testing.T) {
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
-		Where(`id = ?`, id).
+		Where(`id = ?`, dbTenant.Id).
 		First(&tenant).
 		Error
 
@@ -250,7 +250,7 @@ func TestCreateTenantNullEbsOrgId(t *testing.T) {
 	tenantDao := GetTenantDao()
 
 	// Try to insert a tenant without an "external_tenant" and "org_id" values.
-	id, err := tenantDao.GetOrCreateTenantID(&identity.Identity{})
+	tenant, err := tenantDao.GetOrCreateTenant(&identity.Identity{})
 	if err != nil {
 		t.Errorf(`unexpected error when creating a tenant with a NULL EBS account number and OrgId: %s`, err)
 	}
@@ -261,7 +261,7 @@ func TestCreateTenantNullEbsOrgId(t *testing.T) {
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
-		Where("id = ?", id).
+		Where("id = ?", tenant.Id).
 		Find(&createdTenant).
 		Error
 

--- a/dao/test_factories.go
+++ b/dao/test_factories.go
@@ -15,12 +15,12 @@ func CreateTenantForAccountNumber(accountNumber string) (*int64, error) {
 	}
 
 	tenantDao := GetTenantDao()
-	tenantID, err := tenantDao.GetOrCreateTenantID(&identityStruct)
+	tenant, err := tenantDao.GetOrCreateTenant(&identityStruct)
 	if err != nil {
 		return nil, fmt.Errorf("error getting or creating the tenant")
 	}
 
-	return &tenantID, nil
+	return &tenant.Id, nil
 }
 
 func CreateUserForUserID(userIDFromHeader string, tenantID int64) (*m.User, error) {

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -40,12 +40,12 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		c.Logger().Debugf("[org_id: %s][account_number: %s] Looking up Tenant ID", id.Identity.OrgID, id.Identity.AccountNumber)
 
 		tenantDao := dao.GetTenantDao()
-		tenantId, err := tenantDao.GetOrCreateTenantID(&id.Identity)
+		tenant, err := tenantDao.GetOrCreateTenant(&id.Identity)
 		if err != nil {
 			return fmt.Errorf("failed to get or create tenant for request: %s", err)
 		}
 
-		c.Set(h.TENANTID, tenantId)
+		c.Set(h.TENANTID, tenant.Id)
 
 		return next(c)
 	}

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -41,6 +41,11 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 			return fmt.Errorf("failed to get or create tenant for request: %s", err)
 		}
 
+		// Update the identity struct with the tenancy data from the database.
+		id.Identity.OrgID = tenant.OrgID
+		id.Identity.AccountNumber = tenant.ExternalTenant
+		c.Set(h.PARSED_IDENTITY, id)
+
 		// Store the ID, EBS account number and OrgId from what we've got in the database. Prior to this, we stored
 		// the contents of the incoming headers, but this had a problem: if we only received an EBS account number, we
 		// would only forward that account number even if we had a complementary OrgId number stored.

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -1,0 +1,96 @@
+package middleware
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/middleware/headers"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+// mockTenantDao is a mock which will help us mocking the "GetOrCreateTenant" function.
+type mockTenantDao struct {
+	TenantId      int64
+	AccountNumber string
+	OrgId         string
+}
+
+func (mtd mockTenantDao) GetOrCreateTenant(_ *identity.Identity) (*m.Tenant, error) {
+	tenant := m.Tenant{
+		Id:             mtd.TenantId,
+		ExternalTenant: mtd.AccountNumber,
+		OrgID:          mtd.OrgId,
+	}
+
+	return &tenant, nil
+}
+
+// TenantByIdentity is unimplemented since we are not using it in the tests.
+func (_ mockTenantDao) TenantByIdentity(_ *identity.Identity) (*m.Tenant, error) {
+	return nil, nil
+}
+
+// TestTenancySetsAllTenancyVariables tests that even if we simply receive one of the two "EBS account number" and
+// "OrgId" headers, the tenancy middleware will set whatever tenancy contents we have from the database in the context.
+func TestTenancySetsAllTenancyVariables(t *testing.T) {
+	// Set up the data for the mock.
+	tenantId := int64(50)
+	accountNumber := "12345"
+	orgId := "organization-id"
+
+	// Mock the "GetTenantDao" function, which will return a tenant with the above contents.
+	mtd := mockTenantDao{TenantId: tenantId, AccountNumber: accountNumber, OrgId: orgId}
+	dao.GetTenantDao = func() dao.TenantDao { return mtd }
+
+	// Create a dummy request context to be able to run the middlewares.
+	c, _ := request.CreateTestContext(http.MethodGet, "/", nil, nil)
+
+	// Prepare the headers we will be testing this with. We will try with one at a time.
+	testHeaders := map[string]string{
+		headers.ACCOUNT_NUMBER: accountNumber,
+		headers.ORGID:          orgId,
+	}
+
+	for key, value := range testHeaders {
+		// Set one of the headers.
+		c.Request().Header.Add(key, value)
+
+		// Prepare the middlewares and execute them.
+		handlers := ParseHeaders(Tenancy(func(context echo.Context) error { return nil }))
+		err := handlers(c)
+		if err != nil {
+			t.Errorf(`unexpected error when running the "ParseHeaders" and "Tenancy" middlewares: %s`, err)
+		}
+
+		{
+			want := accountNumber
+			got := c.Get(headers.ACCOUNT_NUMBER)
+
+			if want != got {
+				t.Errorf(`"%s" header set with value "%s". Invalid account number set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%s", got "%s"`, key, value, want, got)
+			}
+		}
+
+		{
+			want := orgId
+			got := c.Get(headers.ORGID)
+
+			if want != got {
+				t.Errorf(`"%s" header set with value "%s. Invalid OrgId set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%s", got "%s"`, key, value, want, got)
+			}
+		}
+
+		{
+			want := tenantId
+			got := c.Get(headers.TENANTID)
+
+			if want != got {
+				t.Errorf(`"%s" header set with value "%s. Invalid tenant id set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%d", got "%v"`, key, value, want, got)
+			}
+		}
+	}
+}

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -67,6 +67,29 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 		}
 
 		{
+			id, ok := c.Get(headers.PARSED_IDENTITY).(*identity.XRHID)
+			if !ok {
+				t.Errorf("unable to correctly type cast the parsed identity from the context")
+			}
+
+			{
+				want := orgId
+				got := id.Identity.OrgID
+				if want != got {
+					t.Errorf(`the identity struct does not have the OrgId value from the database. Want "%s", got "%s"`, want, got)
+				}
+			}
+
+			{
+				want := accountNumber
+				got := id.Identity.AccountNumber
+				if want != got {
+					t.Errorf(`the identity struct does not have the AccountNUmber value from the database. Want "%s", got "%s"`, want, got)
+				}
+			}
+		}
+
+		{
 			want := accountNumber
 			got := c.Get(headers.ACCOUNT_NUMBER)
 

--- a/routes.go
+++ b/routes.go
@@ -12,7 +12,7 @@ import (
 )
 
 var listMiddleware = []echo.MiddlewareFunc{middleware.SortAndFilter, middleware.Pagination}
-var tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.UserCatcher}
+var tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.LoggerFields, middleware.UserCatcher}
 
 var tenancyWithListMiddleware = append(tenancyMiddleware, listMiddleware...)
 var permissionMiddleware = append(tenancyMiddleware, []echo.MiddlewareFunc{middleware.PermissionCheck, middleware.RaiseEvent}...)
@@ -37,7 +37,6 @@ func setupRoutes(e *echo.Echo) {
 			middleware.HandleErrors,
 			middleware.IdValidation,
 			middleware.ParseHeaders,
-			middleware.LoggerFields,
 		)
 
 		// openapi
@@ -52,7 +51,7 @@ func setupRoutes(e *echo.Echo) {
 		r.POST("/sources", SourceCreate, permissionMiddleware...)
 		r.PATCH("/sources/:id", SourceEdit, append(permissionMiddleware, middleware.Notifier)...)
 		r.DELETE("/sources/:id", SourceDelete, append(permissionMiddleware, middleware.SuperKeyDestroySource)...)
-		r.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy)
+		r.POST("/sources/:source_id/check_availability", SourceCheckAvailability, middleware.Tenancy, middleware.LoggerFields)
 		r.GET("/sources/:source_id/application_types", SourceListApplicationTypes, tenancyWithListMiddleware...)
 		r.GET("/sources/:source_id/applications", SourceListApplications, tenancyWithListMiddleware...)
 		r.GET("/sources/:source_id/endpoints", SourceListEndpoint, tenancyWithListMiddleware...)
@@ -85,13 +84,13 @@ func setupRoutes(e *echo.Echo) {
 		}
 
 		// ApplicationTypes
-		r.GET("/application_types", ApplicationTypeList, listMiddleware...)
-		r.GET("/application_types/:id", ApplicationTypeGet)
+		r.GET("/application_types", ApplicationTypeList, append(listMiddleware, middleware.LoggerFields)...)
+		r.GET("/application_types/:id", ApplicationTypeGet, middleware.LoggerFields)
 		r.GET("/application_types/:application_type_id/sources", ApplicationTypeListSource, tenancyWithListMiddleware...)
 
 		// Endpoints
 		r.GET("/endpoints", EndpointList, tenancyWithListMiddleware...)
-		r.GET("/endpoints/:id", EndpointGet, middleware.Tenancy)
+		r.GET("/endpoints/:id", EndpointGet, middleware.Tenancy, middleware.LoggerFields)
 		r.POST("/endpoints", EndpointCreate, permissionMiddleware...)
 		r.PATCH("/endpoints/:id", EndpointEdit, append(permissionMiddleware, middleware.Notifier)...)
 		r.DELETE("/endpoints/:id", EndpointDelete, permissionMiddleware...)
@@ -105,13 +104,13 @@ func setupRoutes(e *echo.Echo) {
 		r.DELETE("/application_authentications/:id", ApplicationAuthenticationDelete, permissionMiddleware...)
 
 		// AppMetaData
-		r.GET("/app_meta_data", MetaDataList, listMiddleware...)
-		r.GET("/app_meta_data/:id", MetaDataGet)
-		r.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, listMiddleware...)
+		r.GET("/app_meta_data", MetaDataList, append(listMiddleware, middleware.LoggerFields)...)
+		r.GET("/app_meta_data/:id", MetaDataGet, middleware.LoggerFields)
+		r.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, append(listMiddleware, middleware.LoggerFields)...)
 
 		// SourceTypes
-		r.GET("/source_types", SourceTypeList, listMiddleware...)
-		r.GET("/source_types/:id", SourceTypeGet)
+		r.GET("/source_types", SourceTypeList, append(listMiddleware, middleware.LoggerFields)...)
+		r.GET("/source_types/:id", SourceTypeGet, middleware.LoggerFields)
 		r.GET("/source_types/:source_type_id/sources", SourceTypeListSource, tenancyWithListMiddleware...)
 
 		// Red Hat Connector Connections


### PR DESCRIPTION
Instead of just forwarding the incoming headers, this change ensures
that the "EBS account number" and the "OrgId" are set in the context
using the contents from the database.

This comes from one issue we have been having with the notifications
service: the service was erroring because we were just sending the
incoming "EBS account number" header, even though we had the associated
"OrgId" on the database.

So we have decided to simply use the incoming headers as a validation
—make sure that an EBS account number and/or OrgId are present—, and
then use the database contents to send the headers to the rest of the
services or to the Kafka queues.

## Links

[[RHCLOUD-20860]](https://issues.redhat.com/browse/RHCLOUD-20860)