### PR TITLE
Add GET list /secrets endpoint

### DIFF
--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -143,6 +143,7 @@ type SecretDao interface {
 	Create(src *m.Authentication) error
 	Delete(id *int64) error
 	GetById(id *int64) (*m.Authentication, error)
+	List(limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error)
 	NameExistsInCurrentTenant(name string) bool
 }
 

--- a/dao/secret_dao_test.go
+++ b/dao/secret_dao_test.go
@@ -1,0 +1,95 @@
+package dao
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+func TestSecretListUserOwnership(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	testutils.SkipIfNotSecretStoreDatabase(t)
+	schema := "user_ownership"
+	SwitchSchema(schema)
+
+	userIDWithOwnRecords := "user_based_user"
+	otherUserIDWithOwnRecords := "other_user"
+	userIDWithoutOwnRecords := "another_user"
+
+	userWithOwnRecords, err := CreateUserForUserID(userIDWithOwnRecords, tenantId)
+	if err != nil {
+		t.Error(err)
+	}
+
+	secret1, err := CreateSecretByName("Secret 1", &tenantId, &userWithOwnRecords.Id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	otherUserWithOwnRecords, err := CreateUserForUserID(otherUserIDWithOwnRecords, tenantId)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = CreateSecretByName("Secret 2", &tenantId, &otherUserWithOwnRecords.Id)
+	if err != nil {
+		t.Error(err)
+	}
+
+	secretWithoutOwnership, err := CreateSecretByName("Secret 3", &tenantId, nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	/*
+	  Test 1 - User can see own records and records without ownership
+	*/
+	requestParams := &RequestParams{TenantID: &userWithOwnRecords.TenantID, UserID: &userWithOwnRecords.Id}
+	secretDaoWithUser := GetSecretDao(requestParams)
+
+	secrets, _, err := secretDaoWithUser.List(100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`unexpected error when listing the application authentications: %s`, err)
+	}
+
+	var secretsIDs []int64
+	for _, secret := range secrets {
+		secretsIDs = append(secretsIDs, secret.DbID)
+	}
+
+	expectedSecretsIDs := []int64{secret1.DbID, secretWithoutOwnership.DbID}
+
+	if !util.ElementsInSlicesEqual(secretsIDs, expectedSecretsIDs) {
+		t.Errorf("Expected source IDs %v are not same with obtained IDs: %v", expectedSecretsIDs, secretsIDs)
+	}
+
+	userWithOwnRecords, err = CreateUserForUserID(userIDWithoutOwnRecords, tenantId)
+	if err != nil {
+		t.Error(err)
+	}
+
+	/*
+	  Test 2 - User without any ownership records can see only records without ownership
+	*/
+	requestParams = &RequestParams{TenantID: &userWithOwnRecords.TenantID, UserID: &userWithOwnRecords.Id}
+	secretDaoWithUser = GetSecretDao(requestParams)
+
+	secrets, _, err = secretDaoWithUser.List(100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`unexpected error when listing the application authentications: %s`, err)
+	}
+
+	secretsIDs = []int64{}
+	for _, secret := range secrets {
+		secretsIDs = append(secretsIDs, secret.DbID)
+	}
+
+	expectedSecretsIDs = []int64{secretWithoutOwnership.DbID}
+
+	if !util.ElementsInSlicesEqual(secretsIDs, expectedSecretsIDs) {
+		t.Errorf("Expected source IDs %v are not same with obtained IDs: %v", expectedSecretsIDs, secretsIDs)
+	}
+
+	DropSchema(schema)
+}

