### PR TITLE
[RHCLOUD-21120] Bind() update - added check for no body

### DIFF
--- a/util/echo/binder.go
+++ b/util/echo/binder.go
@@ -2,6 +2,7 @@ package echo
 
 import (
 	"encoding/json"
+	"net/http"
 	"reflect"
 
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -21,6 +22,11 @@ type NoUnknownFieldsBinder struct{}
 func (binder *NoUnknownFieldsBinder) Bind(i interface{}, c echo.Context) error {
 	// Close the request's body after we're done with it.
 	defer c.Request().Body.Close()
+
+	// Check if request contains a body
+	if c.Request().Body == http.NoBody {
+		return util.NewErrBadRequest("no body")
+	}
 
 	// is the struct passed in initially empty? then it's pretty easy to tell if
 	// no fields were plucked from the body.

--- a/util/echo/binder_test.go
+++ b/util/echo/binder_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -51,8 +52,12 @@ func TestNilBody(t *testing.T) {
 	)
 
 	err := c.Bind(&TestStruct{})
-	if err == nil {
-		t.Error("No error was found when there should have been a no body error")
+
+	// Check that returned err is Bad request with "no body" message
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("Expected Bad request err, got %s", err)
+	} else if !strings.Contains(err.Error(), "no body") {
+		t.Errorf("Expected that err message contains 'no body' but got '%s'", err)
 	}
 
 }
@@ -65,8 +70,12 @@ func TestNoBody(t *testing.T) {
 		nil,
 	)
 	err := c.Bind(&TestStruct{})
-	if err == nil {
-		t.Error("No error was found when there should have been a no body error")
+
+	// Check that returned err is Bad request with "no body" message
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("Expected Bad request err, got %s", err)
+	} else if !strings.Contains(err.Error(), "no body") {
+		t.Errorf("Expected that err message contains 'no body' but got '%s'", err)
 	}
 
 }


### PR DESCRIPTION
create an application without body
`POST api/sources/v3.1/applications`
and you get 400 Bad request
```
{
    "errors": [
        {
            "detail": "bad request: EOF",
            "status": "400"
        }
    ]
}
```

in this PR is added check if request contains a body ... otherwise Bad request is returned with more descriptive message
```
{
    "errors": [
        {
            "detail": "bad request: no body",
            "status": "400"
        }
    ]
}
```

**JIRA:** [RHCLOUD-21120](https://issues.redhat.com/browse/RHCLOUD-21120)