### PR TITLE
[RHCLOUD-20914] Add POST /secrets (create action)

### DIFF
--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -139,6 +139,13 @@ type MetaDataDao interface {
 	ApplicationOptedIntoRetry(applicationTypeId int64) (bool, error)
 }
 
+type SecretDao interface {
+	Create(src *m.Authentication) error
+	Delete(id *int64) error
+	GetById(id *int64) (*m.Authentication, error)
+	NameExistsInCurrentTenant(name string) bool
+}
+
 type SourceTypeDao interface {
 	List(limit, offset int, filters []util.Filter) ([]m.SourceType, int64, error)
 	GetById(id *int64) (*m.SourceType, error)

--- a/dao/secret_dao.go
+++ b/dao/secret_dao.go
@@ -9,7 +9,7 @@ import (
 	"gorm.io/gorm"
 )
 
-const SecretResourceType = "Tenant"
+const secretResourceType = "Tenant"
 
 var GetSecretDao func(daoParams *RequestParams) SecretDao
 
@@ -47,7 +47,7 @@ func (secret *secretDaoDbImpl) getDb() *gorm.DB {
 	query := DB.Debug().WithContext(secret.ctx)
 	query = query.Where("tenant_id = ?", secret.TenantID)
 
-	query = query.Where("resource_type = ?", SecretResourceType)
+	query = query.Where("resource_type = ?", secretResourceType)
 
 	return query
 }

--- a/dao/secret_dao.go
+++ b/dao/secret_dao.go
@@ -60,7 +60,7 @@ func (secret *secretDaoDbImpl) GetById(id *int64) (*m.Authentication, error) {
 	var secretAuthentication m.Authentication
 
 	err := secret.getDbWithModel().
-		Where("id = ? AND resource_type = ?", id, SecretResourceType).
+		Where("id = ?", id).
 		First(&secretAuthentication).
 		Error
 

--- a/dao/secret_dao.go
+++ b/dao/secret_dao.go
@@ -73,6 +73,8 @@ func (secret *secretDaoDbImpl) GetById(id *int64) (*m.Authentication, error) {
 
 func (secret *secretDaoDbImpl) Create(authentication *m.Authentication) error {
 	authentication.TenantID = *secret.TenantID // the TenantID gets injected in the middleware
+	authentication.ResourceType = secretResourceType
+	authentication.ResourceID = *secret.TenantID
 	if authentication.Password != nil {
 		encryptedValue, err := util.Encrypt(*authentication.Password)
 		if err != nil {

--- a/dao/secret_dao.go
+++ b/dao/secret_dao.go
@@ -1,0 +1,121 @@
+package dao
+
+import (
+	"context"
+	"fmt"
+
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+	"gorm.io/gorm"
+)
+
+const SecretResourceType = "Tenant"
+
+var GetSecretDao func(daoParams *RequestParams) SecretDao
+
+type secretDaoDbImpl struct {
+	TenantID *int64
+	UserID   *int64
+	ctx      context.Context
+}
+
+func getDefaultSecretDao(daoParams *RequestParams) SecretDao {
+	var tenantID, userID *int64
+	var ctx context.Context
+	if daoParams != nil && daoParams.TenantID != nil {
+		tenantID = daoParams.TenantID
+		userID = daoParams.UserID
+		ctx = daoParams.ctx
+	}
+
+	return &secretDaoDbImpl{
+		TenantID: tenantID,
+		UserID:   userID,
+		ctx:      ctx,
+	}
+}
+
+func init() {
+	GetSecretDao = getDefaultSecretDao
+}
+
+func (secret *secretDaoDbImpl) getDb() *gorm.DB {
+	if secret.TenantID == nil {
+		panic("nil tenant found in sourceDaoImpl DAO")
+	}
+
+	query := DB.Debug().WithContext(secret.ctx)
+	query = query.Where("tenant_id = ?", secret.TenantID)
+
+	query = query.Where("resource_type = ?", SecretResourceType)
+
+	return query
+}
+
+func (secret *secretDaoDbImpl) getDbWithModel() *gorm.DB {
+	return secret.getDb().Model(&m.Authentication{})
+}
+
+func (secret *secretDaoDbImpl) GetById(id *int64) (*m.Authentication, error) {
+	var secretAuthentication m.Authentication
+
+	err := secret.getDbWithModel().
+		Where("id = ? AND resource_type = ?", id, SecretResourceType).
+		First(&secretAuthentication).
+		Error
+
+	if err != nil {
+		return nil, util.NewErrNotFound("secret")
+	}
+
+	return &secretAuthentication, nil
+}
+
+func (secret *secretDaoDbImpl) Create(authentication *m.Authentication) error {
+	authentication.TenantID = *secret.TenantID // the TenantID gets injected in the middleware
+	if authentication.Password != nil {
+		encryptedValue, err := util.Encrypt(*authentication.Password)
+		if err != nil {
+			return err
+		}
+
+		authentication.Password = &encryptedValue
+	}
+
+	return DB.
+		Debug().
+		Create(authentication).
+		Error
+}
+
+func (secret *secretDaoDbImpl) Delete(id *int64) error {
+	var authentication m.Authentication
+
+	err := secret.getDb().
+		Where("id = ?", id).
+		First(&authentication).
+		Error
+
+	if err != nil {
+		return util.NewErrNotFound("secret")
+	}
+
+	err = secret.getDb().
+		Delete(&authentication).
+		Error
+
+	if err != nil {
+		return fmt.Errorf(`failed to delete secret with id "%d"`, &id)
+	}
+
+	return nil
+}
+
+func (secret *secretDaoDbImpl) NameExistsInCurrentTenant(name string) bool {
+	err := secret.getDbWithModel().
+		Where("name = ?", name).
+		First(&m.Authentication{}).
+		Error
+
+	return err == nil
+}

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -70,7 +70,8 @@ func AssertLinks(t *testing.T, path string, links util.Links, limit int, offset 
 
 func IdentityHeaderForUser(testUserId string) *identity.XRHID {
 	accountNumber := fixtures.TestTenantData[0].ExternalTenant
-	return &identity.XRHID{Identity: identity.Identity{AccountNumber: accountNumber, User: identity.User{UserID: testUserId}}}
+	orgID := fixtures.TestTenantData[0].OrgID
+	return &identity.XRHID{Identity: identity.Identity{OrgID: orgID, AccountNumber: accountNumber, User: identity.User{UserID: testUserId}}}
 }
 
 func SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType string) *model.BulkCreateRequest {

--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func runServer(shutdown chan struct{}) {
 	getAuthenticationDao = getAuthenticationDaoWithTenant
 	getApplicationAuthenticationDao = getApplicationAuthenticationDaoWithTenant
 	getApplicationTypeDao = getApplicationTypeDaoWithTenant
+	getSecretDao = getSecretDaoWithTenant
 	getSourceTypeDao = getSourceTypeDaoWithoutTenant
 	getEndpointDao = getEndpointDaoWithTenant
 	getMetaDataDao = getMetaDataDaoWithoutTenant

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,7 @@ func TestMain(t *testing.M) {
 	} else if flags.Integration {
 		database.ConnectAndMigrateDB("public")
 
+		getSecretDao = getSecretDaoWithTenant
 		getSourceDao = getSourceDaoWithTenant
 		getApplicationDao = getApplicationDaoWithTenant
 		getEndpointDao = getEndpointDaoWithTenant

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -73,7 +73,7 @@ func (auth *Authentication) ToResponse() *AuthenticationResponse {
 	}
 }
 
-func (auth *Authentication) SecretToResponse() *SecretResponse {
+func (auth *Authentication) ToSecretResponse() *SecretResponse {
 	id, extra := unmarshalExtraFields(auth)
 	return &SecretResponse{
 		ID:       id,

--- a/model/authentication.go
+++ b/model/authentication.go
@@ -73,6 +73,17 @@ func (auth *Authentication) ToResponse() *AuthenticationResponse {
 	}
 }
 
+func (auth *Authentication) SecretToResponse() *SecretResponse {
+	id, extra := unmarshalExtraFields(auth)
+	return &SecretResponse{
+		ID:       id,
+		Name:     util.ValueOrBlank(auth.Name),
+		AuthType: auth.AuthType,
+		Username: util.ValueOrBlank(auth.Username),
+		Extra:    extra,
+	}
+}
+
 func (auth *Authentication) ToInternalResponse() *AuthenticationInternalResponse {
 	id, extra := mapIdExtraFields(auth)
 	resourceID := strconv.FormatInt(auth.ResourceID, 10)
@@ -202,13 +213,21 @@ func mapIdExtraFields(auth *Authentication) (string, map[string]interface{}) {
 		id = auth.ID
 		extra = auth.Extra
 	} else {
-		id = strconv.FormatInt(auth.DbID, 10)
+		return unmarshalExtraFields(auth)
+	}
 
-		if auth.ExtraDb != nil {
-			err := json.Unmarshal(auth.ExtraDb, &extra)
-			if err != nil {
-				logger.Log.Errorf(`could not unmarshal "extra" field from authentication with ID "%s"`, id)
-			}
+	return id, extra
+}
+
+func unmarshalExtraFields(auth *Authentication) (string, map[string]interface{}) {
+	var id string
+	var extra map[string]interface{}
+	id = strconv.FormatInt(auth.DbID, 10)
+
+	if auth.ExtraDb != nil {
+		err := json.Unmarshal(auth.ExtraDb, &extra)
+		if err != nil {
+			logger.Log.Errorf(`could not unmarshal "extra" field from authentication with ID "%s"`, id)
 		}
 	}
 

--- a/model/secret_http.go
+++ b/model/secret_http.go
@@ -1,0 +1,10 @@
+package model
+
+type SecretResponse struct {
+	ID string `json:"id"`
+
+	Name     string                 `json:"name,omitempty"`
+	AuthType string                 `json:"authtype"`
+	Username string                 `json:"username"`
+	Extra    map[string]interface{} `json:"extra,omitempty"`
+}

--- a/model/secret_http.go
+++ b/model/secret_http.go
@@ -8,3 +8,12 @@ type SecretResponse struct {
 	Username string                 `json:"username"`
 	Extra    map[string]interface{} `json:"extra,omitempty"`
 }
+
+type SecretCreateRequest struct {
+	Name       *string                `json:"name,omitempty"`
+	AuthType   string                 `json:"authtype"`
+	Username   *string                `json:"username"`
+	Password   *string                `json:"password,omitempty"`
+	Extra      map[string]interface{} `json:"extra,omitempty"`
+	UserScoped bool                   `json:"user_scoped"`
+}

--- a/routes.go
+++ b/routes.go
@@ -15,8 +15,9 @@ var listMiddleware = []echo.MiddlewareFunc{middleware.SortAndFilter, middleware.
 var tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.LoggerFields, middleware.UserCatcher}
 
 var tenancyWithListMiddleware = append(tenancyMiddleware, listMiddleware...)
-var permissionMiddleware = append(tenancyMiddleware, []echo.MiddlewareFunc{middleware.PermissionCheck, middleware.RaiseEvent}...)
+var permissionMiddleware = append(permissionMiddlewareWithoutEvents, middleware.RaiseEvent)
 var permissionWithListMiddleware = append(listMiddleware, middleware.PermissionCheck)
+var permissionMiddlewareWithoutEvents = append(tenancyMiddleware, middleware.PermissionCheck)
 
 func setupRoutes(e *echo.Echo) {
 	e.GET("/health", func(c echo.Context) error {
@@ -107,6 +108,9 @@ func setupRoutes(e *echo.Echo) {
 		r.GET("/app_meta_data", MetaDataList, append(listMiddleware, middleware.LoggerFields)...)
 		r.GET("/app_meta_data/:id", MetaDataGet, middleware.LoggerFields)
 		r.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, append(listMiddleware, middleware.LoggerFields)...)
+
+		// Secrets
+		r.POST("/secrets", SecretCreate, permissionMiddlewareWithoutEvents...)
 
 		// SourceTypes
 		r.GET("/source_types", SourceTypeList, append(listMiddleware, middleware.LoggerFields)...)

--- a/secret_handlers.go
+++ b/secret_handlers.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/service"
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
+	"gorm.io/datatypes"
+)
+
+var getSecretDao func(c echo.Context) (dao.SecretDao, error)
+
+func getSecretDaoWithTenant(c echo.Context) (dao.SecretDao, error) {
+	requestParams, err := dao.NewRequestParamsFromContext(c)
+	if err != nil {
+		return nil, err
+	}
+
+	return dao.GetSecretDao(requestParams), nil
+}
+
+func SecretCreate(c echo.Context) error {
+	secretDao, err := getSecretDao(c)
+	if err != nil {
+		return err
+	}
+
+	createRequest := m.AuthenticationCreateRequest{}
+	err = c.Bind(&createRequest)
+	if err != nil {
+		return err
+	}
+
+	requestParams, err := dao.NewRequestParamsFromContext(c)
+	if err != nil {
+		return util.NewErrBadRequest(err)
+	}
+
+	err = service.ValidateSecretCreationRequest(requestParams, createRequest)
+	if err != nil {
+		return util.NewErrBadRequest(err)
+	}
+
+	var extraDb datatypes.JSON
+
+	extraDb, err = json.Marshal(createRequest.Extra)
+
+	if err != nil {
+		return util.NewErrBadRequest(`invalid JSON given in "extra" field`)
+	}
+
+	secret := &m.Authentication{
+		Name:         createRequest.Name,
+		AuthType:     createRequest.AuthType,
+		Username:     createRequest.Username,
+		Password:     createRequest.Password,
+		ExtraDb:      extraDb,
+		ResourceType: dao.SecretResourceType,
+		ResourceID:   *requestParams.TenantID,
+	}
+	err = secretDao.Create(secret)
+	if err != nil {
+		return util.NewErrBadRequest(err)
+	}
+
+	return c.JSON(http.StatusCreated, secret.SecretToResponse())
+}

--- a/secret_handlers.go
+++ b/secret_handlers.go
@@ -29,16 +29,11 @@ func SecretCreate(c echo.Context) error {
 		return err
 	}
 
-	createInputRequest := struct {
-		m.AuthenticationCreateRequest
-		UserOwnership bool `json:"user_ownership"`
-	}{}
-
-	err = c.Bind(&createInputRequest)
+	createRequest := m.SecretCreateRequest{}
+	err = c.Bind(&createRequest)
 	if err != nil {
 		return err
 	}
-	createRequest := createInputRequest.AuthenticationCreateRequest
 
 	requestParams, err := dao.NewRequestParamsFromContext(c)
 	if err != nil {
@@ -66,7 +61,7 @@ func SecretCreate(c echo.Context) error {
 		ExtraDb:  extraDb,
 	}
 
-	if createInputRequest.UserOwnership && requestParams.UserID != nil {
+	if createRequest.UserScoped && requestParams.UserID != nil {
 		secret.UserID = requestParams.UserID
 	}
 

--- a/secret_handlers.go
+++ b/secret_handlers.go
@@ -59,13 +59,11 @@ func SecretCreate(c echo.Context) error {
 	}
 
 	secret := &m.Authentication{
-		Name:         createRequest.Name,
-		AuthType:     createRequest.AuthType,
-		Username:     createRequest.Username,
-		Password:     createRequest.Password,
-		ExtraDb:      extraDb,
-		ResourceType: dao.SecretResourceType,
-		ResourceID:   *requestParams.TenantID,
+		Name:     createRequest.Name,
+		AuthType: createRequest.AuthType,
+		Username: createRequest.Username,
+		Password: createRequest.Password,
+		ExtraDb:  extraDb,
 	}
 
 	if createInputRequest.UserOwnership && requestParams.UserID != nil {

--- a/secret_handlers.go
+++ b/secret_handlers.go
@@ -77,5 +77,5 @@ func SecretCreate(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
-	return c.JSON(http.StatusCreated, secret.SecretToResponse())
+	return c.JSON(http.StatusCreated, secret.ToSecretResponse())
 }

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+const secretResourceType = "Tenant"
+
 func TestSecretCreateNameExistInCurrentTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
@@ -107,7 +109,7 @@ func TestSecretCreate(t *testing.T) {
 		stringMatcher(t, "secret name", *secretOut.Name, name)
 		stringMatcher(t, "secret user name", *secretOut.Username, userName)
 		stringMatcher(t, "secret auth type", secretOut.AuthType, authType)
-		stringMatcher(t, "secret name", secretOut.ResourceType, dao.SecretResourceType)
+		stringMatcher(t, "secret name", secretOut.ResourceType, secretResourceType)
 
 		if userOwnership && secretOut.UserID == nil || !userOwnership && secretOut.UserID != nil {
 			t.Error("user id has to be nil as user ownership was not requested for secret")

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+	"github.com/labstack/echo/v4"
+)
+
+func TestSecretCreateNameExistInCurrentTenant(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	tenantId := int64(1)
+	// Set the encryption key
+	util.OverrideEncryptionKey(strings.Repeat("test", 8))
+
+	name := "test-name"
+	authType := "auth-type"
+	userName := "test-name"
+	password := "123456"
+	secretExtra := map[string]interface{}{"extra": map[string]interface{}{"extra": "params"}}
+
+	secretCreateRequest := secretFromParams(name, authType, userName, password, secretExtra)
+	_, rec, err := createSecretRequest(t, secretCreateRequest, &tenantId)
+	if err != nil {
+		t.Error(err)
+	}
+
+	secret := parseSecretResponse(t, rec)
+
+	_, _, err = createSecretRequest(t, secretCreateRequest, &tenantId)
+
+	if err.Error() != "bad request: secret name "+name+" exists in current tenant" {
+		t.Error(err)
+	}
+
+	cleanSecretByID(t, secret.ID, &tenantId)
+}
+
+func TestSecretCreateEmptyName(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	tenantId := int64(1)
+	// Set the encryption key
+	util.OverrideEncryptionKey(strings.Repeat("test", 8))
+
+	name := ""
+	authType := "auth-type"
+	userName := "test-name"
+	password := "123456"
+	secretExtra := map[string]interface{}{"extra": map[string]interface{}{"extra": "params"}}
+
+	secretCreateRequest := secretFromParams(name, authType, userName, password, secretExtra)
+
+	_, _, err := createSecretRequest(t, secretCreateRequest, &tenantId)
+
+	if err.Error() != "bad request: secret name have to be populated" {
+		t.Error(err)
+	}
+}
+
+func TestSecretCreate(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	tenantId := int64(1)
+	// Set the encryption key
+	util.OverrideEncryptionKey(strings.Repeat("test", 8))
+
+	name := "TestName"
+	authType := "auth-type"
+	userName := "test-name"
+	password := "123456"
+	secretExtra := map[string]interface{}{"extra": map[string]interface{}{"extra": "params"}}
+
+	secretCreateRequest := secretFromParams(name, authType, userName, password, secretExtra)
+
+	_, rec, err := createSecretRequest(t, secretCreateRequest, &tenantId)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != http.StatusCreated {
+		t.Errorf("Did not return 201. Body: %s", rec.Body.String())
+	}
+
+	secret := parseSecretResponse(t, rec)
+
+	stringMatcher(t, "secret name", secret.Name, name)
+	stringMatcher(t, "secret user name", secret.Username, userName)
+	stringMatcher(t, "secret auth type", secret.AuthType, authType)
+
+	secretOut := fetchSecretFromDB(t, secret.ID, tenantId)
+
+	int64Matcher(t, "secret tenant id", secretOut.TenantID, tenantId)
+	stringMatcher(t, "secret name", *secretOut.Name, name)
+	stringMatcher(t, "secret user name", *secretOut.Username, userName)
+	stringMatcher(t, "secret auth type", secretOut.AuthType, authType)
+	stringMatcher(t, "secret name", secretOut.ResourceType, dao.SecretResourceType)
+
+	encryptedPassword, err := util.Encrypt(password)
+	if err != nil {
+		t.Error(err)
+	}
+
+	stringMatcher(t, "secret password", *secretOut.Password, encryptedPassword)
+
+	cleanSecretByID(t, secret.ID, &tenantId)
+}
+
+func stringMatcher(t *testing.T, nameResource, firstValue string, secondValue string) {
+	if firstValue != secondValue {
+		t.Errorf("Wrong %v, wanted %v got %v", nameResource, firstValue, secondValue)
+	}
+}
+
+func int64Matcher(t *testing.T, nameResource string, firstValue int64, secondValue int64) {
+	if firstValue != secondValue {
+		t.Errorf("Wrong %v, wanted %v got %v", nameResource, firstValue, secondValue)
+	}
+}
+
+func parseSecretResponse(t *testing.T, rec *httptest.ResponseRecorder) *m.AuthenticationResponse {
+	secret := &m.AuthenticationResponse{}
+	raw, _ := io.ReadAll(rec.Body)
+	err := json.Unmarshal(raw, &secret)
+	if err != nil {
+		t.Errorf("Failed to unmarshal application from response: %v", err)
+	}
+
+	return secret
+}
+
+func fetchSecretFromDB(t *testing.T, secretIDValue string, secretTenantID int64) *m.Authentication {
+	requestParams := dao.RequestParams{TenantID: &secretTenantID}
+	secretDao := dao.GetSecretDao(&requestParams)
+	secretID, err := util.InterfaceToInt64(secretIDValue)
+	if err != nil {
+		t.Error(err)
+	}
+
+	secret, err := secretDao.GetById(&secretID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	return secret
+}
+
+func secretFromParams(secretName, secretAuthType, secretUserName, secretPassword string, secretExtra map[string]interface{}) *m.AuthenticationCreateRequest {
+	return &m.AuthenticationCreateRequest{
+		Name:     util.StringRef(secretName),
+		AuthType: secretAuthType,
+		Username: util.StringRef(secretUserName),
+		Password: util.StringRef(secretPassword),
+		Extra:    secretExtra,
+	}
+}
+
+func createSecretRequest(t *testing.T, requestBody *m.AuthenticationCreateRequest, tenantIDValue *int64) (echo.Context, *httptest.ResponseRecorder, error) {
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/secrets",
+		bytes.NewReader(body),
+		map[string]interface{}{
+			"tenantID": *tenantIDValue,
+		},
+	)
+	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
+	err = SecretCreate(c)
+
+	return c, rec, err
+}
+
+func cleanSecretByID(t *testing.T, secretIDValue string, tenantId *int64) {
+	secretID, err := util.InterfaceToInt64(secretIDValue)
+	if err != nil {
+		t.Error(err)
+	}
+	requestParams := dao.RequestParams{TenantID: tenantId}
+	secretDao := dao.GetSecretDao(&requestParams)
+	err = secretDao.Delete(&secretID)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/service/secret_validation.go
+++ b/service/secret_validation.go
@@ -7,7 +7,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/model"
 )
 
-func ValidateSecretCreationRequest(requestParams *dao.RequestParams, auth model.AuthenticationCreateRequest) error {
+func ValidateSecretCreationRequest(requestParams *dao.RequestParams, auth model.SecretCreateRequest) error {
 	if auth.Name != nil {
 		if *auth.Name == "" {
 			return fmt.Errorf("secret name have to be populated")
@@ -17,14 +17,5 @@ func ValidateSecretCreationRequest(requestParams *dao.RequestParams, auth model.
 			return fmt.Errorf("secret name %s exists in current tenant", *auth.Name)
 		}
 	}
-
-	if auth.ResourceIDRaw != nil {
-		return fmt.Errorf("resource_id is not applicable to create secret")
-	}
-
-	if auth.ResourceType != "" && auth.ResourceType != dao.SecretResourceType {
-		return fmt.Errorf("invalid resource_type - must be Tenant(default) or empty")
-	}
-
 	return nil
 }

--- a/service/secret_validation.go
+++ b/service/secret_validation.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/model"
+)
+
+func ValidateSecretCreationRequest(requestParams *dao.RequestParams, auth model.AuthenticationCreateRequest) error {
+	if auth.Name != nil {
+		if *auth.Name == "" {
+			return fmt.Errorf("secret name have to be populated")
+		}
+
+		if dao.GetSecretDao(requestParams).NameExistsInCurrentTenant(*auth.Name) {
+			return fmt.Errorf("secret name %s exists in current tenant", *auth.Name)
+		}
+	}
+
+	if auth.ResourceIDRaw != nil {
+		return fmt.Errorf("resource_id is not applicable to create secret")
+	}
+
+	if auth.ResourceType != "" && !strings.EqualFold(auth.ResourceType, dao.SecretResourceType) {
+		return fmt.Errorf("invalid resource_type - must be Tenant(default) or empty")
+	}
+
+	return nil
+}

--- a/service/secret_validation.go
+++ b/service/secret_validation.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/model"
@@ -23,7 +22,7 @@ func ValidateSecretCreationRequest(requestParams *dao.RequestParams, auth model.
 		return fmt.Errorf("resource_id is not applicable to create secret")
 	}
 
-	if auth.ResourceType != "" && !strings.EqualFold(auth.ResourceType, dao.SecretResourceType) {
+	if auth.ResourceType != "" && auth.ResourceType != dao.SecretResourceType {
 		return fmt.Errorf("invalid resource_type - must be Tenant(default) or empty")
 	}
 


### PR DESCRIPTION
This creates secret which is authentication with resource_type="tenant" also
`resource_id` is populated as `tenant_id`. (we were discussing it - but I tend to have consistency data as possible - I don't want potentially break this polymorphic relation by skipping populating `resource_id`)

This doesn't use vault either not optionally.
SecretDao and secret handler created.
New model for secret was not created.

Also I added some other dao functions(DELETE, GetByID) - but in this PR it is only test usage - and they could be changed in other PRs of https://github.com/RedHatInsights/sources-api-go/issues/549.

New route added:

```
POST /api/sources/v3.1/secrets
{
  "extra": {
    "test": {
      "tenant_id": "string"
    }
  },
  "authtype" : "github-token",
  "name": "OpenShift default",
  "password": "NEWPASS",
  "username": "user@example.com"
}
```

Also added possibility to set user ownership: (it is possible with adding `  "user_ownership" : true`)

```
{
  "extra": {
    "azure": {
      "tenant_id": "string"
    }
  },
  "authtype" : "AAAA",
  "name": "OpenShift default",
  "password": "NEWPASS",
  "username": "user@example.com",
  "user_ownership" : true
}

```

### Links

part of https://issues.redhat.com/browse/RHCLOUD-20914
https://github.com/RedHatInsights/sources-api-go/issues/549

