### PR TITLE
[RHCLOUD-20995] Source create validation

### DIFF
--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -949,3 +949,20 @@ func (mad MockAuthenticationDao) ListIdsForResource(resourceType string, resourc
 func (m MockAuthenticationDao) BulkDelete(authentications []m.Authentication) ([]m.Authentication, error) {
 	return authentications, nil
 }
+
+func PopulateMockStaticTypeCache() error {
+	tc := typeCache{}
+	tc.sourceTypes = make(map[string]int64)
+	tc.applicationTypes = make(map[string]int64)
+
+	for _, st := range fixtures.TestSourceTypeData {
+		tc.sourceTypes[st.Name] = st.Id
+	}
+
+	for _, at := range fixtures.TestApplicationTypeData {
+		tc.applicationTypes[at.Name] = at.Id
+	}
+
+	Static = tc
+	return nil
+}

--- a/main_test.go
+++ b/main_test.go
@@ -82,6 +82,10 @@ func TestMain(t *testing.M) {
 		}
 		getAuthenticationDao = func(c echo.Context) (dao.AuthenticationDao, error) { return mockAuthenticationDao, nil }
 
+		err := dao.PopulateMockStaticTypeCache()
+		if err != nil {
+			panic("failed to populate mock static type cache")
+		}
 	}
 
 	code := t.Run()

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -30,6 +30,10 @@ func TestMain(t *testing.M) {
 		endpointDao = dao.GetEndpointDao(&fixtures.TestTenantData[0].Id)
 		sourceDao = dao.GetSourceDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 		database.CreateFixtures("service")
+		err := dao.PopulateStaticTypeCache()
+		if err != nil {
+			panic("failed to populate static type cache")
+		}
 	} else {
 		endpointDao = &dao.MockEndpointDao{}
 		sourceDao = &dao.MockSourceDao{}

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -37,6 +37,10 @@ func TestMain(t *testing.M) {
 	} else {
 		endpointDao = &dao.MockEndpointDao{}
 		sourceDao = &dao.MockSourceDao{}
+		err := dao.PopulateMockStaticTypeCache()
+		if err != nil {
+			panic("failed to populate mock static type cache")
+		}
 	}
 
 	code := t.Run()

--- a/service/source_validation.go
+++ b/service/source_validation.go
@@ -17,13 +17,13 @@ var validWorkflowStatuses = []string{model.AccountAuth, model.ManualConfig}
 // ValidateSourceCreationRequest validates that the required fields of the SourceCreateRequest request hold proper
 // values. In the specific case of the UUID, if an empty or nil one is provided, a new random UUID is generated and
 // appended to the request.
-func ValidateSourceCreationRequest(dao dao.SourceDao, req *model.SourceCreateRequest) error {
+func ValidateSourceCreationRequest(sourceDao dao.SourceDao, req *model.SourceCreateRequest) error {
 
 	if req.Name == nil || *req.Name == "" {
 		return fmt.Errorf("name cannot be empty")
 	}
 
-	if dao.NameExistsInCurrentTenant(*req.Name) {
+	if sourceDao.NameExistsInCurrentTenant(*req.Name) {
 		return fmt.Errorf("name already exists in tenant")
 	}
 
@@ -49,6 +49,12 @@ func ValidateSourceCreationRequest(dao dao.SourceDao, req *model.SourceCreateReq
 
 	if value < 1 {
 		return fmt.Errorf("source type id must be greater than 0")
+	}
+
+	// Check that SourceTypeId exists
+	sourceTypeName := dao.Static.GetSourceTypeName(value)
+	if sourceTypeName == "" {
+		return fmt.Errorf("source type id not found")
 	}
 
 	req.SourceTypeID = &value

--- a/service/source_validation_test.go
+++ b/service/source_validation_test.go
@@ -19,7 +19,7 @@ func setUp() model.SourceCreateRequest {
 	version := "10.5"
 	imported := "true"
 	sourceRef := "Source reference #5"
-	sourceTypeId := "501"
+	sourceTypeId := "1"
 
 	return model.SourceCreateRequest{
 		Name:                &name,


### PR DESCRIPTION
For not existing source type id in source create request the 500 is returned (400 expected)

```
POST localhost:8000/api/sources/v3.1/sources
{
  "name": "source abc",
  "source_type_id": "100"
}
```


in this PR:
- check if source type exists is added into ValidateSourceCreationRequest() - static type cache is used
- modifying the tests to use this cache there as well (inc. new mock for this cache)

**JIRA:** [RHCLOUD-20995](https://issues.redhat.com/browse/RHCLOUD-20995)