### PR TITLE
[RHCLOUD-21159] feature: update source types for the provisioning application

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -69,6 +69,12 @@
   dependent_applications: []
   supported_source_types:
     - amazon
+    - azure
+    - google
   supported_authentication_types:
     amazon:
       - provisioning-arn
+    azure:
+      - provisioning_lighthouse_subscription_id
+    google:
+      - provisioning_project_id

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -114,6 +114,17 @@ google:
         isRequired: true
         validate:
         - type: required
+    - type: provisioning_project_id
+      name: Provisioning — project ID
+      fields:
+        - component: text-field
+          name: authentication.authtype
+          hideField: true
+          initializeOnMount: true
+          initialValue: provisioning_project_id
+        - component: text-field
+          name: authentication.username
+          label: Project ID
     endpoint:
       hidden: true
       fields:
@@ -143,6 +154,20 @@ azure:
         isRequired: true
         validate:
         - type: required
+    - type: provisioning_lighthouse_subscription_id
+      name: Provisioning — Subscription ID
+      fields:
+        - component: text-field
+          name: authentication.authtype
+          hideField: true
+          initializeOnMount: true
+          initialValue: provisioning_lighthouse_subscription_id
+        - component: text-field
+          name: authentication.username
+          label: Subscription ID
+          isRequired: true
+          validate:
+            - type: required
     - type: tenant_id_client_id_client_secret
       name: Tenant ID, Client ID, Client Secret
       fields:


### PR DESCRIPTION
The provisioning team is working on making the application compatible with Azure and Google Cloud. They need new authentication types for those clouds and the ability to create sources of that type.

## Links

[[RHCLOUD-21159]](https://issues.redhat.com/browse/RHCLOUD-21159)