### PR TITLE
[RHCLOUD-20865] Refactor tenancy lookup orgid preference

### DIFF
--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 )
 
@@ -51,6 +53,10 @@ func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenan
 			Where("external_tenant = ? AND external_tenant != ''", identity.AccountNumber).
 			First(&tenant).
 			Error
+
+		if err == nil && tenant != (m.Tenant{}) {
+			logger.Log.WithFields(logrus.Fields{"account_number": identity.AccountNumber}).Warn("tenant found by its EBS account number")
+		}
 
 		// Again, if the error isn't a "Not Found" one, something went wrong.
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -77,6 +77,10 @@ func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenan
 		if err != nil {
 			return nil, fmt.Errorf("unable to create the tenant: %w", err)
 		}
+
+		logger.Log.WithFields(
+			logrus.Fields{"account_number": tenant.ExternalTenant, "org_id": tenant.OrgID, "tenant_id": tenant.Id},
+		).Info("tenant created")
 	}
 
 	return &tenant, nil

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -38,7 +38,9 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		tenantDao := dao.GetTenantDao()
 		tenant, err := tenantDao.GetOrCreateTenant(&id.Identity)
 		if err != nil {
-			return fmt.Errorf("failed to get or create tenant for request: %s", err)
+			c.Logger().Errorf("[identity struct: %v] unable to get or create the tenant: %w", err)
+
+			return fmt.Errorf("failed to get or create tenant for request: %w", err)
 		}
 
 		// Update the identity struct with the tenancy data from the database.


### PR DESCRIPTION
Since the EBS account numbers are deprecated, we want to explicitly find
the tenants by their OrgId first. We are aware that this solution
hurts the performance just a bit, but this will eventually go away.

## Links 

[[RHCLOUD-20865]](https://issues.redhat.com/browse/RHCLOUD-20865)