### PR TITLE
[RHCLOUD-21039] Application create returns 500 instead of 400 for existing combination of app type id and source id

### DIFF
--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -928,3 +928,34 @@ func TestApplicationSubcollectionWithUserOwnership(t *testing.T) {
 
 	DropSchema(schema)
 }
+
+// TestApplicationCreateBadRequest tests that bad request is returned when you try to create
+// an application of same application type that already exists for the source and tenant
+func TestApplicationCreateBadRequest(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("create_bad_request")
+
+	// Existing application from fixtures
+	tenantId := testApplication.TenantID
+	appTypeId := testApplication.ApplicationTypeID
+	sourceId := testApplication.SourceID
+
+	// Create new app of same app type for same source id and tenant id
+	daoParams := RequestParams{TenantID: &tenantId}
+	applicationDao := GetApplicationDao(&daoParams)
+
+	application := m.Application{
+		Extra:             []byte(`{"create_app": "bad_request"}`),
+		SourceID:          sourceId,
+		TenantID:          tenantId,
+		ApplicationTypeID: appTypeId,
+	}
+
+	// Create the test application.
+	err := applicationDao.Create(&application)
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("wanted Bad Request err, got '%s'", err)
+	}
+
+	DropSchema("create_bad_request")
+}

--- a/dao/db.go
+++ b/dao/db.go
@@ -25,6 +25,12 @@ var (
 	conf = config.Get()
 )
 
+// PostgreSQL Error Codes
+const (
+	// PG_UNIQUE_CONSTRAINT_VIOLATION is PostgreSQL error code for unique index violation (more here: https://www.postgresql.org/docs/current/errcodes-appendix.html)
+	PG_UNIQUE_CONSTRAINT_VIOLATION = "23505"
+)
+
 func Init() {
 	l := &logging.GormLogger{
 		SkipErrorRecordNotFound: true,

--- a/go.mod
+++ b/go.mod
@@ -17,11 +17,13 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/vault/api v1.1.1
 	github.com/iancoleman/strcase v0.2.0
+	github.com/jackc/pgconn v1.11.0 // indirect
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/labstack/echo-contrib v0.12.0
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/labstack/gommon v0.3.1
+	github.com/lib/pq v1.10.2 // indirect
 	github.com/lindgrenj6/logrus_zinc v0.0.0-20220822152658-d8a0b604f3f9 // indirect
 	github.com/prometheus/client_golang v1.12.1
 	github.com/redhatinsights/app-common-go v1.6.3


### PR DESCRIPTION
When we create new application and in db already exists application of same app type + same source id and tenant id, the 500 is returned because of unique constraint in the applications table (unique combination for app type id + source id + tenant id) ... and we are returning in this case every error as 500

```
{
    "errors": [
        {
            "detail": "Internal Server Error: ERROR: duplicate key value violates unique constraint \"applications_app_type_id_source_id_tenant_id_idx\" (SQLSTATE 23505)",
            "status": "500"
        }
    ]
}
```

I think we want in this case return 400 Bad Request because invalid input data was provided

one option is to add new check into create application request validation function - this check should be probably some db query or we could reuse some existing app dao method ... but this increase number of db calls 

so my idea was to distinguish error returned after create application query and if specific error code and message is returned then we send descriptive message nad 400 err type

**JIRA:** [RHCLOUD-21039](https://issues.redhat.com/browse/RHCLOUD-21039)