### PR TITLE
[RHCLOUD-20896] Moving binder.go into new package and updating tests

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"io"
 	"net/http"
 	"reflect"
@@ -29,7 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 func TestSourceApplicationSubcollectionList(t *testing.T) {
@@ -635,8 +635,8 @@ func TestApplicationCreateGood(t *testing.T) {
 	}
 
 	id, _ := strconv.ParseInt(app.ID, 10, 64)
-	dao, _ := getApplicationDao(c)
-	_, _ = dao.Delete(&id)
+	applicationDao, _ := getApplicationDao(c)
+	_, _ = applicationDao.Delete(&id)
 }
 
 func TestApplicationCreateMissingSourceId(t *testing.T) {
@@ -1932,10 +1932,6 @@ func TestApplicationEditPaused(t *testing.T) {
 		},
 	)
 
-	// Make sure we are using the "NoUnknownFieldsBinder".
-	backupBinder := c.Echo().Binder
-	c.Echo().Binder = &NoUnknownFieldsBinder{}
-
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
@@ -1974,9 +1970,6 @@ func TestApplicationEditPaused(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	// Restore the binder to not affect any other tests.
-	c.Echo().Binder = backupBinder
 }
 
 // TestApplicationEditPausedUnitInvalidFields tests that a "bad request" response is returned when a paused application
@@ -2002,10 +1995,6 @@ func TestApplicationEditPausedIntegration(t *testing.T) {
 		},
 	)
 
-	// Make sure we are using the "NoUnknownFieldsBinder".
-	backupBinder := c.Echo().Binder
-	c.Echo().Binder = &NoUnknownFieldsBinder{}
-
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
@@ -2044,9 +2033,6 @@ func TestApplicationEditPausedIntegration(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-
-	// Restore the binder to not affect any other tests.
-	c.Echo().Binder = backupBinder
 }
 
 // TestApplicationEditPaused tests that an application can be edited even if it is paused, if the payload is right.
@@ -2074,10 +2060,6 @@ func TestApplicationEditPausedUnit(t *testing.T) {
 		},
 	)
 
-	// Make sure we are using the "NoUnknownFieldsBinder".
-	backupBinder := c.Echo().Binder
-	c.Echo().Binder = &NoUnknownFieldsBinder{}
-
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
@@ -2102,8 +2084,6 @@ func TestApplicationEditPausedUnit(t *testing.T) {
 		t.Errorf("Wrong return code, expected %v got %v", http.StatusOK, rec.Code)
 	}
 
-	// Restore the binder to not affect any other tests.
-	c.Echo().Binder = backupBinder
 }
 
 // TestApplicationEditPausedUnitInvalidFields tests that a "bad request" response is returned when a paused application
@@ -2126,10 +2106,6 @@ func TestApplicationEditPausedUnitInvalidFields(t *testing.T) {
 			"tenantID": int64(1),
 		},
 	)
-
-	// Make sure we don't accept the "Extra" field we set up above
-	backupBinder := c.Echo().Binder
-	c.Echo().Binder = &NoUnknownFieldsBinder{}
 
 	c.SetParamNames("id")
 	c.SetParamValues("1")
@@ -2170,9 +2146,6 @@ func TestApplicationEditPausedUnitInvalidFields(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("Wrong return code, expected %v got %v", http.StatusBadRequest, rec.Code)
 	}