--- a/dao/secret_dao_test.go
+++ b/dao/secret_dao_test.go
@@ -50,7 +50,7 @@ func TestSecretListUserOwnership(t *testing.T) {
 
 	secrets, _, err := secretDaoWithUser.List(100, 0, []util.Filter{})
 	if err != nil {
-		t.Errorf(`unexpected error when listing the application authentications: %s`, err)
+		t.Errorf(`unexpected error when listing the secrets: %s`, err)
 	}
 
 	var secretsIDs []int64
@@ -61,7 +61,7 @@ func TestSecretListUserOwnership(t *testing.T) {
 	expectedSecretsIDs := []int64{secret1.DbID, secretWithoutOwnership.DbID}
 
 	if !util.ElementsInSlicesEqual(secretsIDs, expectedSecretsIDs) {
-		t.Errorf("Expected source IDs %v are not same with obtained IDs: %v", expectedSecretsIDs, secretsIDs)
+		t.Errorf("Expected secrets IDs %v are not same with obtained IDs: %v", expectedSecretsIDs, secretsIDs)
 	}
 
 	userWithOwnRecords, err = CreateUserForUserID(userIDWithoutOwnRecords, tenantId)
@@ -77,7 +77,7 @@ func TestSecretListUserOwnership(t *testing.T) {
 
 	secrets, _, err = secretDaoWithUser.List(100, 0, []util.Filter{})
 	if err != nil {
-		t.Errorf(`unexpected error when listing the application authentications: %s`, err)
+		t.Errorf(`unexpected error when listing the secrets: %s`, err)
 	}
 
 	secretsIDs = []int64{}
@@ -88,7 +88,7 @@ func TestSecretListUserOwnership(t *testing.T) {
 	expectedSecretsIDs = []int64{secretWithoutOwnership.DbID}
 
 	if !util.ElementsInSlicesEqual(secretsIDs, expectedSecretsIDs) {
-		t.Errorf("Expected source IDs %v are not same with obtained IDs: %v", expectedSecretsIDs, secretsIDs)
+		t.Errorf("Expected secrets IDs %v are not same with obtained IDs: %v", expectedSecretsIDs, secretsIDs)
 	}
 
 	DropSchema(schema)

--- a/dao/test_factories.go
+++ b/dao/test_factories.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/google/uuid"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -280,4 +281,23 @@ func TestSuiteForSourceWithOwnership(performTest func(suiteData *SourceOwnership
 	}
 
 	return nil
+}
+
+func CreateSecretByName(name string, tenantID *int64, userID *int64) (*m.Authentication, error) {
+	secretDao := GetSecretDao(&RequestParams{TenantID: tenantID})
+
+	secret := &m.Authentication{
+		Name:         util.StringRef(name),
+		AuthType:     "X",
+		Username:     util.StringRef("Y"),
+		ResourceType: secretResourceType,
+		ResourceID:   *tenantID,
+	}
+
+	if userID != nil {
+		secret.UserID = userID
+	}
+
+	err := secretDao.Create(secret)
+	return secret, err
 }

--- a/routes.go
+++ b/routes.go
@@ -110,6 +110,7 @@ func setupRoutes(e *echo.Echo) {
 		r.GET("/application_types/:application_type_id/app_meta_data", ApplicationTypeListMetaData, append(listMiddleware, middleware.LoggerFields)...)
 
 		// Secrets
+		r.GET("/secrets", SecretList, tenancyWithListMiddleware...)
 		r.POST("/secrets", SecretCreate, permissionMiddlewareWithoutEvents...)
 
 		// SourceTypes

--- a/secret_handlers.go
+++ b/secret_handlers.go
@@ -72,3 +72,32 @@ func SecretCreate(c echo.Context) error {
 
 	return c.JSON(http.StatusCreated, secret.ToSecretResponse())
 }
+
+func SecretList(c echo.Context) error {
+	secretDao, err := getSecretDao(c)
+	if err != nil {
+		return err
+	}
+
+	filters, err := getFilters(c)
+	if err != nil {
+		return err
+	}
+
+	limit, offset, err := getLimitAndOffset(c)
+	if err != nil {
+		return err
+	}
+
+	secrets, count, err := secretDao.List(limit, offset, filters)
+	if err != nil {
+		return err
+	}
+
+	out := make([]interface{}, 0, len(secrets))
+	for _, secret := range secrets {
+		out = append(out, *secret.ToSecretResponse())
+	}
+
+	return c.JSON(http.StatusOK, util.CollectionResponse(out, c.Request(), int(count), limit, offset))
+}


### PR DESCRIPTION
supports
- user based filtering 
- filtering by parameters

example:

With filtering:

```
GET /secrets?filter[authtype]=AAAA

{
  "data": [
    {
      "id": "37",
      "name": "OpenShift default6",
      "authtype": "AAAA",
      "username": "user@example.com",
      "extra": {
        "azure": {
          "tenant_id": "string"
        }
      }
    },
...

```

### Links

- [x] https://github.com/RedHatInsights/sources-api-go/pull/548
- part of https://issues.redhat.com/browse/RHCLOUD-20914
- https://github.com/RedHatInsights/sources-api-go/issues/549

