### PR TITLE
[RHCLOUD-20908] Endpoint create - source id validation (tenancy)

### DIFF
--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -138,6 +138,26 @@ func EndpointCreate(c echo.Context) error {
 		return err
 	}
 
+	// Check that source exists
+	sourceId, err := util.InterfaceToInt64(input.SourceIDRaw)
+	if err != nil {
+		return util.NewErrBadRequest(err)
+	}
+
+	sourceDao, err := getSourceDao(c)
+	if err != nil {
+		return err
+	}
+
+	sourceExists, err := sourceDao.Exists(sourceId)
+	if err != nil {
+		return err
+	}
+
+	if !sourceExists {
+		return util.NewErrBadRequest("source id not found")
+	}
+
 	err = service.ValidateEndpointCreateRequest(endpointDao, input)
 	if err != nil {
 		return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %s", err))

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -689,6 +689,42 @@ func TestEndpointCreateBadRequest(t *testing.T) {
 	templates.BadRequestTest(t, rec)
 }
 
+// TestEndpointCreateInvalidSource tests bad request is returned
+// when create request contains source id that is not owned by tenant
+func TestEndpointCreateInvalidSource(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	tenantId := int64(2)
+	sourceId := int64(1)
+
+	requestBody := m.EndpointCreateRequest{
+		Role:        "invalid tenant",
+		SourceIDRaw: sourceId,
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/endpoints",
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": tenantId,
+		},
+	)
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+
+	badRequestEndpointCreate := ErrorHandlingContext(EndpointCreate)
+	err = badRequestEndpointCreate(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	templates.BadRequestTest(t, rec)
+}
+
 func TestEndpointEdit(t *testing.T) {
 	tenantId := int64(1)
 	backupNotificationProducer := service.NotificationProducer


### PR DESCRIPTION
in endpoint create handler we need to check if provided source id belongs to the tenant

I added the check outside `service.ValidateEndpointCreateRequest()` because we are using this function in bulk create where all resources are created in a transaction ... so the source doesnt exist when the bulk create calls this validation for endpoint

**JIRA:** [RHCLOUD-20908](https://issues.redhat.com/browse/RHCLOUD-20908)