### PR TITLE
Source dao test TestSourceSubcollectionWithUserOwnership() fix

### DIFF
--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"errors"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
@@ -271,8 +272,10 @@ func TestApplicationAuthenticationListUserOwnership(t *testing.T) {
 		expectedAppAuthsIDs = append(expectedAppAuthsIDs, appAuth.ID)
 	}
 
+	sort.Slice(appAuthsIDs, func(i, j int) bool { return appAuthsIDs[i] < appAuthsIDs[j] })
+
 	if !cmp.Equal(appAuthsIDs, expectedAppAuthsIDs) {
-		t.Errorf("Expected application authentication IDS %v are not same with obtained ids: %v", expectedAppAuthsIDs, appAuthsIDs)
+		t.Errorf("Expected application authentication IDs %v are not same with obtained IDs: %v", expectedAppAuthsIDs, appAuthsIDs)
 	}
 
 	userWithoutOwnRecords, err := CreateUserForUserID(userIDWithoutOwnRecords, user.TenantID)
@@ -298,8 +301,10 @@ func TestApplicationAuthenticationListUserOwnership(t *testing.T) {
 		expectedAppAuthsIDs = append(expectedAppAuthsIDs, appAuth.ID)
 	}
 
+	sort.Slice(appAuthsIDs, func(i, j int) bool { return appAuthsIDs[i] < appAuthsIDs[j] })
+
 	if !cmp.Equal(appAuthsIDs, expectedAppAuthsIDs) {
-		t.Errorf("Expected application authentication IDS %v are not same with obtained ids: %v", expectedAppAuthsIDs, appAuthsIDs)
+		t.Errorf("Expected application authentication IDs %v are not same with obtained IDs: %v", expectedAppAuthsIDs, appAuthsIDs)
 	}
 
 	DropSchema(schema)

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -453,8 +454,10 @@ func TestApplicationListUserOwnership(t *testing.T) {
 		expectedApplicationIDs = append(expectedApplicationIDs, application.ID)
 	}
 
+	sort.Slice(applicationIDs, func(i, j int) bool { return applicationIDs[i] < applicationIDs[j] })
+
 	if !cmp.Equal(applicationIDs, expectedApplicationIDs) {
-		t.Errorf("Expected application authentication IDS %v are not same with obtained ids: %v", expectedApplicationIDs, applicationIDs)
+		t.Errorf("Expected application authentication IDs %v are not same with obtained IDs: %v", expectedApplicationIDs, applicationIDs)
 	}
 
 	userWithoutOwnRecords, err := CreateUserForUserID(userIDWithoutOwnRecords, user.TenantID)
@@ -480,8 +483,10 @@ func TestApplicationListUserOwnership(t *testing.T) {
 		expectedApplicationIDs = append(expectedApplicationIDs, application.ID)
 	}
 
+	sort.Slice(applicationIDs, func(i, j int) bool { return applicationIDs[i] < applicationIDs[j] })
+
 	if !cmp.Equal(applicationIDs, expectedApplicationIDs) {
-		t.Errorf("Expected application authentication IDS %v are not same with obtained ids: %v", expectedApplicationIDs, applicationIDs)
+		t.Errorf("Expected application authentication IDs %v are not same with obtained IDs: %v", expectedApplicationIDs, applicationIDs)
 	}
 
 	DropSchema(schema)

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -353,8 +354,10 @@ func TestAuthenticationListUserOwnership(t *testing.T) {
 		expectedAuthenticationIDs = append(expectedAuthenticationIDs, authentication.DbID)
 	}
 
+	sort.Slice(authenticationIDs, func(i, j int) bool { return authenticationIDs[i] < authenticationIDs[j] })
+
 	if !cmp.Equal(authenticationIDs, expectedAuthenticationIDs) {
-		t.Errorf("Expected authentication IDs %v are not same with obtained ids: %v", expectedAuthenticationIDs, authenticationIDs)
+		t.Errorf("Expected authentication IDs %v are not same with obtained IDs: %v", expectedAuthenticationIDs, authenticationIDs)
 	}
 
 	userWithoutOwnRecords, err := CreateUserForUserID(userIDWithoutOwnRecords, user.TenantID)
@@ -380,8 +383,10 @@ func TestAuthenticationListUserOwnership(t *testing.T) {
 		expectedAuthenticationIDs = append(expectedAuthenticationIDs, authentication.DbID)
 	}
 
