### PR TITLE
[RHCLOUD-20691] Check err handling from Bind() in handlers

### DIFF
--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -150,13 +150,13 @@ func AuthenticationEdit(c echo.Context) error {
 		return err
 	}
 
-	updateRequest := &m.AuthenticationEditRequest{}
-	err = c.Bind(updateRequest)
+	updateRequest := m.AuthenticationEditRequest{}
+	err = c.Bind(&updateRequest)
 	if err != nil {
-		return util.NewErrBadRequest(err)
+		return err
 	}
 
-	err = service.ValidateAuthenticationEditRequest(updateRequest)
+	err = service.ValidateAuthenticationEditRequest(&updateRequest)
 	if err != nil {
 		return util.NewErrBadRequest(err)
 	}
@@ -170,7 +170,7 @@ func AuthenticationEdit(c echo.Context) error {
 	if auth.AvailabilityStatus != nil {
 		previousStatus = *auth.AvailabilityStatus
 	}
-	err = auth.UpdateFromRequest(updateRequest)
+	err = auth.UpdateFromRequest(&updateRequest)
 	if err != nil {
 		return util.NewErrBadRequest(`invalid JSON given in "extra" field`)
 	}

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -24,8 +24,11 @@ import (
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/go-cmp/cmp"
+	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
+
+var echoBinder echo.Binder = &NoUnknownFieldsBinder{}
 
 func TestAuthenticationList(t *testing.T) {
 	tenantId := int64(1)
@@ -417,6 +420,8 @@ func TestAuthenticationCreateBadRequestInvalidResourceType(t *testing.T) {
 	)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
+	c.Echo().Binder = echoBinder
+
 	badRequestAuthenticationCreate := ErrorHandlingContext(AuthenticationCreate)
 	err = badRequestAuthenticationCreate(c)
 	if err != nil {
@@ -503,6 +508,8 @@ func TestAuthenticationEdit(t *testing.T) {
 	c.SetParamValues(uid)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+
+	c.Echo().Binder = echoBinder
 
 	authEditHandlerWithNotifier := middleware.Notifier(AuthenticationEdit)
 	err = authEditHandlerWithNotifier(c)


### PR DESCRIPTION
Within authentication_handlers.go, instead of util.NewErrBadRequest(err), change to err and check err handling from Bind() in handlers.

Within authentication_handlers_test.go, set binder on each invocation

JIRA: RH-CLOUD 20691[https://issues.redhat.com/browse/RHCLOUD-20691](url)