### PR TITLE
[RHCLOUD-21027] Source validation update

### DIFF
--- a/service/source_validation.go
+++ b/service/source_validation.go
@@ -42,6 +42,10 @@ func ValidateSourceCreationRequest(sourceDao dao.SourceDao, req *model.SourceCre
 
 	// Try to get the SourceTypeID. If an error occurs, the user gets a generic error message, as they are not
 	// interested in the underlying ones
+	if req.SourceTypeIDRaw == nil {
+		return errors.New("source type id cannot be empty")
+	}
+
 	value, err := util.InterfaceToInt64(req.SourceTypeIDRaw)
 	if err != nil {
 		return errors.New("the source type id is not valid")

--- a/service/source_validation_test.go
+++ b/service/source_validation_test.go
@@ -279,6 +279,23 @@ func TestInvalidSourceTypeIdFormat(t *testing.T) {
 	}
 }
 
+// TestSourceTypeIdIsNil tests that validate function reports an error when source type id is missing in the request
+func TestSourceTypeIdIsNil(t *testing.T) {
+	request := model.SourceCreateRequest{
+		Name: util.StringRef("source name"),
+	}
+
+	err := ValidateSourceCreationRequest(sourceDao, &request)
+
+	if err == nil {
+		t.Errorf("Error expected, got none")
+	}
+
+	if err.Error() != "source type id cannot be empty" {
+		t.Errorf("got \"%s\", want \"%s\"", err.Error(), "source type id cannot be empty")
+	}
+}
+
 //TestEditSourceNameRequest tests if the function ValidateEditSourceNameRequest() will return a bad request if a source is edited to have the same name as another source within the same tenant.
 func TestEditSourceNameRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)


### PR DESCRIPTION
For create source request validation and missing source type id

```
POST /api/sources/v3.1/sources
{
  "name": "source test name"
}
```
we get 400 Bad request + message `bad request: Validation failed: the source type id is not valid`

I think we can improve this and for this case return that source type is missing and cannot be empty

so now we get 400 Bad request + message `bad request: Validation failed: source type id cannot be empty`


**JIRA:** [RHCLOUD-21027](https://issues.redhat.com/browse/RHCLOUD-21027)