+	sort.Slice(authenticationIDs, func(i, j int) bool { return authenticationIDs[i] < authenticationIDs[j] })
+
 	if !cmp.Equal(authenticationIDs, expectedAuthenticationIDs) {
-		t.Errorf("Expected authentication IDs %v are not same with obtained ids: %v", expectedAuthenticationIDs, authenticationIDs)
+		t.Errorf("Expected authentication IDs %v are not same with obtained IDs: %v", expectedAuthenticationIDs, authenticationIDs)
 	}
 
 	DropSchema(schema)

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -887,8 +888,10 @@ func TestSourceListUserOwnership(t *testing.T) {
 		expectedSourcesIDs = append(expectedSourcesIDs, appAuth.ID)
 	}
 
+	sort.Slice(sourcesIDs, func(i, j int) bool { return sourcesIDs[i] < sourcesIDs[j] })
+
 	if !cmp.Equal(sourcesIDs, expectedSourcesIDs) {
-		t.Errorf("Expected application authentication IDS %v are not same with obtained ids: %v", expectedSourcesIDs, sourcesIDs)
+		t.Errorf("Expected application authentication IDs %v are not same with obtained IDs: %v", expectedSourcesIDs, sourcesIDs)
 	}
 
 	userWithoutOwnRecords, err := CreateUserForUserID(userIDWithoutOwnRecords, user.TenantID)
@@ -914,8 +917,10 @@ func TestSourceListUserOwnership(t *testing.T) {
 		expectedSourcesIDs = append(expectedSourcesIDs, source.ID)
 	}
 
+	sort.Slice(sourcesIDs, func(i, j int) bool { return sourcesIDs[i] < sourcesIDs[j] })
+
 	if !cmp.Equal(sourcesIDs, expectedSourcesIDs) {
-		t.Errorf("Expected application authentication IDS %v are not same with obtained ids: %v", expectedSourcesIDs, sourcesIDs)
+		t.Errorf("Expected application authentication IDs %v are not same with obtained IDs: %v", expectedSourcesIDs, sourcesIDs)
 	}
 
 	DropSchema(schema)
@@ -1078,8 +1083,10 @@ func TestSourceSubcollectionWithUserOwnership(t *testing.T) {
 			subCollectionSourcesIDs = append(subCollectionSourcesIDs, source.ID)
 		}
 
+		sort.Slice(subCollectionSourcesIDs, func(i, j int) bool { return subCollectionSourcesIDs[i] < subCollectionSourcesIDs[j] })
+
 		if !cmp.Equal(subCollectionSourcesIDs, suiteData.SourceIDsUserA()) {
-			t.Errorf("Expected source IDS %v are not same with obtained ids: %v", suiteData.SourceIDsUserA(), subCollectionSourcesIDs)
+			t.Errorf("Expected source IDs %v are not same with obtained IDs: %v", suiteData.SourceIDsUserA(), subCollectionSourcesIDs)
 		}
 
 		/*
@@ -1099,8 +1106,10 @@ func TestSourceSubcollectionWithUserOwnership(t *testing.T) {
 			subCollectionSourcesIDs = append(subCollectionSourcesIDs, source.ID)
 		}
 
+		sort.Slice(subCollectionSourcesIDs, func(i, j int) bool { return subCollectionSourcesIDs[i] < subCollectionSourcesIDs[j] })
+
 		if !cmp.Equal(subCollectionSourcesIDs, suiteData.SourceIDsNoUser()) {
-			t.Errorf("Expected source IDS %v are not same with obtained ids: %v", suiteData.SourceIDsUserA(), subCollectionSourcesIDs)
+			t.Errorf("Expected source IDs %v are not same with obtained IDs: %v", suiteData.SourceIDsUserA(), subCollectionSourcesIDs)
 		}
 
 		rhcDAO := GetRhcConnectionDao(suiteData.TenantID())


### PR DESCRIPTION
without JIRA ticket

sometimes when I run the tests I get this result
```
--- FAIL: TestSourceSubcollectionWithUserOwnership (2.16s)
    source_dao_test.go:1082: Expected source IDS [103 105] are not same with obtained ids: [105 103]
```

I found out that subcollection source IDs can be returned in random order so they have to be sorted before comparing them with the expected result

EDIT:
updated other tests that contains same logic