### PR TITLE
Revert "feature: set the maxReplicas to 0 to perform the database upgrade"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -45,7 +45,6 @@ objects:
     deployments:
     - name: background-worker
       minReplicas: 1
-      maxReplicas: 0
       podSpec:
         args:
         - -background-worker
@@ -67,7 +66,6 @@ objects:
             memory: ${AVAILABILITY_LISTENER_MEMORY_REQUEST}
     - name: availability-status-listener
       minReplicas: ${{AVAILABILITY_MIN_REPLICAS}}
-      maxReplicas: 0
       podSpec:
         args:
         - -listener
@@ -89,7 +87,6 @@ objects:
             memory: ${AVAILABILITY_LISTENER_MEMORY_REQUEST}
     - name: svc
       minReplicas: ${{MIN_REPLICAS}}
-      maxReplicas: 0
       webServices:
         public:
           enabled: true


### PR DESCRIPTION
Luke Couzens has explained to us that scaling down doesn't work with AppInterface right now, and that an AppSre engineer must do that. So I'm reverting these changes...

Reverts RedHatInsights/sources-api-go#528