### PR TITLE
[RHCLOUD-20931] [GO] Edit source name to be set nil not empty

### DIFF
--- a/service/source_validation.go
+++ b/service/source_validation.go
@@ -63,13 +63,14 @@ func ValidateSourceCreationRequest(sourceDao dao.SourceDao, req *model.SourceCre
 }
 
 func ValidateEditSourceNameRequest(dao dao.SourceDao, req *model.SourceEditRequest) error {
-	if req.Name == nil || *req.Name == "" {
-		return fmt.Errorf("name cannot be empty")
-	}
+	if req.Name != nil {
+		if *req.Name == "" {
+			return fmt.Errorf("name cannot be empty string")
+		}
 
-	if dao.NameExistsInCurrentTenant(*req.Name) {
-		return fmt.Errorf("source name already exists in same tenant")
+		if dao.NameExistsInCurrentTenant(*req.Name) {
+			return fmt.Errorf("source name already exists in same tenant")
+		}
 	}
-
 	return nil
 }


### PR DESCRIPTION
Within source_validation.go, edit ValidateEditSourceNameRequest() to allow req.Name to be null.

Within source_handlers_test.go, created tests TestSourceEditNameEmptyString and TestSourceEditNoNameRequest in order to test that a bad request is returned if the changing name to an empty string and that the request returns a 200 without name in body of request respectively

LINK: [RHCLOUD-20931](https://issues.redhat.com/browse/RHCLOUD-20931)
