### PR TITLE
[RHCLOUD-18659] feature: remove unused Kafka topics

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -175,21 +175,6 @@ objects:
     - topicName: platform.sources.superkey-requests
       partitions: 3
       replicas: 3
-    - topicName: platform.topological-inventory.operations-amazon
-      partitions: 3
-      replicas: 3
-    - topicName: platform.topological-inventory.operations-ansible-tower
-      partitions: 3
-      replicas: 3
-    - topicName: platform.topological-inventory.operations-azure
-      partitions: 3
-      replicas: 3
-    - topicName: platform.topological-inventory.operations-google
-      partitions: 3
-      replicas: 3
-    - topicName: platform.topological-inventory.operations-openshift
-      partitions: 3
-      replicas: 3
     - topicName: platform.topological-inventory.operations-satellite
       partitions: 3
       replicas: 3


### PR DESCRIPTION
Since topological inventory is no more, we can safely drop almost all
the Kafka topics related to it. The only one that we need to keep around
is "operations-satellite" until that thing gets shut down too.

## Links
[[RHCLOUD-18659]](https://issues.redhat.com/browse/RHCLOUD-18659)