### PR TITLE
[RHCLOUD-20415] Move mock daos into separate package and split it by handler

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -593,7 +593,7 @@ func TestApplicationGetBadRequest(t *testing.T) {
 
 func TestApplicationCreateGood(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	service.AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	service.AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		SourceIDRaw:          "2",
@@ -640,7 +640,7 @@ func TestApplicationCreateGood(t *testing.T) {
 }
 
 func TestApplicationCreateMissingSourceId(t *testing.T) {
-	service.AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	service.AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		ApplicationTypeIDRaw: "1",
@@ -670,7 +670,7 @@ func TestApplicationCreateMissingSourceId(t *testing.T) {
 }
 
 func TestApplicationCreateMissingApplicationTypeId(t *testing.T) {
-	service.AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	service.AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		SourceIDRaw: "1",
@@ -701,7 +701,7 @@ func TestApplicationCreateMissingApplicationTypeId(t *testing.T) {
 
 func TestApplicationCreateIncompatible(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	service.AppTypeDao = &dao.MockApplicationTypeDao{Compatible: false}
+	service.AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: false}
 
 	req := m.ApplicationCreateRequest{
 		SourceIDRaw:          "2",
@@ -2085,7 +2085,7 @@ func TestApplicationEditPausedUnit(t *testing.T) {
 	// Get the specific ApplicationDao mock which simulates that the applications are paused.
 	backupDao := getApplicationDao
 	getApplicationDao = func(c echo.Context) (dao.ApplicationDao, error) {
-		return &dao.MockApplicationDao{Applications: fixtures.TestApplicationData}, nil
+		return &mocks.MockApplicationDao{Applications: fixtures.TestApplicationData}, nil
 	}
 
 	appEdit := ErrorHandlingContext(ApplicationEdit)
@@ -2138,7 +2138,7 @@ func TestApplicationEditPausedUnitInvalidFields(t *testing.T) {
 	// Get the specific ApplicationDao mock which simulates that the applications are paused.
 	backupDao := getApplicationDao
 	getApplicationDao = func(c echo.Context) (dao.ApplicationDao, error) {
-		return &dao.MockApplicationDao{Applications: fixtures.TestApplicationData}, nil
+		return &mocks.MockApplicationDao{Applications: fixtures.TestApplicationData}, nil
 	}
 
 	// Set the fixture application as "paused".

--- a/dao/mock_daos.go
+++ b/dao/mock_daos.go
@@ -949,20 +949,3 @@ func (mad MockAuthenticationDao) ListIdsForResource(resourceType string, resourc
 func (m MockAuthenticationDao) BulkDelete(authentications []m.Authentication) ([]m.Authentication, error) {
 	return authentications, nil
 }
-
-func PopulateMockStaticTypeCache() error {
-	tc := typeCache{}
-	tc.sourceTypes = make(map[string]int64)
-	tc.applicationTypes = make(map[string]int64)
-
-	for _, st := range fixtures.TestSourceTypeData {
-		tc.sourceTypes[st.Name] = st.Id
-	}
-
-	for _, at := range fixtures.TestApplicationTypeData {
-		tc.applicationTypes[at.Name] = at.Id
-	}
-
-	Static = tc
-	return nil
-}

--- a/dao/type_cache_mock.go
+++ b/dao/type_cache_mock.go
@@ -1,0 +1,20 @@
+package dao
+
+import "github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+
+func PopulateMockStaticTypeCache() error {
+	tc := typeCache{}
+	tc.sourceTypes = make(map[string]int64)
+	tc.applicationTypes = make(map[string]int64)
+
+	for _, st := range fixtures.TestSourceTypeData {
+		tc.sourceTypes[st.Name] = st.Id
+	}
+
+	for _, at := range fixtures.TestApplicationTypeData {
+		tc.applicationTypes[at.Name] = at.Id
+	}
+
+	Static = tc
+	return nil
+}

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -1145,7 +1145,7 @@ func TestEndpointEditPaused(t *testing.T) {
 	// Store the original "getEndopintDao" function to restore it later.
 	backupGetEndpointDao := getEndpointDao
 	getEndpointDao = func(c echo.Context) (dao.EndpointDao, error) {
-		return &dao.MockEndpointDao{Endpoints: fixtures.TestEndpointData}, nil
+		return &mocks.MockEndpointDao{Endpoints: fixtures.TestEndpointData}, nil
 	}
 
 	// Set the fixture endpoint as "paused".
@@ -1209,7 +1209,7 @@ func TestEndpointEditPausedInvalidFields(t *testing.T) {
 	// Store the original "getEndopintDao" function to restore it later.
 	backupGetEndpointDao := getEndpointDao
 	getEndpointDao = func(c echo.Context) (dao.EndpointDao, error) {
-		return &dao.MockEndpointDao{Endpoints: fixtures.TestEndpointData}, nil
+		return &mocks.MockEndpointDao{Endpoints: fixtures.TestEndpointData}, nil
 	}
 
 	badRequestEndpointEdit := ErrorHandlingContext(EndpointEdit)

--- a/internal/testutils/mocks/mock_dao_application.go
+++ b/internal/testutils/mocks/mock_dao_application.go
@@ -1,0 +1,148 @@
+package mocks
+
+import (
+	"strings"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type MockApplicationDao struct {
+	Applications []m.Application
+}
+
+func (a *MockApplicationDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Application, int64, error) {
+	var applications []m.Application
+
+	switch object := primaryCollection.(type) {
+	case m.Source:
+		var sourceExists bool
+
+		for _, s := range fixtures.TestSourceData {
+			if s.ID == object.ID {
+				sourceExists = true
+			}
+		}
+		// if source doesn't exist, return Not Found Err
+		if !sourceExists {
+			return nil, 0, util.NewErrNotFound("source")
+		}
+
+		// else return list of related applications
+		for _, app := range a.Applications {
+			if object.ID == app.SourceID {
+				applications = append(applications, app)
+			}
+		}
+	}
+
+	return applications, int64(len(applications)), nil
+}
+
+func (a *MockApplicationDao) List(limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
+	count := int64(len(a.Applications))
+	return a.Applications, count, nil
+}
+
+func (a *MockApplicationDao) GetById(id *int64) (*m.Application, error) {
+	for _, app := range a.Applications {
+		if app.ID == *id {
+			return &app, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("application")
+}
+
+func (a *MockApplicationDao) GetByIdWithPreload(id *int64, preloads ...string) (*m.Application, error) {
+	for _, app := range a.Applications {
+		if app.ID == *id {
+			for _, preload := range preloads {
+				if strings.Contains(strings.ToLower(preload), "source") {
+					app.Source = fixtures.TestSourceData[0]
+				}
+			}
+
+			return &app, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("application")
+}
+
+func (a *MockApplicationDao) Create(src *m.Application) error {
+	return nil
+}
+
+func (a *MockApplicationDao) Update(src *m.Application) error {
+	return nil
+}
+
+func (a *MockApplicationDao) Delete(id *int64) (*m.Application, error) {
+	for _, app := range a.Applications {
+		if app.ID == *id {
+			return &app, nil
+		}
+	}
+	return nil, util.NewErrNotFound("application")
+}
+
+func (a *MockApplicationDao) Tenant() *int64 {
+	tenant := int64(1)
+	return &tenant
+}
+
+func (a *MockApplicationDao) User() *int64 {
+	user := int64(1)
+	return &user
+}
+
+func (a *MockApplicationDao) DeleteCascade(applicationId int64) ([]m.ApplicationAuthentication, *m.Application, error) {
+	var application *m.Application
+	for _, app := range fixtures.TestApplicationData {
+		if app.ID == applicationId {
+			application = &app
+		}
+	}
+
+	if application == nil {
+		return nil, nil, util.NewErrNotFound("application")
+	}
+
+	return fixtures.TestApplicationAuthenticationData, application, nil
+}
+
+func (a *MockApplicationDao) Exists(applicationId int64) (bool, error) {
+	for _, application := range a.Applications {
+		if application.ID == applicationId {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (m *MockApplicationDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockApplicationDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockApplicationDao) ToEventJSON(_ util.Resource) ([]byte, error) {
+	return nil, nil
+}
+
+func (a *MockApplicationDao) Pause(_ int64) error {
+	return nil
+}
+
+func (a *MockApplicationDao) Unpause(_ int64) error {
+	return nil
+}
+
+func (src *MockApplicationDao) IsSuperkey(id int64) bool {
+	return false
+}

--- a/internal/testutils/mocks/mock_dao_application_authentication.go
+++ b/internal/testutils/mocks/mock_dao_application_authentication.go
@@ -1,0 +1,46 @@
+package mocks
+
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type MockApplicationAuthenticationDao struct {
+	ApplicationAuthentications []m.ApplicationAuthentication
+}
+
+func (m MockApplicationAuthenticationDao) List(limit, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
+	count := int64(len(m.ApplicationAuthentications))
+	return m.ApplicationAuthentications, count, nil
+}
+
+func (m MockApplicationAuthenticationDao) GetById(id *int64) (*m.ApplicationAuthentication, error) {
+	for _, appAuth := range m.ApplicationAuthentications {
+		if appAuth.ID == *id {
+			return &appAuth, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("application authentication")
+}
+
+func (m MockApplicationAuthenticationDao) Create(src *m.ApplicationAuthentication) error {
+	return nil
+}
+
+func (m MockApplicationAuthenticationDao) Update(src *m.ApplicationAuthentication) error {
+	panic("implement me")
+}
+
+func (m MockApplicationAuthenticationDao) Delete(id *int64) (*m.ApplicationAuthentication, error) {
+	return m.GetById(id)
+}
+
+func (m MockApplicationAuthenticationDao) Tenant() *int64 {
+	tenant := int64(1)
+	return &tenant
+}
+
+func (m MockApplicationAuthenticationDao) ApplicationAuthenticationsByResource(_ string, _ []m.Application, _ []m.Authentication) ([]m.ApplicationAuthentication, error) {
+	return m.ApplicationAuthentications, nil
+}

--- a/internal/testutils/mocks/mock_dao_application_type.go
+++ b/internal/testutils/mocks/mock_dao_application_type.go
@@ -1,0 +1,104 @@
+package mocks
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type MockApplicationTypeDao struct {
+	ApplicationTypes []m.ApplicationType
+	Compatible       bool
+}
+
+func (a *MockApplicationTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
+	count := int64(len(a.ApplicationTypes))
+	return a.ApplicationTypes, count, nil
+}
+
+func (a *MockApplicationTypeDao) GetById(id *int64) (*m.ApplicationType, error) {
+	for _, i := range a.ApplicationTypes {
+		if i.Id == *id {
+			return &i, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("application type")
+}
+
+func (a *MockApplicationTypeDao) Create(src *m.ApplicationType) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockApplicationTypeDao) Update(src *m.ApplicationType) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockApplicationTypeDao) Delete(id *int64) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
+	var appTypesOut []m.ApplicationType
+
+	switch object := primaryCollection.(type) {
+	case m.Source:
+		var sourceExists bool
+		for _, src := range fixtures.TestSourceData {
+			if src.ID == object.ID {
+				sourceExists = true
+			}
+		}
+		if !sourceExists {
+			return nil, 0, util.NewErrNotFound("source")
+		}
+
+		appTypes := make(map[int64]int)
+		for _, app := range fixtures.TestApplicationData {
+			if app.SourceID == object.ID {
+				appTypes[app.ApplicationTypeID]++
+			}
+		}
+
+		for _, appType := range a.ApplicationTypes {
+			for id := range appTypes {
+				if appType.Id == id {
+					appTypesOut = append(appTypesOut, appType)
+					break
+				}
+			}
+		}
+	default:
+		return nil, 0, fmt.Errorf("unexpected primary collection type")
+	}
+
+	count := int64(len(appTypesOut))
+	return appTypesOut, count, nil
+}
+
+func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSource(_, _ int64) error {
+	if a.Compatible {
+		return nil
+	}
+
+	return errors.New("Not compatible!")
+}
+
+func (at *MockApplicationTypeDao) GetSuperKeyResultType(applicationTypeId int64, authType string) (string, error) {
+	panic("not needed")
+}
+
+func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSourceType(_, _ int64) error {
+	if a.Compatible {
+		return nil
+	}
+
+	return errors.New("Not compatible!")
+}
+
+func (a *MockApplicationTypeDao) GetByName(_ string) (*m.ApplicationType, error) {
+	return nil, nil
+}

--- a/internal/testutils/mocks/mock_dao_authentication.go
+++ b/internal/testutils/mocks/mock_dao_authentication.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"fmt"
+
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"

--- a/internal/testutils/mocks/mock_dao_endpoint.go
+++ b/internal/testutils/mocks/mock_dao_endpoint.go
@@ -1,0 +1,116 @@
+package mocks
+
+import (
+	"fmt"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type MockEndpointDao struct {
+	Endpoints []m.Endpoint
+}
+
+func (a *MockEndpointDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
+	// Return not found err when the source doesn't exist
+	var sourceExist bool
+	var sourceId int64
+	switch object := primaryCollection.(type) {
+	case m.Source:
+		for _, source := range fixtures.TestSourceData {
+			if object.ID == source.ID {
+				sourceExist = true
+				sourceId = object.ID
+				break
+			}
+		}
+	default:
+		return nil, 0, fmt.Errorf("unexpected primary collection type")
+	}
+
+	if !sourceExist {
+		return nil, 0, util.NewErrNotFound("source")
+	}
+
+	// Get list of endpoints for existing source
+	var endpointsOut []m.Endpoint
+	for _, e := range a.Endpoints {
+		if e.SourceID == sourceId {
+			endpointsOut = append(endpointsOut, e)
+		}
+	}
+
+	return endpointsOut, int64(len(endpointsOut)), nil
+}
+
+func (a *MockEndpointDao) List(limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
+	count := int64(len(a.Endpoints))
+	return a.Endpoints, count, nil
+}
+
+func (a *MockEndpointDao) GetById(id *int64) (*m.Endpoint, error) {
+	for _, app := range a.Endpoints {
+		if app.ID == *id {
+			return &app, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("endpoint")
+}
+
+func (a *MockEndpointDao) Create(src *m.Endpoint) error {
+	return nil
+}
+
+func (a *MockEndpointDao) Update(endpoint *m.Endpoint) error {
+	if endpoint.ID == fixtures.TestEndpointData[0].ID {
+		return nil
+	}
+
+	return util.NewErrNotFound("endpoint")
+}
+
+func (endpointDao *MockEndpointDao) Delete(id *int64) (*m.Endpoint, error) {
+	for i, e := range endpointDao.Endpoints {
+		if e.ID == *id {
+			endpointDao.Endpoints = append(endpointDao.Endpoints[:i], endpointDao.Endpoints[i+1:]...)
+
+			return &e, nil
+		}
+	}
+	return nil, util.NewErrNotFound("endpoint")
+}
+
+func (m *MockEndpointDao) Tenant() *int64 {
+	tenant := int64(1)
+	return &tenant
+}
+
+func (m *MockEndpointDao) CanEndpointBeSetAsDefaultForSource(sourceId int64) bool {
+	return true
+}
+
+func (m *MockEndpointDao) IsRoleUniqueForSource(role string, sourceId int64) bool {
+	return true
+}
+
+func (m *MockEndpointDao) SourceHasEndpoints(sourceId int64) bool {
+	return true
+}
+
+func (m *MockEndpointDao) Exists(endpointId int64) (bool, error) {
+	return true, nil
+}
+
+func (m *MockEndpointDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockEndpointDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockEndpointDao) ToEventJSON(_ util.Resource) ([]byte, error) {
+	return nil, nil
+}

--- a/internal/testutils/mocks/mock_dao_meta_data.go
+++ b/internal/testutils/mocks/mock_dao_meta_data.go
@@ -1,0 +1,72 @@
+package mocks
+
+import (
+	"fmt"
+
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type MockMetaDataDao struct {
+	MetaDatas []m.MetaData
+}
+
+func (a *MockMetaDataDao) List(limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
+	count := int64(len(a.MetaDatas))
+	return a.MetaDatas, count, nil
+}
+
+func (a *MockMetaDataDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
+	var appMetaDataList []m.MetaData
+
+	for index, i := range a.MetaDatas {
+		switch object := primaryCollection.(type) {
+		case m.ApplicationType:
+			if i.ApplicationTypeID == object.Id {
+				appMetaDataList = append(appMetaDataList, a.MetaDatas[index])
+			}
+		default:
+			return nil, 0, fmt.Errorf("unexpected primary collection type")
+		}
+	}
+	count := int64(len(appMetaDataList))
+	if count == 0 {
+		return nil, count, util.NewErrNotFound("metadata")
+	}
+
+	return appMetaDataList, count, nil
+}
+
+func (a *MockMetaDataDao) GetById(id *int64) (*m.MetaData, error) {
+	for _, i := range a.MetaDatas {
+		if i.ID == *id {
+			return &i, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("metadata")
+}
+
+func (a *MockMetaDataDao) Create(src *m.MetaData) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockMetaDataDao) Update(src *m.MetaData) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockMetaDataDao) Delete(id *int64) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (md *MockMetaDataDao) GetSuperKeySteps(_ int64) ([]m.MetaData, error) {
+	panic("not implemented")
+}
+
+func (md *MockMetaDataDao) GetSuperKeyAccountNumber(applicationTypeId int64) (string, error) {
+	panic("not implemented!")
+}
+
+func (md *MockMetaDataDao) ApplicationOptedIntoRetry(applicationTypeId int64) (bool, error) {
+	panic("not implemented!")
+}

--- a/internal/testutils/mocks/mock_dao_rhc_connection.go
+++ b/internal/testutils/mocks/mock_dao_rhc_connection.go
@@ -1,0 +1,93 @@
+package mocks
+
+import (
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type MockRhcConnectionDao struct {
+	RhcConnections        []m.RhcConnection
+	RelatedRhcConnections []m.RhcConnection
+}
+
+func (m *MockRhcConnectionDao) List(limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error) {
+	count := int64(len(m.RhcConnections))
+	return m.RhcConnections, count, nil
+}
+
+func (mr *MockRhcConnectionDao) GetById(id *int64) (*m.RhcConnection, error) {
+	// The ".ToResponse" method of the RhcConnection expects to have at least one related source.
+	source := []m.Source{
+		{
+			ID: 1,
+		},
+	}
+
+	for _, rhcConnection := range mr.RhcConnections {
+		if rhcConnection.ID == *id {
+			rhcConnection.Sources = source
+			return &rhcConnection, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("rhcConnection")
+}
+
+func (mr *MockRhcConnectionDao) Create(rhcConnection *m.RhcConnection) (*m.RhcConnection, error) {
+	// Check if in fixtures is a source with given source id
+	var sourceExists bool
+	for _, src := range fixtures.TestSourceData {
+		if src.ID == rhcConnection.Sources[0].ID {
+			sourceExists = true
+		}
+	}
+
+	if !sourceExists {
+		return nil, util.NewErrNotFound("source")
+	}
+
+	// Check if in fixtures exists same relation
+	var relationExists bool
+	for _, s := range fixtures.TestSourceRhcConnectionData {
+		if s.SourceId == rhcConnection.Sources[0].ID {
+			for _, r := range fixtures.TestRhcConnectionData {
+				if s.RhcConnectionId == r.ID && r.RhcId == rhcConnection.RhcId {
+					relationExists = true
+				}
+			}
+		}
+	}
+
+	if relationExists {
+		return nil, util.NewErrBadRequest("connection already exists")
+	}
+
+	return rhcConnection, nil
+}
+
+func (m *MockRhcConnectionDao) Update(rhcConnection *m.RhcConnection) error {
+	for _, rhcTmp := range m.RhcConnections {
+		if rhcTmp.ID == rhcConnection.ID {
+			return nil
+		}
+	}
+
+	return util.NewErrNotFound("rhcConnection")
+}
+
+func (m *MockRhcConnectionDao) Delete(id *int64) (*m.RhcConnection, error) {
+	for _, rhcTmp := range m.RhcConnections {
+		if rhcTmp.ID == *id {
+			return &rhcTmp, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("rhcConnection")
+}
+
+func (m *MockRhcConnectionDao) ListForSource(sourceId *int64, limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error) {
+	count := int64(len(m.RelatedRhcConnections))
+
+	return m.RelatedRhcConnections, count, nil
+}

--- a/internal/testutils/mocks/mock_dao_source.go
+++ b/internal/testutils/mocks/mock_dao_source.go
@@ -1,0 +1,184 @@
+package mocks
+
+import (
+	"fmt"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type MockSourceDao struct {
+	Sources        []m.Source
+	RelatedSources []m.Source
+}
+
+func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
+	var sources []m.Source
+
+	switch object := primaryCollection.(type) {
+	case m.SourceType:
+		var sourceTypeExists bool
+		for _, sourceType := range fixtures.TestSourceTypeData {
+			if sourceType.Id == object.Id {
+				sourceTypeExists = true
+			}
+		}
+
+		// Source type doesn't exist = return Not Found err
+		if !sourceTypeExists {
+			return nil, 0, util.NewErrNotFound("source type")
+		}
+
+		// Source type exists = return sources subcollection
+		for index, source := range src.Sources {
+			if source.SourceTypeID == object.Id {
+				sources = append(sources, src.Sources[index])
+			}
+		}
+
+	case m.ApplicationType:
+		var appTypeExists bool
+		for _, appType := range fixtures.TestApplicationTypeData {
+			if appType.Id == object.Id {
+				appTypeExists = true
+			}
+		}
+
+		// Application type doesn't exist = return Not Found err
+		if !appTypeExists {
+			return nil, 0, util.NewErrNotFound("application type")
+		}
+
+		// Application type exists = find related sources
+		sources = testutils.GetSourcesWithAppType(object.Id)
+
+	default:
+		return nil, 0, fmt.Errorf("unexpected primary collection type")
+	}
+
+	count := int64(len(sources))
+	return sources, count, nil
+}
+
+func (src *MockSourceDao) List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
+	count := int64(len(src.Sources))
+	return src.Sources, count, nil
+}
+
+func (src *MockSourceDao) ListInternal(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
+	count := int64(len(src.Sources))
+	return src.Sources, count, nil
+}
+
+func (src *MockSourceDao) GetById(id *int64) (*m.Source, error) {
+	for _, i := range src.Sources {
+		if i.ID == *id {
+			return &i, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("source")
+}
+
+func (src *MockSourceDao) Create(s *m.Source) error {
+	src.Sources = append(src.Sources, *s)
+	return nil
+}
+
+func (src *MockSourceDao) Update(s *m.Source) error {
+	return nil
+}
+
+func (src *MockSourceDao) Delete(id *int64) (*m.Source, error) {
+	for i, source := range src.Sources {
+		if source.ID == *id {
+			src.Sources = append(src.Sources[:i], src.Sources[i+1:]...)
+
+			return &source, nil
+		}
+	}
+	return nil, util.NewErrNotFound("source")
+}
+
+func (src *MockSourceDao) Tenant() *int64 {
+	tenant := int64(1)
+	return &tenant
+}
+
+func (src *MockSourceDao) User() *int64 {
+	user := int64(1)
+	return &user
+}
+
+func (src *MockSourceDao) Exists(sourceId int64) (bool, error) {
+	for _, source := range src.Sources {
+		if source.ID == sourceId {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// NameExistsInCurrentTenant returns always false because it's the safe default in case the request gets validated
+// in the tests.
+func (src *MockSourceDao) NameExistsInCurrentTenant(name string) bool {
+	return false
+}
+
+func (src *MockSourceDao) IsSuperkey(id int64) bool {
+	return false
+}
+
+func (src *MockSourceDao) GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error) {
+	for _, i := range src.Sources {
+		if i.ID == *id {
+			return &i, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("source")
+}
+
+func (m *MockSourceDao) ListForRhcConnection(id *int64, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
+	count := int64(len(m.RelatedSources))
+
+	return m.RelatedSources, count, nil
+}
+
+func (msd *MockSourceDao) DeleteCascade(id int64) ([]m.ApplicationAuthentication, []m.Application, []m.Endpoint, []m.RhcConnection, *m.Source, error) {
+	var source *m.Source
+	for _, src := range fixtures.TestSourceData {
+		if src.ID == id {
+			source = &src
+		}
+	}
+
+	if source == nil {
+		return nil, nil, nil, nil, nil, util.NewErrNotFound("source")
+	}
+
+	return fixtures.TestApplicationAuthenticationData, fixtures.TestApplicationData, fixtures.TestEndpointData, fixtures.TestRhcConnectionData, source, nil
+}
+
+func (m *MockSourceDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockSourceDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (m *MockSourceDao) ToEventJSON(_ util.Resource) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *MockSourceDao) Pause(_ int64) error {
+	return nil
+}
+
+func (s *MockSourceDao) Unpause(_ int64) error {
+	return nil
+}

--- a/internal/testutils/mocks/mock_dao_source_type.go
+++ b/internal/testutils/mocks/mock_dao_source_type.go
@@ -1,0 +1,41 @@
+package mocks
+
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+type MockSourceTypeDao struct {
+	SourceTypes []m.SourceType
+}
+
+func (a *MockSourceTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
+	count := int64(len(a.SourceTypes))
+	return a.SourceTypes, count, nil
+}
+
+func (a *MockSourceTypeDao) GetById(id *int64) (*m.SourceType, error) {
+	for _, i := range a.SourceTypes {
+		if i.Id == *id {
+			return &i, nil
+		}
+	}
+
+	return nil, util.NewErrNotFound("source type")
+}
+
+func (a *MockSourceTypeDao) GetByName(_ string) (*m.SourceType, error) {
+	return nil, nil
+}
+
+func (a *MockSourceTypeDao) Create(src *m.SourceType) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockSourceTypeDao) Update(src *m.SourceType) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *MockSourceTypeDao) Delete(id *int64) error {
+	panic("not implemented") // TODO: Implement
+}

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -6,18 +6,12 @@ import (
 	"strings"
 
 	"github.com/RedHatInsights/sources-api-go/config"
-	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 var conf = config.Get()
-
-type MockSourceDao struct {
-	Sources        []m.Source
-	RelatedSources []m.Source
-}
 
 type MockApplicationDao struct {
 	Applications []m.Application
@@ -26,6 +20,7 @@ type MockApplicationDao struct {
 type MockEndpointDao struct {
 	Endpoints []m.Endpoint
 }
+
 type MockApplicationTypeDao struct {
 	ApplicationTypes []m.ApplicationType
 	Compatible       bool
@@ -50,174 +45,6 @@ type MockApplicationAuthenticationDao struct {
 
 type MockAuthenticationDao struct {
 	Authentications []m.Authentication
-}
-
-func (src *MockSourceDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
-	var sources []m.Source
-
-	switch object := primaryCollection.(type) {
-	case m.SourceType:
-		var sourceTypeExists bool
-		for _, sourceType := range fixtures.TestSourceTypeData {
-			if sourceType.Id == object.Id {
-				sourceTypeExists = true
-			}
-		}
-
-		// Source type doesn't exist = return Not Found err
-		if !sourceTypeExists {
-			return nil, 0, util.NewErrNotFound("source type")
-		}
-
-		// Source type exists = return sources subcollection
-		for index, source := range src.Sources {
-			if source.SourceTypeID == object.Id {
-				sources = append(sources, src.Sources[index])
-			}
-		}
-
-	case m.ApplicationType:
-		var appTypeExists bool
-		for _, appType := range fixtures.TestApplicationTypeData {
-			if appType.Id == object.Id {
-				appTypeExists = true
-			}
-		}
-
-		// Application type doesn't exist = return Not Found err
-		if !appTypeExists {
-			return nil, 0, util.NewErrNotFound("application type")
-		}
-
-		// Application type exists = find related sources
-		sources = testutils.GetSourcesWithAppType(object.Id)
-
-	default:
-		return nil, 0, fmt.Errorf("unexpected primary collection type")
-	}
-
-	count := int64(len(sources))
-	return sources, count, nil
-}
-
-func (src *MockSourceDao) List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
-	count := int64(len(src.Sources))
-	return src.Sources, count, nil
-}
-
-func (src *MockSourceDao) ListInternal(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
-	count := int64(len(src.Sources))
-	return src.Sources, count, nil
-}
-
-func (src *MockSourceDao) GetById(id *int64) (*m.Source, error) {
-	for _, i := range src.Sources {
-		if i.ID == *id {
-			return &i, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("source")
-}
-
-func (src *MockSourceDao) Create(s *m.Source) error {
-	src.Sources = append(src.Sources, *s)
-	return nil
-}
-
-func (src *MockSourceDao) Update(s *m.Source) error {
-	return nil
-}
-
-func (src *MockSourceDao) Delete(id *int64) (*m.Source, error) {
-	for i, source := range src.Sources {
-		if source.ID == *id {
-			src.Sources = append(src.Sources[:i], src.Sources[i+1:]...)
-
-			return &source, nil
-		}
-	}
-	return nil, util.NewErrNotFound("source")
-}
-
-func (src *MockSourceDao) Tenant() *int64 {
-	tenant := int64(1)
-	return &tenant
-}
-func (src *MockSourceDao) User() *int64 {
-	user := int64(1)
-	return &user
-}
-
-func (src *MockSourceDao) Exists(sourceId int64) (bool, error) {
-	for _, source := range src.Sources {
-		if source.ID == sourceId {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-// NameExistsInCurrentTenant returns always false because it's the safe default in case the request gets validated
-// in the tests.
-func (src *MockSourceDao) NameExistsInCurrentTenant(name string) bool {
-	return false
-}
-
-func (src *MockSourceDao) IsSuperkey(id int64) bool {
-	return false
-}
-
-func (src *MockSourceDao) GetByIdWithPreload(id *int64, preloads ...string) (*m.Source, error) {
-	for _, i := range src.Sources {
-		if i.ID == *id {
-			return &i, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("source")
-}
-
-func (m *MockSourceDao) ListForRhcConnection(id *int64, limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
-	count := int64(len(m.RelatedSources))
-
-	return m.RelatedSources, count, nil
-}
-
-func (msd *MockSourceDao) DeleteCascade(id int64) ([]m.ApplicationAuthentication, []m.Application, []m.Endpoint, []m.RhcConnection, *m.Source, error) {
-	var source *m.Source
-	for _, src := range fixtures.TestSourceData {
-		if src.ID == id {
-			source = &src
-		}
-	}
-
-	if source == nil {
-		return nil, nil, nil, nil, nil, util.NewErrNotFound("source")
-	}
-
-	return fixtures.TestApplicationAuthenticationData, fixtures.TestApplicationData, fixtures.TestEndpointData, fixtures.TestRhcConnectionData, source, nil
-}
-
-func (m *MockSourceDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
-	return nil, nil
-}
-
-func (m *MockSourceDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) (interface{}, error) {
-	return nil, nil
-}
-
-func (m *MockSourceDao) ToEventJSON(_ util.Resource) ([]byte, error) {
-	return nil, nil
-}
-
-func (s *MockSourceDao) Pause(_ int64) error {
-	return nil
-}
-
-func (s *MockSourceDao) Unpause(_ int64) error {
-	return nil
 }
 
 func (a *MockApplicationTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -10,10 +10,6 @@ import (
 
 var conf = config.Get()
 
-type MockSourceTypeDao struct {
-	SourceTypes []m.SourceType
-}
-
 type MockMetaDataDao struct {
 	MetaDatas []m.MetaData
 }
@@ -89,37 +85,6 @@ func (md *MockMetaDataDao) GetSuperKeyAccountNumber(applicationTypeId int64) (st
 
 func (md *MockMetaDataDao) ApplicationOptedIntoRetry(applicationTypeId int64) (bool, error) {
 	panic("not implemented!")
-}
-
-func (a *MockSourceTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {
-	count := int64(len(a.SourceTypes))
-	return a.SourceTypes, count, nil
-}
-
-func (a *MockSourceTypeDao) GetById(id *int64) (*m.SourceType, error) {
-	for _, i := range a.SourceTypes {
-		if i.Id == *id {
-			return &i, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("source type")
-}
-
-func (a *MockSourceTypeDao) GetByName(_ string) (*m.SourceType, error) {
-	return nil, nil
-}
-
-func (a *MockSourceTypeDao) Create(src *m.SourceType) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockSourceTypeDao) Update(src *m.SourceType) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockSourceTypeDao) Delete(id *int64) error {
-	panic("not implemented") // TODO: Implement
 }
 
 func (m *MockRhcConnectionDao) List(limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error) {

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -1,8 +1,9 @@
-package dao
+package mocks
 
 import (
 	"errors"
 	"fmt"
+	"github.com/RedHatInsights/sources-api-go/dao"
 	"strings"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
@@ -760,7 +761,7 @@ func (m MockAuthenticationDao) GetById(id string) (*m.Authentication, error) {
 	for _, auth := range m.Authentications {
 		// If secret store is database, we compare given ID with different field
 		// than if secret store is vault
-		if conf.SecretStore == "database" {
+		if dao.conf.SecretStore == "database" {
 			if fmt.Sprintf("%d", auth.DbID) == id {
 				return &auth, nil
 			}
@@ -890,7 +891,7 @@ func (m MockAuthenticationDao) Delete(id string) (*m.Authentication, error) {
 	for _, auth := range m.Authentications {
 		// If secret store is database, we compare given ID with different field
 		// than if secret store is vault
-		if conf.SecretStore == "database" {
+		if dao.conf.SecretStore == "database" {
 			if fmt.Sprintf("%d", auth.DbID) == id {
 				return &auth, nil
 			}

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -10,48 +10,8 @@ import (
 
 var conf = config.Get()
 
-type MockApplicationAuthenticationDao struct {
-	ApplicationAuthentications []m.ApplicationAuthentication
-}
-
 type MockAuthenticationDao struct {
 	Authentications []m.Authentication
-}
-
-func (m MockApplicationAuthenticationDao) List(limit, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {
-	count := int64(len(m.ApplicationAuthentications))
-	return m.ApplicationAuthentications, count, nil
-}
-
-func (m MockApplicationAuthenticationDao) GetById(id *int64) (*m.ApplicationAuthentication, error) {
-	for _, appAuth := range m.ApplicationAuthentications {
-		if appAuth.ID == *id {
-			return &appAuth, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("application authentication")
-}
-
-func (m MockApplicationAuthenticationDao) Create(src *m.ApplicationAuthentication) error {
-	return nil
-}
-
-func (m MockApplicationAuthenticationDao) Update(src *m.ApplicationAuthentication) error {
-	panic("implement me")
-}
-
-func (m MockApplicationAuthenticationDao) Delete(id *int64) (*m.ApplicationAuthentication, error) {
-	return m.GetById(id)
-}
-
-func (m MockApplicationAuthenticationDao) Tenant() *int64 {
-	tenant := int64(1)
-	return &tenant
-}
-
-func (m MockApplicationAuthenticationDao) ApplicationAuthenticationsByResource(_ string, _ []m.Application, _ []m.Authentication) ([]m.ApplicationAuthentication, error) {
-	return m.ApplicationAuthentications, nil
 }
 
 func (m MockAuthenticationDao) List(limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -1,7 +1,6 @@
 package mocks
 
 import (
-	"errors"
 	"fmt"
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
@@ -10,11 +9,6 @@ import (
 )
 
 var conf = config.Get()
-
-type MockApplicationTypeDao struct {
-	ApplicationTypes []m.ApplicationType
-	Compatible       bool
-}
 
 type MockSourceTypeDao struct {
 	SourceTypes []m.SourceType
@@ -35,21 +29,6 @@ type MockApplicationAuthenticationDao struct {
 
 type MockAuthenticationDao struct {
 	Authentications []m.Authentication
-}
-
-func (a *MockApplicationTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
-	count := int64(len(a.ApplicationTypes))
-	return a.ApplicationTypes, count, nil
-}
-
-func (a *MockApplicationTypeDao) GetById(id *int64) (*m.ApplicationType, error) {
-	for _, i := range a.ApplicationTypes {
-		if i.Id == *id {
-			return &i, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("application type")
 }
 
 func (a *MockMetaDataDao) List(limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
@@ -110,80 +89,6 @@ func (md *MockMetaDataDao) GetSuperKeyAccountNumber(applicationTypeId int64) (st
 
 func (md *MockMetaDataDao) ApplicationOptedIntoRetry(applicationTypeId int64) (bool, error) {
 	panic("not implemented!")
-}
-
-func (a *MockApplicationTypeDao) Create(src *m.ApplicationType) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockApplicationTypeDao) Update(src *m.ApplicationType) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockApplicationTypeDao) Delete(id *int64) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockApplicationTypeDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.ApplicationType, int64, error) {
-	var appTypesOut []m.ApplicationType
-
-	switch object := primaryCollection.(type) {
-	case m.Source:
-		var sourceExists bool
-		for _, src := range fixtures.TestSourceData {
-			if src.ID == object.ID {
-				sourceExists = true
-			}
-		}
-		if !sourceExists {
-			return nil, 0, util.NewErrNotFound("source")
-		}
-
-		appTypes := make(map[int64]int)
-		for _, app := range fixtures.TestApplicationData {
-			if app.SourceID == object.ID {
-				appTypes[app.ApplicationTypeID]++
-			}
-		}
-
-		for _, appType := range a.ApplicationTypes {
-			for id := range appTypes {
-				if appType.Id == id {
-					appTypesOut = append(appTypesOut, appType)
-					break
-				}
-			}
-		}
-	default:
-		return nil, 0, fmt.Errorf("unexpected primary collection type")
-	}
-
-	count := int64(len(appTypesOut))
-	return appTypesOut, count, nil
-}
-
-func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSource(_, _ int64) error {
-	if a.Compatible {
-		return nil
-	}
-
-	return errors.New("Not compatible!")
-}
-
-func (at *MockApplicationTypeDao) GetSuperKeyResultType(applicationTypeId int64, authType string) (string, error) {
-	panic("not needed")
-}
-
-func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSourceType(_, _ int64) error {
-	if a.Compatible {
-		return nil
-	}
-
-	return errors.New("Not compatible!")
-}
-
-func (a *MockApplicationTypeDao) GetByName(_ string) (*m.ApplicationType, error) {
-	return nil, nil
 }
 
 func (a *MockSourceTypeDao) List(limit int, offset int, filters []util.Filter) ([]m.SourceType, int64, error) {

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -10,10 +10,6 @@ import (
 
 var conf = config.Get()
 
-type MockMetaDataDao struct {
-	MetaDatas []m.MetaData
-}
-
 type MockRhcConnectionDao struct {
 	RhcConnections        []m.RhcConnection
 	RelatedRhcConnections []m.RhcConnection
@@ -25,66 +21,6 @@ type MockApplicationAuthenticationDao struct {
 
 type MockAuthenticationDao struct {
 	Authentications []m.Authentication
-}
-
-func (a *MockMetaDataDao) List(limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
-	count := int64(len(a.MetaDatas))
-	return a.MetaDatas, count, nil
-}
-
-func (a *MockMetaDataDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
-	var appMetaDataList []m.MetaData
-
-	for index, i := range a.MetaDatas {
-		switch object := primaryCollection.(type) {
-		case m.ApplicationType:
-			if i.ApplicationTypeID == object.Id {
-				appMetaDataList = append(appMetaDataList, a.MetaDatas[index])
-			}
-		default:
-			return nil, 0, fmt.Errorf("unexpected primary collection type")
-		}
-	}
-	count := int64(len(appMetaDataList))
-	if count == 0 {
-		return nil, count, util.NewErrNotFound("metadata")
-	}
-
-	return appMetaDataList, count, nil
-}
-
-func (a *MockMetaDataDao) GetById(id *int64) (*m.MetaData, error) {
-	for _, i := range a.MetaDatas {
-		if i.ID == *id {
-			return &i, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("metadata")
-}
-
-func (a *MockMetaDataDao) Create(src *m.MetaData) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockMetaDataDao) Update(src *m.MetaData) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockMetaDataDao) Delete(id *int64) error {
-	panic("not implemented") // TODO: Implement
-}
-
-func (md *MockMetaDataDao) GetSuperKeySteps(_ int64) ([]m.MetaData, error) {
-	panic("not implemented")
-}
-
-func (md *MockMetaDataDao) GetSuperKeyAccountNumber(applicationTypeId int64) (string, error) {
-	panic("not implemented!")
-}
-
-func (md *MockMetaDataDao) ApplicationOptedIntoRetry(applicationTypeId int64) (bool, error) {
-	panic("not implemented!")
 }
 
 func (m *MockRhcConnectionDao) List(limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error) {

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -10,98 +10,12 @@ import (
 
 var conf = config.Get()
 
-type MockRhcConnectionDao struct {
-	RhcConnections        []m.RhcConnection
-	RelatedRhcConnections []m.RhcConnection
-}
-
 type MockApplicationAuthenticationDao struct {
 	ApplicationAuthentications []m.ApplicationAuthentication
 }
 
 type MockAuthenticationDao struct {
 	Authentications []m.Authentication
-}
-
-func (m *MockRhcConnectionDao) List(limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error) {
-	count := int64(len(m.RhcConnections))
-	return m.RhcConnections, count, nil
-}
-
-func (mr *MockRhcConnectionDao) GetById(id *int64) (*m.RhcConnection, error) {
-	// The ".ToResponse" method of the RhcConnection expects to have at least one related source.
-	source := []m.Source{
-		{
-			ID: 1,
-		},
-	}
-
-	for _, rhcConnection := range mr.RhcConnections {
-		if rhcConnection.ID == *id {
-			rhcConnection.Sources = source
-			return &rhcConnection, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("rhcConnection")
-}
-
-func (mr *MockRhcConnectionDao) Create(rhcConnection *m.RhcConnection) (*m.RhcConnection, error) {
-	// Check if in fixtures is a source with given source id
-	var sourceExists bool
-	for _, src := range fixtures.TestSourceData {
-		if src.ID == rhcConnection.Sources[0].ID {
-			sourceExists = true
-		}
-	}
-
-	if !sourceExists {
-		return nil, util.NewErrNotFound("source")
-	}
-
-	// Check if in fixtures exists same relation
-	var relationExists bool
-	for _, s := range fixtures.TestSourceRhcConnectionData {
-		if s.SourceId == rhcConnection.Sources[0].ID {
-			for _, r := range fixtures.TestRhcConnectionData {
-				if s.RhcConnectionId == r.ID && r.RhcId == rhcConnection.RhcId {
-					relationExists = true
-				}
-			}
-		}
-	}
-
-	if relationExists {
-		return nil, util.NewErrBadRequest("connection already exists")
-	}
-
-	return rhcConnection, nil
-}
-
-func (m *MockRhcConnectionDao) Update(rhcConnection *m.RhcConnection) error {
-	for _, rhcTmp := range m.RhcConnections {
-		if rhcTmp.ID == rhcConnection.ID {
-			return nil
-		}
-	}
-
-	return util.NewErrNotFound("rhcConnection")
-}
-
-func (m *MockRhcConnectionDao) Delete(id *int64) (*m.RhcConnection, error) {
-	for _, rhcTmp := range m.RhcConnections {
-		if rhcTmp.ID == *id {
-			return &rhcTmp, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("rhcConnection")
-}
-
-func (m *MockRhcConnectionDao) ListForSource(sourceId *int64, limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error) {
-	count := int64(len(m.RelatedRhcConnections))
-
-	return m.RelatedRhcConnections, count, nil
 }
 
 func (m MockApplicationAuthenticationDao) List(limit, offset int, filters []util.Filter) ([]m.ApplicationAuthentication, int64, error) {

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -11,10 +11,6 @@ import (
 
 var conf = config.Get()
 
-type MockEndpointDao struct {
-	Endpoints []m.Endpoint
-}
-
 type MockApplicationTypeDao struct {
 	ApplicationTypes []m.ApplicationType
 	Compatible       bool
@@ -219,109 +215,6 @@ func (a *MockSourceTypeDao) Update(src *m.SourceType) error {
 
 func (a *MockSourceTypeDao) Delete(id *int64) error {
 	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockEndpointDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
-	// Return not found err when the source doesn't exist
-	var sourceExist bool
-	var sourceId int64
-	switch object := primaryCollection.(type) {
-	case m.Source:
-		for _, source := range fixtures.TestSourceData {
-			if object.ID == source.ID {
-				sourceExist = true
-				sourceId = object.ID
-				break
-			}
-		}
-	default:
-		return nil, 0, fmt.Errorf("unexpected primary collection type")
-	}
-
-	if !sourceExist {
-		return nil, 0, util.NewErrNotFound("source")
-	}
-
-	// Get list of endpoints for existing source
-	var endpointsOut []m.Endpoint
-	for _, e := range a.Endpoints {
-		if e.SourceID == sourceId {
-			endpointsOut = append(endpointsOut, e)
-		}
-	}
-
-	return endpointsOut, int64(len(endpointsOut)), nil
-}
-
-func (a *MockEndpointDao) List(limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
-	count := int64(len(a.Endpoints))
-	return a.Endpoints, count, nil
-}
-
-func (a *MockEndpointDao) GetById(id *int64) (*m.Endpoint, error) {
-	for _, app := range a.Endpoints {
-		if app.ID == *id {
-			return &app, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("endpoint")
-}
-
-func (a *MockEndpointDao) Create(src *m.Endpoint) error {
-	return nil
-}
-
-func (a *MockEndpointDao) Update(endpoint *m.Endpoint) error {
-	if endpoint.ID == fixtures.TestEndpointData[0].ID {
-		return nil
-	}
-
-	return util.NewErrNotFound("endpoint")
-}
-
-func (endpointDao *MockEndpointDao) Delete(id *int64) (*m.Endpoint, error) {
-	for i, e := range endpointDao.Endpoints {
-		if e.ID == *id {
-			endpointDao.Endpoints = append(endpointDao.Endpoints[:i], endpointDao.Endpoints[i+1:]...)
-
-			return &e, nil
-		}
-	}
-	return nil, util.NewErrNotFound("endpoint")
-}
-
-func (m *MockEndpointDao) Tenant() *int64 {
-	tenant := int64(1)
-	return &tenant
-}
-
-func (m *MockEndpointDao) CanEndpointBeSetAsDefaultForSource(sourceId int64) bool {
-	return true
-}
-
-func (m *MockEndpointDao) IsRoleUniqueForSource(role string, sourceId int64) bool {
-	return true
-}
-
-func (m *MockEndpointDao) SourceHasEndpoints(sourceId int64) bool {
-	return true
-}
-
-func (m *MockEndpointDao) Exists(endpointId int64) (bool, error) {
-	return true, nil
-}
-
-func (m *MockEndpointDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
-	return nil, nil
-}
-
-func (m *MockEndpointDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) (interface{}, error) {
-	return nil, nil
-}
-
-func (m *MockEndpointDao) ToEventJSON(_ util.Resource) ([]byte, error) {
-	return nil, nil
 }
 
 func (m *MockRhcConnectionDao) List(limit, offset int, filters []util.Filter) ([]m.RhcConnection, int64, error) {

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -3,14 +3,16 @@ package mocks
 import (
 	"errors"
 	"fmt"
-	"github.com/RedHatInsights/sources-api-go/dao"
 	"strings"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
+
+var conf = config.Get()
 
 type MockSourceDao struct {
 	Sources        []m.Source
@@ -761,7 +763,7 @@ func (m MockAuthenticationDao) GetById(id string) (*m.Authentication, error) {
 	for _, auth := range m.Authentications {
 		// If secret store is database, we compare given ID with different field
 		// than if secret store is vault
-		if dao.conf.SecretStore == "database" {
+		if conf.SecretStore == "database" {
 			if fmt.Sprintf("%d", auth.DbID) == id {
 				return &auth, nil
 			}
@@ -891,7 +893,7 @@ func (m MockAuthenticationDao) Delete(id string) (*m.Authentication, error) {
 	for _, auth := range m.Authentications {
 		// If secret store is database, we compare given ID with different field
 		// than if secret store is vault
-		if dao.conf.SecretStore == "database" {
+		if conf.SecretStore == "database" {
 			if fmt.Sprintf("%d", auth.DbID) == id {
 				return &auth, nil
 			}

--- a/internal/testutils/mocks/mock_daos.go
+++ b/internal/testutils/mocks/mock_daos.go
@@ -3,8 +3,6 @@ package mocks
 import (
 	"errors"
 	"fmt"
-	"strings"
-
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"
@@ -12,10 +10,6 @@ import (
 )
 
 var conf = config.Get()
-
-type MockApplicationDao struct {
-	Applications []m.Application
-}
 
 type MockEndpointDao struct {
 	Endpoints []m.Endpoint
@@ -183,6 +177,7 @@ func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSource(_, _ int64)
 func (at *MockApplicationTypeDao) GetSuperKeyResultType(applicationTypeId int64, authType string) (string, error) {
 	panic("not needed")
 }
+
 func (a *MockApplicationTypeDao) ApplicationTypeCompatibleWithSourceType(_, _ int64) error {
 	if a.Compatible {
 		return nil
@@ -224,141 +219,6 @@ func (a *MockSourceTypeDao) Update(src *m.SourceType) error {
 
 func (a *MockSourceTypeDao) Delete(id *int64) error {
 	panic("not implemented") // TODO: Implement
-}
-
-func (a *MockApplicationDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Application, int64, error) {
-	var applications []m.Application
-
-	switch object := primaryCollection.(type) {
-	case m.Source:
-		var sourceExists bool
-
-		for _, s := range fixtures.TestSourceData {
-			if s.ID == object.ID {
-				sourceExists = true
-			}
-		}
-		// if source doesn't exist, return Not Found Err
-		if !sourceExists {
-			return nil, 0, util.NewErrNotFound("source")
-		}
-
-		// else return list of related applications
-		for _, app := range a.Applications {
-			if object.ID == app.SourceID {
-				applications = append(applications, app)
-			}
-		}
-	}
-
-	return applications, int64(len(applications)), nil
-}
-
-func (a *MockApplicationDao) List(limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
-	count := int64(len(a.Applications))
-	return a.Applications, count, nil
-}
-
-func (a *MockApplicationDao) GetById(id *int64) (*m.Application, error) {
-	for _, app := range a.Applications {
-		if app.ID == *id {
-			return &app, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("application")
-}
-
-func (a *MockApplicationDao) GetByIdWithPreload(id *int64, preloads ...string) (*m.Application, error) {
-	for _, app := range a.Applications {
-		if app.ID == *id {
-			for _, preload := range preloads {
-				if strings.Contains(strings.ToLower(preload), "source") {
-					app.Source = fixtures.TestSourceData[0]
-				}
-			}
-
-			return &app, nil
-		}
-	}
-
-	return nil, util.NewErrNotFound("application")
-}
-
-func (a *MockApplicationDao) Create(src *m.Application) error {
-	return nil
-}
-
-func (a *MockApplicationDao) Update(src *m.Application) error {
-	return nil
-}
-
-func (a *MockApplicationDao) Delete(id *int64) (*m.Application, error) {
-	for _, app := range a.Applications {
-		if app.ID == *id {
-			return &app, nil
-		}
-	}
-	return nil, util.NewErrNotFound("application")
-}
-
-func (a *MockApplicationDao) Tenant() *int64 {
-	tenant := int64(1)
-	return &tenant
-}
-
-func (a *MockApplicationDao) User() *int64 {
-	user := int64(1)
-	return &user
-}
-
-func (a *MockApplicationDao) DeleteCascade(applicationId int64) ([]m.ApplicationAuthentication, *m.Application, error) {
-	var application *m.Application
-	for _, app := range fixtures.TestApplicationData {
-		if app.ID == applicationId {
-			application = &app
-		}
-	}
-
-	if application == nil {
-		return nil, nil, util.NewErrNotFound("application")
-	}
-
-	return fixtures.TestApplicationAuthenticationData, application, nil
-}
-
-func (a *MockApplicationDao) Exists(applicationId int64) (bool, error) {
-	for _, application := range a.Applications {
-		if application.ID == applicationId {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func (m *MockApplicationDao) BulkMessage(_ util.Resource) (map[string]interface{}, error) {
-	return nil, nil
-}
-
-func (m *MockApplicationDao) FetchAndUpdateBy(_ util.Resource, _ map[string]interface{}) (interface{}, error) {
-	return nil, nil
-}
-
-func (m *MockApplicationDao) ToEventJSON(_ util.Resource) ([]byte, error) {
-	return nil, nil
-}
-
-func (a *MockApplicationDao) Pause(_ int64) error {
-	return nil
-}
-
-func (a *MockApplicationDao) Unpause(_ int64) error {
-	return nil
-}
-
-func (src *MockApplicationDao) IsSuperkey(id int64) bool {
-	return false
 }
 
 func (a *MockEndpointDao) SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -60,15 +60,15 @@ func TestMain(t *testing.M) {
 			panic("failed to populate static type cache")
 		}
 	} else {
-		mockSourceDao = &dao.MockSourceDao{Sources: fixtures.TestSourceData, RelatedSources: fixtures.TestSourceData}
-		mockApplicationDao = &dao.MockApplicationDao{Applications: fixtures.TestApplicationData}
-		mockEndpointDao = &dao.MockEndpointDao{Endpoints: fixtures.TestEndpointData}
-		mockSourceTypeDao = &dao.MockSourceTypeDao{SourceTypes: fixtures.TestSourceTypeData}
-		mockApplicationTypeDao = &dao.MockApplicationTypeDao{ApplicationTypes: fixtures.TestApplicationTypeData}
-		mockMetaDataDao = &dao.MockMetaDataDao{MetaDatas: fixtures.TestMetaDataData}
-		mockRhcConnectionDao = &dao.MockRhcConnectionDao{RhcConnections: fixtures.TestRhcConnectionData, RelatedRhcConnections: fixtures.TestRhcConnectionData}
-		mockApplicationAuthenticationDao = &dao.MockApplicationAuthenticationDao{ApplicationAuthentications: fixtures.TestApplicationAuthenticationData}
-		mockAuthenticationDao = &dao.MockAuthenticationDao{Authentications: fixtures.TestAuthenticationData}
+		mockSourceDao = &mocks.MockSourceDao{Sources: fixtures.TestSourceData, RelatedSources: fixtures.TestSourceData}
+		mockApplicationDao = &mocks.MockApplicationDao{Applications: fixtures.TestApplicationData}
+		mockEndpointDao = &mocks.MockEndpointDao{Endpoints: fixtures.TestEndpointData}
+		mockSourceTypeDao = &mocks.MockSourceTypeDao{SourceTypes: fixtures.TestSourceTypeData}
+		mockApplicationTypeDao = &mocks.MockApplicationTypeDao{ApplicationTypes: fixtures.TestApplicationTypeData}
+		mockMetaDataDao = &mocks.MockMetaDataDao{MetaDatas: fixtures.TestMetaDataData}
+		mockRhcConnectionDao = &mocks.MockRhcConnectionDao{RhcConnections: fixtures.TestRhcConnectionData, RelatedRhcConnections: fixtures.TestRhcConnectionData}
+		mockApplicationAuthenticationDao = &mocks.MockApplicationAuthenticationDao{ApplicationAuthentications: fixtures.TestApplicationAuthenticationData}
+		mockAuthenticationDao = &mocks.MockAuthenticationDao{Authentications: fixtures.TestAuthenticationData}
 
 		getSourceDao = func(c echo.Context) (dao.SourceDao, error) { return mockSourceDao, nil }
 		getApplicationDao = func(c echo.Context) (dao.ApplicationDao, error) { return mockApplicationDao, nil }

--- a/service/application_validation_test.go
+++ b/service/application_validation_test.go
@@ -4,15 +4,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/mocks"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 func TestValidApplicationRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		Extra:                []byte(`{"a good":"thing"`),
@@ -40,7 +40,7 @@ func TestValidApplicationRequest(t *testing.T) {
 
 func TestInvalidApplicationTypeForSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	AppTypeDao = &dao.MockApplicationTypeDao{Compatible: false}
+	AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: false}
 
 	req := m.ApplicationCreateRequest{
 		Extra:                []byte(`{"a good":"thing"`),
@@ -59,7 +59,7 @@ func TestInvalidApplicationTypeForSource(t *testing.T) {
 }
 
 func TestMissingApplicationTypeId(t *testing.T) {
-	AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		Extra:       []byte(`{"a good":"thing"`),
@@ -73,7 +73,7 @@ func TestMissingApplicationTypeId(t *testing.T) {
 }
 
 func TestMissingSourceId(t *testing.T) {
-	AppTypeDao = &dao.MockApplicationTypeDao{Compatible: true}
+	AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
 		Extra:                []byte(`{"a good":"thing"`),

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/mocks"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
 	"github.com/RedHatInsights/sources-api-go/logger"
 )
@@ -40,8 +41,8 @@ func TestMain(t *testing.M) {
 			panic("failed to populate static type cache")
 		}
 	} else {
-		endpointDao = &dao.MockEndpointDao{Endpoints: fixtures.TestEndpointData}
-		sourceDao = &dao.MockSourceDao{Sources: fixtures.TestSourceData}
+		endpointDao = &mocks.MockEndpointDao{Endpoints: fixtures.TestEndpointData}
+		sourceDao = &mocks.MockSourceDao{Sources: fixtures.TestSourceData}
 
 		err := dao.PopulateMockStaticTypeCache()
 		if err != nil {

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -2633,7 +2633,7 @@ func TestSourceEditPausedUnit(t *testing.T) {
 	// Get the specific SourceDao mock which simulates that the sources are paused.
 	backupDao := getSourceDao
 	getSourceDao = func(c echo.Context) (dao.SourceDao, error) {
-		return &dao.MockSourceDao{Sources: fixtures.TestSourceData}, nil
+		return &mocks.MockSourceDao{Sources: fixtures.TestSourceData}, nil
 	}
 
 	// Set the fixture source as "paused".


### PR DESCRIPTION
Move mock daos into separate package and split it by handler

- [x] Move mock_daos.go into internal/testutils/mocks
- [x] Move mock for type cache into separate file (dao/mock_type_cache)
- [x] Split mock_daos.go by handler

In this PR I split the file mock_daos.go by handler and nothing else. I plan to do some small refactor of these new files (e.g. unify receiver names) in next PR. 

**JIRA:** )[RHCLOUD-20415](https://issues.redhat.com/browse/RHCLOUD-20415)