### PR TITLE
Enable record creation with user ownership for AppStudio application type

### DIFF
--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -64,8 +64,6 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 func TestBulkCreateWithUserCreation(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
-	conf.ResourceOwnership = "user"
-
 	testUserId := "testUser"
 	identityHeader := testutils.IdentityHeaderForUser(testUserId)
 
@@ -175,8 +173,6 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 
 func TestBulkCreate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-
-	conf.ResourceOwnership = ""
 
 	testUserId := "testUser"
 	identityHeader := testutils.IdentityHeaderForUser(testUserId)

--- a/config/config.go
+++ b/config/config.go
@@ -52,7 +52,6 @@ type SourcesApiConfig struct {
 	MigrationsReset         bool
 	SecretStore             string
 	TenantTranslatorUrl     string
-	ResourceOwnership       string
 	Env                     string
 }
 
@@ -210,7 +209,6 @@ func Get() *SourcesApiConfig {
 	}
 	options.SetDefault("SecretStore", secretStore)
 	options.SetDefault("TenantTranslatorUrl", os.Getenv("TENANT_TRANSLATOR_URL"))
-	options.SetDefault("ResourceOwnership", os.Getenv("RESOURCE_OWNERSHIP"))
 
 	// Parse any Flags (using our own flag set to not conflict with the global flag)
 	fs := flag.NewFlagSet("runtime", flag.ContinueOnError)
@@ -284,7 +282,6 @@ func Get() *SourcesApiConfig {
 		MigrationsReset:         options.GetBool("MigrationsReset"),
 		SecretStore:             options.GetString("SecretStore"),
 		TenantTranslatorUrl:     options.GetString("TenantTranslatorUrl"),
-		ResourceOwnership:       options.GetString("ResourceOwnership"),
 		Env:                     options.GetString("Env"),
 	}
 

--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -19,6 +19,7 @@
       - gitlab-personal-access-token
     quay:
       - quay-encrypted-password
+  resource_ownership: user
 
 "/insights/platform/cost-management":
   display_name: Cost Management

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -143,8 +143,6 @@ objects:
               optional: true
         - name: FEATURE_FLAGS_SERVICE
           value: ${FEATURE_FLAGS_SERVICE}
-        - name: RESOURCE_OWNERSHIP
-          value: ${RESOURCE_OWNERSHIP}
         - name: SOURCE_TYPE_SKIP_LIST
           value: ${SOURCE_TYPE_SKIP_LIST}
         - name: APPLICATION_TYPE_SKIP_LIST
@@ -336,9 +334,6 @@ parameters:
 - description: Specify name of service for Feature Flags
   name: FEATURE_FLAGS_SERVICE
   value: 'unleash'
-- description: Specify name to select strategy to ensure resource ownership
-  name: RESOURCE_OWNERSHIP
-  value: ''
 - description: Specify any source_types to not seed into the database
   name: SOURCE_TYPE_SKIP_LIST
   value: ''

--- a/model/user_resource.go
+++ b/model/user_resource.go
@@ -12,25 +12,19 @@ type UserResource struct {
 	SourceNames           []string
 	ApplicationTypesNames []string
 	User                  *User
-	ResourceOwnership     string
 }
 
 func (ur *UserResource) AddSourceAndApplicationTypeNames(sourceName, applicationTypeName string) {
-	if ur.userResourceOwnership() {
+	if ur.userIDPresent() {
 		ur.SourceNames = append(ur.SourceNames, sourceName)
 		ur.ApplicationTypesNames = append(ur.ApplicationTypesNames, applicationTypeName)
 	}
 }
 
-func (ur *UserResource) userResourceOwnership() bool {
-	return ur.ResourceOwnership == UserOwnership
-}
-
 func (ur *UserResource) UserOwnershipActive() bool {
 	return len(ur.SourceNames) > 0 &&
 		len(ur.ApplicationTypesNames) > 0 &&
-		ur.userIDPresent() &&
-		ur.userResourceOwnership()
+		ur.userIDPresent()
 }
 
 func (ur *UserResource) userIDPresent() bool {

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -521,7 +521,7 @@ func loadUserResourceSettingFromBulkCreateApplication(userResource *m.UserResour
 }
 
 func userResourceFromBulkCreateApplications(user *m.User, applications []m.BulkCreateApplication, tenant *m.Tenant) (*m.UserResource, error) {
-	userResource := &m.UserResource{User: user, ResourceOwnership: ""}
+	userResource := &m.UserResource{User: user}
 
 	for _, reqApp := range applications {
 		err := loadUserResourceSettingFromBulkCreateApplication(userResource, &reqApp, tenant)

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	l "github.com/RedHatInsights/sources-api-go/logger"
@@ -522,7 +521,7 @@ func loadUserResourceSettingFromBulkCreateApplication(userResource *m.UserResour
 }
 
 func userResourceFromBulkCreateApplications(user *m.User, applications []m.BulkCreateApplication, tenant *m.Tenant) (*m.UserResource, error) {
-	userResource := &m.UserResource{User: user, ResourceOwnership: config.Get().ResourceOwnership}
+	userResource := &m.UserResource{User: user, ResourceOwnership: ""}
 
 	for _, reqApp := range applications {
 		err := loadUserResourceSettingFromBulkCreateApplication(userResource, &reqApp, tenant)


### PR DESCRIPTION
1. Remove UserOwnership var from config
2. Replace userResourceOwnership with userIDPresent in UserResource
3. Set user ownership for app-studio in application_type.yml
---
Point 1. and 2. I removed possibility to enable user based feature with config - It looks to me now superfluous.
Point 3. This set `ApplicationType#UserOwnership` to `user` for AppStudio - which enable to populate user_id records during bulk creation for records for Sources tied with AppStudio application type 



### Links
- https://github.com/RedHatInsights/sources-api-go/issues/356