### PR TITLE
Remove endpoint object from amazon section for provisioning

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -84,14 +84,6 @@ amazon:
               pattern: "^arnaws:.*"
             - type: min-length
               threshold: 10
-    endpoint:
-      hidden: true
-      fields:
-      - component: text-field
-        name: endpoint.role
-        hideField: true
-        initializeOnMount: true
-        initialValue: aws
   vendor: Amazon
   icon_url: "/apps/frontend-assets/partners-icons/aws-long.svg"
 google:


### PR DESCRIPTION
Not sure why this was there in the first place - it looks like it was part of the cloud-meter-arn object above but obviously we haven't been sending it for a while so maybe it just isn't used anymore.

It doesn't make sense to begin with since we don't need an endpoint for an application based source. So I'm thinking it's legacy code. 

...lets see if the checks all pass. 