### PR TITLE
[RHCLOUD-20947] middleware function update for rhc connection source list endpoint

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -119,7 +119,7 @@ func setupRoutes(e *echo.Echo) {
 		r.POST("/rhc_connections", RhcConnectionCreate, permissionMiddleware...)
 		r.PATCH("/rhc_connections/:id", RhcConnectionEdit, append(permissionMiddleware, middleware.Notifier)...)
 		r.DELETE("/rhc_connections/:id", RhcConnectionDelete, permissionMiddleware...)
-		r.GET("/rhc_connections/:id/sources", RhcConnectionSourcesList, permissionWithListMiddleware...)
+		r.GET("/rhc_connections/:id/sources", RhcConnectionSourcesList, tenancyWithListMiddleware...)
 
 		// GraphQL
 		r.POST("/graphql", GraphQLQuery, tenancyMiddleware...)


### PR DESCRIPTION
I found out that for existing rhc connection the endpoint `/rhc_connections/:id/sources` returns not found
because we used for this route wrong middleware (tenant was not set from header and that led to not found err)

**JIRA:** [RHCLOUD-20947](https://issues.redhat.com/browse/RHCLOUD-20947)