-
-	// Restore the binder to not affect any other tests.
-	c.Echo().Binder = backupBinder
 }
 
 func TestApplicationDeleteWithOwnership(t *testing.T) {

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"io"
 	"net/http"
 	"reflect"
@@ -30,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 func TestSourceApplicationSubcollectionList(t *testing.T) {

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/dao"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -14,7 +15,7 @@ import (
 var getApplicationTypeDao func(c echo.Context) (dao.ApplicationTypeDao, error)
 
 func getApplicationTypeDaoWithTenant(c echo.Context) (dao.ApplicationTypeDao, error) {
-	tenantId, err := util.GetTenantFromEchoContext(c)
+	tenantId, err := sourcesEcho.GetTenantFromEchoContext(c)
 
 	if err != nil {
 		return nil, err

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/dao"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
-	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -15,7 +15,7 @@ import (
 var getApplicationTypeDao func(c echo.Context) (dao.ApplicationTypeDao, error)
 
 func getApplicationTypeDaoWithTenant(c echo.Context) (dao.ApplicationTypeDao, error) {
-	tenantId, err := sourcesEcho.GetTenantFromEchoContext(c)
+	tenantId, err := echoUtils.GetTenantFromEchoContext(c)
 
 	if err != nil {
 		return nil, err

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -153,7 +153,7 @@ func AuthenticationEdit(c echo.Context) error {
 	updateRequest := &m.AuthenticationEditRequest{}
 	err = c.Bind(updateRequest)
 	if err != nil {
-		return util.NewErrBadRequest(err)
+		return err
 	}
 
 	err = service.ValidateAuthenticationEditRequest(updateRequest)

--- a/dao/request_params.go
+++ b/dao/request_params.go
@@ -2,7 +2,7 @@ package dao
 
 import (
 	"context"
-	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -13,12 +13,12 @@ type RequestParams struct {
 }
 
 func NewRequestParamsFromContext(c echo.Context) (*RequestParams, error) {
-	tenantId, err := sourcesEcho.GetTenantFromEchoContext(c)
+	tenantId, err := echoUtils.GetTenantFromEchoContext(c)
 	if err != nil {
 		return nil, err
 	}
 
-	userID, err := sourcesEcho.GetUserFromEchoContext(c)
+	userID, err := echoUtils.GetUserFromEchoContext(c)
 	if err != nil {
 		return nil, err
 	}

--- a/dao/request_params.go
+++ b/dao/request_params.go
@@ -2,8 +2,7 @@ package dao
 
 import (
 	"context"
-
-	"github.com/RedHatInsights/sources-api-go/util"
+	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -14,12 +13,12 @@ type RequestParams struct {
 }
 
 func NewRequestParamsFromContext(c echo.Context) (*RequestParams, error) {
-	tenantId, err := util.GetTenantFromEchoContext(c)
+	tenantId, err := sourcesEcho.GetTenantFromEchoContext(c)
 	if err != nil {
 		return nil, err
 	}
 
-	userID, err := util.GetUserFromEchoContext(c)
+	userID, err := sourcesEcho.GetUserFromEchoContext(c)
 	if err != nil {
 		return nil, err
 	}

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -10,7 +10,7 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
-	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -18,7 +18,7 @@ import (
 var getEndpointDao func(c echo.Context) (dao.EndpointDao, error)
 
 func getEndpointDaoWithTenant(c echo.Context) (dao.EndpointDao, error) {
-	tenantId, err := sourcesEcho.GetTenantFromEchoContext(c)
+	tenantId, err := echoUtils.GetTenantFromEchoContext(c)
 
 	if err != nil {
 		return nil, err

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -10,6 +10,7 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
+	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -17,7 +18,7 @@ import (
 var getEndpointDao func(c echo.Context) (dao.EndpointDao, error)
 
 func getEndpointDaoWithTenant(c echo.Context) (dao.EndpointDao, error) {
-	tenantId, err := util.GetTenantFromEchoContext(c)
+	tenantId, err := sourcesEcho.GetTenantFromEchoContext(c)
 
 	if err != nil {
 		return nil, err
@@ -209,7 +210,7 @@ func EndpointEdit(c echo.Context) error {
 	if endpoint.PausedAt != nil {
 		input := &m.ResourceEditPausedRequest{}
 		if err := c.Bind(input); err != nil {
-			return util.NewErrBadRequest(err)
+			return err
 		}
 
 		if err := endpoint.UpdateFromRequestPaused(input); err != nil {
@@ -218,7 +219,7 @@ func EndpointEdit(c echo.Context) error {
 	} else {
 		input := &m.EndpointEditRequest{}
 		if err := c.Bind(input); err != nil {
-			return util.NewErrBadRequest(err)
+			return err
 		}
 
 		if err = service.ValidateEndpointEditRequest(endpointDao, endpoint.SourceID, input); err != nil {

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -1133,10 +1133,6 @@ func TestEndpointEditPaused(t *testing.T) {
 		},
 	)
 
-	// Make sure we are using the "NoUnknownFieldsBinder".
-	backupBinder := c.Echo().Binder
-	c.Echo().Binder = &NoUnknownFieldsBinder{}
-
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
@@ -1167,9 +1163,6 @@ func TestEndpointEditPaused(t *testing.T) {
 
 	// Restore the original "getEndpointDao" function.
 	getEndpointDao = backupGetEndpointDao
-
-	// Restore the binder to not affect any other tests.
-	c.Echo().Binder = backupBinder
 }
 
 // TestEndpointEditPausedInvalidFields tests that a "bad request" response is returned when a paused endpoint is tried
@@ -1192,10 +1185,6 @@ func TestEndpointEditPausedInvalidFields(t *testing.T) {
 			"tenantID": int64(1),
 		},
 	)
-
-	// Make sure we don't accept the "Scheme" field we set up above.
-	backupBinder := c.Echo().Binder
-	c.Echo().Binder = &NoUnknownFieldsBinder{}
 
 	c.SetParamNames("id")
 	c.SetParamValues("1")
@@ -1241,9 +1230,6 @@ func TestEndpointEditPausedInvalidFields(t *testing.T) {
 
 	// Restore the original "getEndpointDao" function.
 	getEndpointDao = backupGetEndpointDao
-
-	// Restore the binder to not affect any other tests.
-	c.Echo().Binder = backupBinder
 }
 
 func TestEndpointListAuthentications(t *testing.T) {

--- a/internal/testutils/request/request.go
+++ b/internal/testutils/request/request.go
@@ -1,11 +1,12 @@
 package request
 
 import (
-	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
-	"github.com/labstack/echo/v4"
 	"io"
 	"net/http"
 	"net/http/httptest"
+
+	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	"github.com/labstack/echo/v4"
 )
 
 var echoInstance = echo.New()

--- a/internal/testutils/request/request.go
+++ b/internal/testutils/request/request.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -14,7 +14,7 @@ var echoInstance = echo.New()
 // CreateTestContext sets up a new echo context with the parameters given, and returns the context itself and the
 // response recorder.
 func CreateTestContext(method string, path string, body io.Reader, context map[string]interface{}) (echo.Context, *httptest.ResponseRecorder) {
-	echoInstance.Binder = &sourcesEcho.NoUnknownFieldsBinder{}
+	echoInstance.Binder = &echoUtils.NoUnknownFieldsBinder{}
 	request := httptest.NewRequest(method, path, body)
 	recorder := httptest.NewRecorder()
 	echoContext := echoInstance.NewContext(request, recorder)

--- a/internal/testutils/request/request.go
+++ b/internal/testutils/request/request.go
@@ -1,11 +1,11 @@
 package request
 
 import (
+	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	"github.com/labstack/echo/v4"
 	"io"
 	"net/http"
 	"net/http/httptest"
-
-	"github.com/labstack/echo/v4"
 )
 
 var echoInstance = echo.New()
@@ -13,6 +13,7 @@ var echoInstance = echo.New()
 // CreateTestContext sets up a new echo context with the parameters given, and returns the context itself and the
 // response recorder.
 func CreateTestContext(method string, path string, body io.Reader, context map[string]interface{}) (echo.Context, *httptest.ResponseRecorder) {
+	echoInstance.Binder = &sourcesEcho.NoUnknownFieldsBinder{}
 	request := httptest.NewRequest(method, path, body)
 	recorder := httptest.NewRecorder()
 	echoContext := echoInstance.NewContext(request, recorder)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	l "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/redis"
 	"github.com/RedHatInsights/sources-api-go/statuslistener"
+	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
 	echoMetrics "github.com/labstack/echo-contrib/prometheus"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -65,7 +66,7 @@ func runServer(shutdown chan struct{}) {
 	e.Logger = l.EchoLogger{Entry: l.Log.WithFields(logrus.Fields{})}
 
 	// set the binder to the one that does not allow extra parameters in payload
-	e.Binder = &NoUnknownFieldsBinder{}
+	e.Binder = &sourcesEcho.NoUnknownFieldsBinder{}
 
 	// strip trailing slashes
 	e.Pre(middleware.RemoveTrailingSlash())

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	l "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/redis"
 	"github.com/RedHatInsights/sources-api-go/statuslistener"
-	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	echoMetrics "github.com/labstack/echo-contrib/prometheus"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
@@ -66,7 +66,7 @@ func runServer(shutdown chan struct{}) {
 	e.Logger = l.EchoLogger{Entry: l.Log.WithFields(logrus.Fields{})}
 
 	// set the binder to the one that does not allow extra parameters in payload
-	e.Binder = &sourcesEcho.NoUnknownFieldsBinder{}
+	e.Binder = &echoUtils.NoUnknownFieldsBinder{}
 
 	// strip trailing slashes
 	e.Pre(middleware.RemoveTrailingSlash())

--- a/rhc_connection_handlers.go
+++ b/rhc_connection_handlers.go
@@ -9,14 +9,14 @@ import (
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
-	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
 var getRhcConnectionDao func(c echo.Context) (dao.RhcConnectionDao, error)
 
 func getDefaultRhcConnectionDao(c echo.Context) (dao.RhcConnectionDao, error) {
-	tenantId, err := sourcesEcho.GetTenantFromEchoContext(c)
+	tenantId, err := echoUtils.GetTenantFromEchoContext(c)
 
 	if err != nil {
 		return nil, err

--- a/rhc_connection_handlers.go
+++ b/rhc_connection_handlers.go
@@ -9,13 +9,14 @@ import (
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
+	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
 var getRhcConnectionDao func(c echo.Context) (dao.RhcConnectionDao, error)
 
 func getDefaultRhcConnectionDao(c echo.Context) (dao.RhcConnectionDao, error) {
-	tenantId, err := util.GetTenantFromEchoContext(c)
+	tenantId, err := sourcesEcho.GetTenantFromEchoContext(c)
 
 	if err != nil {
 		return nil, err

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -649,10 +649,19 @@ func TestRhcConnectionEditInvalidParam(t *testing.T) {
 func TestRhcConnectionEditNotFound(t *testing.T) {
 	invalidId := "12345"
 
+	requestBody := model.RhcConnectionEditRequest{
+		Extra: nil,
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		t.Error("Could not marshal JSON")
+	}
+
 	c, rec := request.CreateTestContext(
 		http.MethodPatch,
 		"/api/sources/v3.1/rhc_connections/"+invalidId,
-		nil,
+		bytes.NewReader(body),
 		map[string]interface{}{
 			"tenantID": int64(1),
 		},
@@ -663,7 +672,8 @@ func TestRhcConnectionEditNotFound(t *testing.T) {
 	c.SetParamValues(invalidId)
 
 	notFoundRhcConnectionEdit := ErrorHandlingContext(RhcConnectionEdit)
-	err := notFoundRhcConnectionEdit(c)
+	err = notFoundRhcConnectionEdit(c)
+
 	if err != nil {
 		t.Error(err)
 	}

--- a/routes.go
+++ b/routes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/middleware"
-	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
+	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -26,7 +26,7 @@ func setupRoutes(e *echo.Echo) {
 	// overriding the echo.Context instance with our own - so we can use any
 	// changes we made to the context's methods.
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error { return next(&sourcesEcho.SourcesContext{Context: c}) }
+		return func(c echo.Context) error { return next(&echoUtils.SourcesContext{Context: c}) }
 	})
 
 	apiVersions := []string{"v1.0", "v2.0", "v3.0", "v3.1", "v1", "v2", "v3"}

--- a/routes.go
+++ b/routes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/middleware"
-	"github.com/RedHatInsights/sources-api-go/util"
+	sourcesEcho "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
@@ -26,7 +26,7 @@ func setupRoutes(e *echo.Echo) {
 	// overriding the echo.Context instance with our own - so we can use any
 	// changes we made to the context's methods.
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error { return next(&util.SourcesContext{Context: c}) }
+		return func(c echo.Context) error { return next(&sourcesEcho.SourcesContext{Context: c}) }
 	})
 
 	apiVersions := []string{"v1.0", "v2.0", "v3.0", "v3.1", "v1", "v2", "v3"}

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -2565,9 +2565,6 @@ func TestSourceEditPausedIntegration(t *testing.T) {
 			"tenantID": int64(1),
 		},
 	)
-	// Make sure we are using the "NoUnknownFieldsBinder".
-	backupBinder := c.Echo().Binder
-	c.Echo().Binder = &NoUnknownFieldsBinder{}
 
 	c.SetParamNames("id")
 	c.SetParamValues("1")
@@ -2600,9 +2597,6 @@ func TestSourceEditPausedIntegration(t *testing.T) {
 	if !strings.Contains(got, want) {
 		t.Errorf(`unexpected body returned. Want "%s" contained in what we got "%s"`, want, got)
 	}
-
-	// Restore the binder to not affect any other tests.
-	c.Echo().Binder = backupBinder
 }
 
 // TestSourceEditPausedUnit tests that a "bad request" response is returned when a paused source is tried to be updated
@@ -2640,10 +2634,6 @@ func TestSourceEditPausedUnit(t *testing.T) {
 	pausedAt := time.Now()
 	fixtures.TestSourceData[0].PausedAt = &pausedAt
 
-	// Make sure we don't accept the "Name" field we set up above.
-	backupBinder := c.Echo().Binder
-	c.Echo().Binder = &NoUnknownFieldsBinder{}
-
 	badRequestSourceEdit := ErrorHandlingContext(SourceEdit)
 	err := badRequestSourceEdit(c)
 
@@ -2669,9 +2659,6 @@ func TestSourceEditPausedUnit(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("Wrong return code, expected %v got %v", http.StatusBadRequest, rec.Code)
 	}
-
-	// Restore the binder to not affect any other tests.
-	c.Echo().Binder = backupBinder
 }
 
 // HELPERS:

--- a/util/echo/binder.go
+++ b/util/echo/binder.go
@@ -1,4 +1,4 @@
-package main
+package echo
 
 import (
 	"encoding/json"

--- a/util/echo/binder_test.go
+++ b/util/echo/binder_test.go
@@ -1,4 +1,4 @@
-package main
+package echo
 
 import (
 	"bytes"

--- a/util/echo/binder_test.go
+++ b/util/echo/binder_test.go
@@ -2,120 +2,67 @@ package echo
 
 import (
 	"bytes"
-	"errors"
 	"net/http"
-	"reflect"
 	"testing"
-
-	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
-	"github.com/RedHatInsights/sources-api-go/util"
-	"github.com/labstack/echo/v4"
 )
-
-var binder echo.Binder = &NoUnknownFieldsBinder{}
 
 type TestStruct struct {
 	YesIamAField bool `json:"good_field"`
 }
 
 func TestGoodPayload(t *testing.T) {
-	c, _ := request.CreateTestContext(
+	c, _ := CreateTestContext(
 		http.MethodPost,
 		"/",
 		bytes.NewBufferString(`{"good_field": true}`),
 		nil,
 	)
-	// set the binder to our custom instance.
-	c.Echo().Binder = binder
-
 	err := c.Bind(&TestStruct{})
 	if err != nil {
 		t.Error(err)
 	}
-
-	// resetting due to messing with other tests.
-	c.Echo().Binder = &echo.DefaultBinder{}
 }
 
 func TestBadPayload(t *testing.T) {
-	c, _ := request.CreateTestContext(
+	c, _ := CreateTestContext(
 		http.MethodPost,
 		"/",
 		bytes.NewBufferString(`{"good_field": true, "oops": "yes"}`),
 		nil,
 	)
-	c.Echo().Binder = binder
 
 	err := c.Bind(&TestStruct{})
 	if err == nil {
 		t.Error("No error was found when there should have been an extra field error")
 	}
 
-	c.Echo().Binder = &echo.DefaultBinder{}
 }
 
 func TestNilBody(t *testing.T) {
-	c, _ := request.CreateTestContext(
+	c, _ := CreateTestContext(
 		http.MethodPost,
 		"/",
 		nil,
 		nil,
 	)
-	c.Echo().Binder = binder
 
 	err := c.Bind(&TestStruct{})
 	if err == nil {
 		t.Error("No error was found when there should have been a no body error")
 	}
 
-	c.Echo().Binder = &echo.DefaultBinder{}
 }
 
 func TestNoBody(t *testing.T) {
-	c, _ := request.CreateTestContext(
+	c, _ := CreateTestContext(
 		http.MethodPost,
 		"/",
 		http.NoBody,
 		nil,
 	)
-	c.Echo().Binder = binder
-
 	err := c.Bind(&TestStruct{})
 	if err == nil {
 		t.Error("No error was found when there should have been a no body error")
 	}
 
-	c.Echo().Binder = &echo.DefaultBinder{}
-}
-
-// TestEmptyJsonBody tests that when a valid, empty JSON object is given, a "bad request" error is returned.
-func TestEmptyJsonBody(t *testing.T) {
-	testValues := []*bytes.Buffer{
-		bytes.NewBufferString("{}"),
-		bytes.NewBufferString("{     }"),
-		bytes.NewBufferString("[]"),
-		bytes.NewBufferString("[     ]"),
-		bytes.NewBufferString("null"),
-	}
-
-	for _, tv := range testValues {
-		c, _ := request.CreateTestContext(
-			http.MethodPost,
-			"/",
-			tv,
-			nil,
-		)
-		c.Echo().Binder = binder
-
-		err := c.Bind(&TestStruct{})
-		if err == nil {
-			t.Error("No error was found when there should have been a no body error")
-		}
-
-		if !errors.Is(err, util.ErrBadRequestEmpty) {
-			t.Errorf(`bad request error expected when passing it an empty JSON body, got "%s"`, reflect.TypeOf(err))
-		}
-
-		c.Echo().Binder = &echo.DefaultBinder{}
-	}
 }

--- a/util/echo/echo_context.go
+++ b/util/echo/echo_context.go
@@ -1,4 +1,4 @@
-package util
+package echo
 
 import (
 	"errors"

--- a/util/echo/echo_context_test.go
+++ b/util/echo/echo_context_test.go
@@ -1,12 +1,11 @@
 package echo
 
 import (
-	"github.com/RedHatInsights/sources-api-go/util"
 	"net/http"
 	"strings"
 	"testing"
 
-	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )
 
@@ -18,7 +17,7 @@ var _ = (echo.Context)(&SourcesContext{})
 func TestGetTenantFromEchoContext(t *testing.T) {
 	want := int64(12345)
 
-	c, _ := request.CreateTestContext(
+	c, _ := CreateTestContext(
 		http.MethodGet,
 		"/api/sources/v3.1/whatever",
 		nil,
@@ -46,7 +45,7 @@ func TestGetTenantFromEchoContextLowerOrEqualsZero(t *testing.T) {
 	invalidTenantIds := []int64{-5, 0}
 
 	for _, iti := range invalidTenantIds {
-		c, _ := request.CreateTestContext(
+		c, _ := CreateTestContext(
 			http.MethodGet,
 			"/api/sources/v3.1/whatever",
 			nil,
@@ -72,7 +71,7 @@ func TestGetTenantFromEchoContextLowerOrEqualsZero(t *testing.T) {
 func TestGetTenantFromEchoContextInvalidFormat(t *testing.T) {
 	invalidTenantIdFormat := "12345"
 
-	c, _ := request.CreateTestContext(
+	c, _ := CreateTestContext(
 		http.MethodGet,
 		"/api/sources/v3.1/whatever",
 		nil,
@@ -94,7 +93,7 @@ func TestGetTenantFromEchoContextInvalidFormat(t *testing.T) {
 // TestGetTenantFromEchoContextMissing tests that when the tenant is missing from the context the function returns a
 // default value and a nil error.
 func TestGetTenantFromEchoContextMissing(t *testing.T) {
-	c, _ := request.CreateTestContext(
+	c, _ := CreateTestContext(
 		http.MethodGet,
 		"/api/sources/v3.1/whatever",
 		nil,

--- a/util/echo/echo_context_test.go
+++ b/util/echo/echo_context_test.go
@@ -1,6 +1,7 @@
-package util
+package echo
 
 import (
+	"github.com/RedHatInsights/sources-api-go/util"
 	"net/http"
 	"strings"
 	"testing"
@@ -24,7 +25,7 @@ func TestGetTenantFromEchoContext(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": want,
 		},
 	)
@@ -52,7 +53,7 @@ func TestGetTenantFromEchoContextLowerOrEqualsZero(t *testing.T) {
 			map[string]interface{}{
 				"limit":    100,
 				"offset":   0,
-				"filters":  []Filter{},
+				"filters":  []util.Filter{},
 				"tenantID": iti,
 			},
 		)
@@ -78,7 +79,7 @@ func TestGetTenantFromEchoContextInvalidFormat(t *testing.T) {
 		map[string]interface{}{
 			"limit":    100,
 			"offset":   0,
-			"filters":  []Filter{},
+			"filters":  []util.Filter{},
 			"tenantID": invalidTenantIdFormat,
 		},
 	)
@@ -100,7 +101,7 @@ func TestGetTenantFromEchoContextMissing(t *testing.T) {
 		map[string]interface{}{
 			"limit":   100,
 			"offset":  0,
-			"filters": []Filter{},
+			"filters": []util.Filter{},
 		},
 	)
 

--- a/util/echo/main_test.go
+++ b/util/echo/main_test.go
@@ -1,0 +1,39 @@
+package echo
+
+import (
+	"io"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+	l "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/labstack/echo/v4"
+)
+
+var echoInstance = echo.New()
+
+//duplicating helper function CreateTestContext() from internal/testutils/request/request.go in order to
+// effectively test and importing this to other packages to prevent import cycle
+func CreateTestContext(method string, path string, body io.Reader, context map[string]interface{}) (echo.Context, *httptest.ResponseRecorder) {
+	echoInstance.Binder = &NoUnknownFieldsBinder{}
+	request := httptest.NewRequest(method, path, body)
+	recorder := httptest.NewRecorder()
+	echoContext := echoInstance.NewContext(request, recorder)
+	for k, v := range context {
+		echoContext.Set(k, v)
+	}
+
+	return echoContext, recorder
+}
+
+func TestMain(t *testing.M) {
+	// we need this to parse arguments otherwise there are not recognized which lead to error
+	_ = parser.ParseFlags()
+
+	// Initialize the logger to avoid nil pointer dereferences.
+	l.InitLogger(config.Get())
+
+	os.Exit(t.Run())
+}


### PR DESCRIPTION
Moved binder.go, binder_test.go, echo_context.go, and echo_context_test.go into new echo package within util package.

Deleted echo.Binder() within the different test files. 

Made sure that the files imported the correct files. 

Within some of the handlers.go files, after the Bind() function, made sure to change util.NewBadRequestErr(err) to err. 

JIRA ticket: [RHCLOUD-20896](https://issues.redhat.com/browse/RHCLOUD-20896)