### PR TITLE
[WIP][RHCLOUD-21109] Refactor of constants in middleware/headers/headers.go

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -833,7 +834,7 @@ func TestApplicationEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(strconv.Itoa(int(applicationID)))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	appEditHandlerWithNotifier := middleware.Notifier(ApplicationEdit)
 	err = appEditHandlerWithNotifier(c)

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -834,7 +834,7 @@ func TestApplicationEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(strconv.Itoa(int(applicationID)))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	appEditHandlerWithNotifier := middleware.Notifier(ApplicationEdit)
 	err = appEditHandlerWithNotifier(c)

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -502,7 +503,7 @@ func TestAuthenticationEdit(t *testing.T) {
 	c.SetParamNames("uid")
 	c.SetParamValues(uid)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	authEditHandlerWithNotifier := middleware.Notifier(AuthenticationEdit)
 	err = authEditHandlerWithNotifier(c)

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -503,7 +503,7 @@ func TestAuthenticationEdit(t *testing.T) {
 	c.SetParamNames("uid")
 	c.SetParamValues(uid)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	authEditHandlerWithNotifier := middleware.Notifier(AuthenticationEdit)
 	err = authEditHandlerWithNotifier(c)

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -23,9 +23,9 @@ func BulkCreate(c echo.Context) error {
 		return fmt.Errorf("failed to pull tenant from request")
 	}
 
-	xrhid, ok := c.Get(h.XRHID).(string)
+	xrhid, ok := c.Get(h.IdentityKey).(string)
 	if !ok {
-		c.Logger().Warnf("bad xrhid %v", c.Get(h.XRHID))
+		c.Logger().Warnf("bad xrhid %v", c.Get(h.IdentityKey))
 	}
 	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
 	if !ok {

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -27,7 +27,7 @@ func BulkCreate(c echo.Context) error {
 	if !ok {
 		c.Logger().Warnf("bad xrhid %v", c.Get(h.Identity))
 	}
-	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
 		c.Logger().Warnf("failed to pull identity from request")
 		return fmt.Errorf("failed to pull identity from request")

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -23,9 +23,9 @@ func BulkCreate(c echo.Context) error {
 		return fmt.Errorf("failed to pull tenant from request")
 	}
 
-	xrhid, ok := c.Get(h.IdentityKey).(string)
+	xrhid, ok := c.Get(h.Identity).(string)
 	if !ok {
-		c.Logger().Warnf("bad xrhid %v", c.Get(h.IdentityKey))
+		c.Logger().Warnf("bad xrhid %v", c.Get(h.Identity))
 	}
 	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 	if !ok {

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -18,7 +18,7 @@ func BulkCreate(c echo.Context) error {
 		return err
 	}
 
-	tenantID, ok := c.Get(h.TENANTID).(int64)
+	tenantID, ok := c.Get(h.TenantIdKey).(int64)
 	if !ok {
 		return fmt.Errorf("failed to pull tenant from request")
 	}

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -27,7 +27,7 @@ func BulkCreate(c echo.Context) error {
 	if !ok {
 		c.Logger().Warnf("bad xrhid %v", c.Get(h.IdentityKey))
 	}
-	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 	if !ok {
 		c.Logger().Warnf("failed to pull identity from request")
 		return fmt.Errorf("failed to pull identity from request")

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -34,7 +34,7 @@ func BulkCreate(c echo.Context) error {
 	}
 
 	user := &m.User{TenantID: tenantID}
-	userID, ok := c.Get(h.USERID).(int64)
+	userID, ok := c.Get(h.UserIdKey).(int64)
 
 	if ok {
 		user.UserID = id.Identity.User.UserID

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -18,7 +18,7 @@ func BulkCreate(c echo.Context) error {
 		return err
 	}
 
-	tenantID, ok := c.Get(h.TenantIdKey).(int64)
+	tenantID, ok := c.Get(h.TenantId).(int64)
 	if !ok {
 		return fmt.Errorf("failed to pull tenant from request")
 	}

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -34,7 +34,7 @@ func BulkCreate(c echo.Context) error {
 	}
 
 	user := &m.User{TenantID: tenantID}
-	userID, ok := c.Get(h.UserIdKey).(int64)
+	userID, ok := c.Get(h.UserId).(int64)
 
 	if ok {
 		user.UserID = id.Identity.User.UserID

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -41,7 +41,7 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 		},
 	)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	user, err := dao.GetUserDao(&fixtures.TestTenantData[0].Id).FindOrCreate(testUserId)
 	if err != nil {
@@ -89,7 +89,7 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", identityHeader)
+	c.Set(h.ParsedIdentityKey, identityHeader)
 
 	var user m.User
 	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).First(&user).Error
@@ -199,7 +199,7 @@ func TestBulkCreate(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", identityHeader)
+	c.Set(h.ParsedIdentityKey, identityHeader)
 
 	err = BulkCreate(c)
 	if err != nil {
@@ -285,7 +285,7 @@ func TestBulkCreateSourceValidationBadRequest(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	badRequestBulkCreate := ErrorHandlingContext(BulkCreate)
 	err = badRequestBulkCreate(c)

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -41,7 +41,7 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 		},
 	)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	user, err := dao.GetUserDao(&fixtures.TestTenantData[0].Id).FindOrCreate(testUserId)
 	if err != nil {
@@ -89,7 +89,7 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, identityHeader)
+	c.Set(h.ParsedIdentity, identityHeader)
 
 	var user m.User
 	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).First(&user).Error
@@ -199,7 +199,7 @@ func TestBulkCreate(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, identityHeader)
+	c.Set(h.ParsedIdentity, identityHeader)
 
 	err = BulkCreate(c)
 	if err != nil {
@@ -285,7 +285,7 @@ func TestBulkCreateSourceValidationBadRequest(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	badRequestBulkCreate := ErrorHandlingContext(BulkCreate)
 	err = badRequestBulkCreate(c)

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -48,7 +48,7 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 		t.Error(err)
 	}
 
-	c.Set(h.USERID, user.Id)
+	c.Set(h.UserIdKey, user.Id)
 
 	err = BulkCreate(c)
 	if !strings.Contains(err.Error(), "no source type present, need either [source_type_name] or [source_type_id]") {

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -48,7 +48,7 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 		t.Error(err)
 	}
 
-	c.Set(h.UserIdKey, user.Id)
+	c.Set(h.UserId, user.Id)
 
 	err = BulkCreate(c)
 	if !strings.Contains(err.Error(), "no source type present, need either [source_type_name] or [source_type_id]") {

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -755,7 +756,7 @@ func TestEndpointEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(EndpointEdit)
 	err := sourceEditHandlerWithNotifier(c)

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -756,7 +756,7 @@ func TestEndpointEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(EndpointEdit)
 	err := sourceEditHandlerWithNotifier(c)

--- a/helpers.go
+++ b/helpers.go
@@ -80,7 +80,7 @@ func setEventStreamResource(c echo.Context, model m.Event) {
 }
 
 func getAccountNumberFromEchoContext(c echo.Context) (string, error) {
-	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 	if !ok {
 		return "", fmt.Errorf("failed to pull identity from context")
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -80,7 +80,7 @@ func setEventStreamResource(c echo.Context, model m.Event) {
 }
 
 func getAccountNumberFromEchoContext(c echo.Context) (string, error) {
-	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
 		return "", fmt.Errorf("failed to pull identity from context")
 	}

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -47,7 +47,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 				return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Unauthorized Action: Incorrect PSK", "401"))
 			}
 
-		case c.Get(h.XRHID) != nil:
+		case c.Get(h.IdentityKey) != nil:
 			// first check the identity (already parsed) to see if it contains
 			// the system key and if it does do some extra checks to authorize
 			// based on some internal rules (operator + satellite)
@@ -85,7 +85,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 
 			// otherwise, ship the xrhid off to rbac and check access rights.
-			rhid, ok := c.Get(h.XRHID).(string)
+			rhid, ok := c.Get(h.IdentityKey).(string)
 			if !ok {
 				return fmt.Errorf("error casting x-rh-identity to string: %v", c.Get("x-rh-identity"))
 			}

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -37,10 +37,10 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 		switch {
 		case bypassRbac:
 			c.Logger().Debugf("Skipping authorization check -- disabled in ENV")
-		case c.Get(h.PskKey) != nil:
-			psk, ok := c.Get(h.PskKey).(string)
+		case c.Get(h.Psk) != nil:
+			psk, ok := c.Get(h.Psk).(string)
 			if !ok {
-				return fmt.Errorf("error casting psk to string: %v", c.Get(h.PskKey))
+				return fmt.Errorf("error casting psk to string: %v", c.Get(h.Psk))
 			}
 
 			if !pskMatches(psk) {

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -51,9 +51,9 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			// first check the identity (already parsed) to see if it contains
 			// the system key and if it does do some extra checks to authorize
 			// based on some internal rules (operator + satellite)
-			id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
+			id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 			if !ok {
-				return fmt.Errorf("error casting identity to struct: %+v", c.Get(h.ParsedIdentityKey))
+				return fmt.Errorf("error casting identity to struct: %+v", c.Get(h.ParsedIdentity))
 			}
 
 			// checking to see if we're going to change the results since

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -47,7 +47,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 				return c.JSON(http.StatusUnauthorized, util.ErrorDoc("Unauthorized Action: Incorrect PSK", "401"))
 			}
 
-		case c.Get(h.IdentityKey) != nil:
+		case c.Get(h.Identity) != nil:
 			// first check the identity (already parsed) to see if it contains
 			// the system key and if it does do some extra checks to authorize
 			// based on some internal rules (operator + satellite)
@@ -85,7 +85,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 
 			// otherwise, ship the xrhid off to rbac and check access rights.
-			rhid, ok := c.Get(h.IdentityKey).(string)
+			rhid, ok := c.Get(h.Identity).(string)
 			if !ok {
 				return fmt.Errorf("error casting x-rh-identity to string: %v", c.Get("x-rh-identity"))
 			}

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -53,7 +53,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			// based on some internal rules (operator + satellite)
 			id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 			if !ok {
-				return fmt.Errorf("error casting identity to struct: %+v", c.Get("identity"))
+				return fmt.Errorf("error casting identity to struct: %+v", c.Get(h.ParsedIdentityKey))
 			}
 
 			// checking to see if we're going to change the results since

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -37,10 +37,10 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 		switch {
 		case bypassRbac:
 			c.Logger().Debugf("Skipping authorization check -- disabled in ENV")
-		case c.Get(h.PSK) != nil:
-			psk, ok := c.Get(h.PSK).(string)
+		case c.Get(h.PskKey) != nil:
+			psk, ok := c.Get(h.PskKey).(string)
 			if !ok {
-				return fmt.Errorf("error casting psk to string: %v", c.Get(h.PSK))
+				return fmt.Errorf("error casting psk to string: %v", c.Get(h.PskKey))
 			}
 
 			if !pskMatches(psk) {

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -51,7 +51,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			// first check the identity (already parsed) to see if it contains
 			// the system key and if it does do some extra checks to authorize
 			// based on some internal rules (operator + satellite)
-			id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+			id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("error casting identity to struct: %+v", c.Get("identity"))
 			}

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -112,7 +112,7 @@ func TestSystemClusterID(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.Identity: "dummy",
-			h.ParsedIdentityKey: &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						ClusterId: "test_cluster",
@@ -139,7 +139,7 @@ func TestSystemCN(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.Identity: "dummy",
-			h.ParsedIdentityKey: &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -166,7 +166,7 @@ func TestSystemPatch(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.Identity: "dummy",
-			h.ParsedIdentityKey: &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -193,7 +193,7 @@ func TestSystemDelete(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.Identity: "dummy",
-			h.ParsedIdentityKey: &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -220,7 +220,7 @@ func TestSystemDeleteSource(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.Identity: "dummy",
-			h.ParsedIdentityKey: &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -247,7 +247,7 @@ func TestSystemDeleteSourceVersioned(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.Identity: "dummy",
-			h.ParsedIdentityKey: &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -289,8 +289,8 @@ func TestRbacWithAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.Identity:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
+			h.Identity:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentity: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -312,8 +312,8 @@ func TestRbacWithoutAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.Identity:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
+			h.Identity:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentity: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -335,8 +335,8 @@ func TestRbacNoConnection(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.Identity:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
+			h.Identity:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentity: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -54,7 +54,7 @@ func TestGoodPSK(t *testing.T) {
 		http.MethodPost,
 		"/",
 		nil,
-		map[string]interface{}{h.PSK: "1234"},
+		map[string]interface{}{h.PskKey: "1234"},
 	)
 
 	err := permCheckOrElse204(c)
@@ -73,7 +73,7 @@ func TestBadPSK(t *testing.T) {
 		http.MethodPost,
 		"/",
 		nil,
-		map[string]interface{}{h.PSK: "1234"},
+		map[string]interface{}{h.PskKey: "1234"},
 	)
 
 	err := permCheckOrElse204(c)

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -54,7 +54,7 @@ func TestGoodPSK(t *testing.T) {
 		http.MethodPost,
 		"/",
 		nil,
-		map[string]interface{}{h.PskKey: "1234"},
+		map[string]interface{}{h.Psk: "1234"},
 	)
 
 	err := permCheckOrElse204(c)
@@ -73,7 +73,7 @@ func TestBadPSK(t *testing.T) {
 		http.MethodPost,
 		"/",
 		nil,
-		map[string]interface{}{h.PskKey: "1234"},
+		map[string]interface{}{h.Psk: "1234"},
 	)
 
 	err := permCheckOrElse204(c)

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -111,7 +111,7 @@ func TestSystemClusterID(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "dummy",
+			h.Identity: "dummy",
 			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -138,7 +138,7 @@ func TestSystemCN(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "dummy",
+			h.Identity: "dummy",
 			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -165,7 +165,7 @@ func TestSystemPatch(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "dummy",
+			h.Identity: "dummy",
 			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -192,7 +192,7 @@ func TestSystemDelete(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "dummy",
+			h.Identity: "dummy",
 			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -219,7 +219,7 @@ func TestSystemDeleteSource(t *testing.T) {
 		"/sources/1235",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "dummy",
+			h.Identity: "dummy",
 			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -246,7 +246,7 @@ func TestSystemDeleteSourceVersioned(t *testing.T) {
 		"/api/sources/v3.1/sources/1235",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "dummy",
+			h.Identity: "dummy",
 			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -289,7 +289,7 @@ func TestRbacWithAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.Identity:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
 			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
@@ -312,7 +312,7 @@ func TestRbacWithoutAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.Identity:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
 			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
@@ -335,7 +335,7 @@ func TestRbacNoConnection(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.Identity:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
 			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -112,7 +112,7 @@ func TestSystemClusterID(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.IdentityKey: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						ClusterId: "test_cluster",
@@ -139,7 +139,7 @@ func TestSystemCN(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.IdentityKey: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -166,7 +166,7 @@ func TestSystemPatch(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.IdentityKey: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -193,7 +193,7 @@ func TestSystemDelete(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.IdentityKey: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -220,7 +220,7 @@ func TestSystemDeleteSource(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.IdentityKey: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -247,7 +247,7 @@ func TestSystemDeleteSourceVersioned(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.IdentityKey: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentityKey: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -289,8 +289,8 @@ func TestRbacWithAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":    &identity.XRHID{Identity: identity.Identity{}},
+			h.IdentityKey:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -312,8 +312,8 @@ func TestRbacWithoutAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":    &identity.XRHID{Identity: identity.Identity{}},
+			h.IdentityKey:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -335,8 +335,8 @@ func TestRbacNoConnection(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.IdentityKey: "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":    &identity.XRHID{Identity: identity.Identity{}},
+			h.IdentityKey:       "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentityKey: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -111,7 +111,7 @@ func TestSystemClusterID(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "dummy",
+			h.IdentityKey: "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -138,7 +138,7 @@ func TestSystemCN(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "dummy",
+			h.IdentityKey: "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -165,7 +165,7 @@ func TestSystemPatch(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "dummy",
+			h.IdentityKey: "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -192,7 +192,7 @@ func TestSystemDelete(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "dummy",
+			h.IdentityKey: "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -219,7 +219,7 @@ func TestSystemDeleteSource(t *testing.T) {
 		"/sources/1235",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "dummy",
+			h.IdentityKey: "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -246,7 +246,7 @@ func TestSystemDeleteSourceVersioned(t *testing.T) {
 		"/api/sources/v3.1/sources/1235",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "dummy",
+			h.IdentityKey: "dummy",
 			"identity": &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
@@ -289,8 +289,8 @@ func TestRbacWithAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":      &identity.XRHID{Identity: identity.Identity{}},
+			h.IdentityKey: "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			"identity":    &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -312,8 +312,8 @@ func TestRbacWithoutAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":      &identity.XRHID{Identity: identity.Identity{}},
+			h.IdentityKey: "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			"identity":    &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -335,8 +335,8 @@ func TestRbacNoConnection(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			"x-rh-identity": "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity":      &identity.XRHID{Identity: identity.Identity{}},
+			h.IdentityKey: "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			"identity":    &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 

--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -25,7 +25,7 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 				message = util.ErrorDocWithoutLogging(err.Error(), "400")
 			default:
 				c.Logger().Error(err)
-				uuid, ok := c.Get(h.InsightsRequestIdKey).(string)
+				uuid, ok := c.Get(h.InsightsRequestId).(string)
 				if !ok {
 					uuid = ""
 				}

--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -25,7 +25,7 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 				message = util.ErrorDocWithoutLogging(err.Error(), "400")
 			default:
 				c.Logger().Error(err)
-				uuid, ok := c.Get(h.INSIGHTS_REQUEST_ID).(string)
+				uuid, ok := c.Get(h.InsightsRequestIdKey).(string)
 				if !ok {
 					uuid = ""
 				}

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -90,7 +90,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", h.IdentityKey, h.AccountNumber, h.OrgIdKey}
+	expected := []string{"event_type", h.IdentityKey, h.AccountNumber, h.OrgId}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -90,7 +90,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", h.IdentityKey, h.AccountNumberKey, h.OrgIdKey}
+	expected := []string{"event_type", h.IdentityKey, h.AccountNumber, h.OrgIdKey}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -60,7 +60,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 	s := mocks.MockSender{}
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
-		h.PskKey:      "1234",
+		h.Psk:         "1234",
 		h.IdentityKey: util.GeneratedXRhIdentity("1234", "1234"),
 	})
 

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -60,8 +60,8 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 	s := mocks.MockSender{}
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
-		h.PskKey: "1234",
-		"x-rh-identity":    util.GeneratedXRhIdentity("1234", "1234"),
+		h.PskKey:      "1234",
+		h.IdentityKey: util.GeneratedXRhIdentity("1234", "1234"),
 	})
 
 	f := raiseMiddleware(func(c echo.Context) error {
@@ -90,7 +90,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", "x-rh-identity", h.AccountNumberKey, h.OrgIdKey}
+	expected := []string{"event_type", h.IdentityKey, h.AccountNumberKey, h.OrgIdKey}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -90,7 +90,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", "x-rh-identity", "x-rh-sources-account-number", "x-rh-sources-org-id"}
+	expected := []string{"event_type", "x-rh-identity", h.AccountNumberKey, "x-rh-sources-org-id"}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -60,8 +60,8 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 	s := mocks.MockSender{}
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
-		h.Psk:         "1234",
-		h.IdentityKey: util.GeneratedXRhIdentity("1234", "1234"),
+		h.Psk:      "1234",
+		h.Identity: util.GeneratedXRhIdentity("1234", "1234"),
 	})
 
 	f := raiseMiddleware(func(c echo.Context) error {
@@ -90,7 +90,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", h.IdentityKey, h.AccountNumber, h.OrgId}
+	expected := []string{"event_type", h.Identity, h.AccountNumber, h.OrgId}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -90,7 +90,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", "x-rh-identity", h.AccountNumberKey, "x-rh-sources-org-id"}
+	expected := []string{"event_type", "x-rh-identity", h.AccountNumberKey, h.OrgIdKey}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/events"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/mocks"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
@@ -59,7 +60,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 	s := mocks.MockSender{}
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
-		"x-rh-sources-psk": "1234",
+		h.PskKey: "1234",
 		"x-rh-identity":    util.GeneratedXRhIdentity("1234", "1234"),
 	})
 

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -27,8 +27,8 @@ import (
 func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// the PSK related headers - just storing them as raw strings.
-		if c.Request().Header.Get(h.PSK) != "" {
-			c.Set(h.PSK, c.Request().Header.Get(h.PSK))
+		if c.Request().Header.Get(h.PskKey) != "" {
+			c.Set(h.PskKey, c.Request().Header.Get(h.PskKey))
 		}
 
 		if c.Request().Header.Get(h.ACCOUNT_NUMBER) != "" {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -39,8 +39,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.OrgIdKey, c.Request().Header.Get(h.OrgIdKey))
 		}
 
-		if c.Request().Header.Get(h.UserIdKey) != "" {
-			c.Set(h.UserIdKey, c.Request().Header.Get(h.UserIdKey))
+		if c.Request().Header.Get(h.XrhUserIdKey) != "" {
+			c.Set(h.XrhUserIdKey, c.Request().Header.Get(h.XrhUserIdKey))
 		}
 
 		if c.Request().Header.Get(h.InsightsRequestIdKey) != "" {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -82,7 +82,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			id = xRhIdentity
 		}
 
-		c.Set(h.ParsedIdentityKey, id)
+		c.Set(h.ParsedIdentity, id)
 
 		return next(c)
 	}

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -39,8 +39,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.OrgId, c.Request().Header.Get(h.OrgId))
 		}
 
-		if c.Request().Header.Get(h.XrhUserIdKey) != "" {
-			c.Set(h.XrhUserIdKey, c.Request().Header.Get(h.XrhUserIdKey))
+		if c.Request().Header.Get(h.XrhUserId) != "" {
+			c.Set(h.XrhUserId, c.Request().Header.Get(h.XrhUserId))
 		}
 
 		if c.Request().Header.Get(h.InsightsRequestIdKey) != "" {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -39,8 +39,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.OrgIdKey, c.Request().Header.Get(h.OrgIdKey))
 		}
 
-		if c.Request().Header.Get(h.PSK_USER) != "" {
-			c.Set(h.PSK_USER, c.Request().Header.Get(h.PSK_USER))
+		if c.Request().Header.Get(h.UserIdKey) != "" {
+			c.Set(h.UserIdKey, c.Request().Header.Get(h.UserIdKey))
 		}
 
 		if c.Request().Header.Get(h.INSIGHTS_REQUEST_ID) != "" {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -51,12 +51,12 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		// received, generate an identity struct from the given "OrgId" and "EBS account number". If the "x-rh-identity"
 		// header is present, simply decode it and use the decided identity.
 		var id *identity.XRHID
-		xRhIdentityRaw := c.Request().Header.Get(h.IdentityKey)
+		xRhIdentityRaw := c.Request().Header.Get(h.Identity)
 		if xRhIdentityRaw == "" {
 			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumber), c.Request().Header.Get(h.OrgId))
 
 			// Store the raw, base64 encoded "xRhIdentity" string.
-			c.Set(h.IdentityKey, generatedIdentity)
+			c.Set(h.Identity, generatedIdentity)
 
 			// Generate the identity which we will store in the context.
 			genId, err := util.ParseXRHIDHeader(generatedIdentity)
@@ -72,7 +72,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 
 			// Store the raw identity header to forward it latter.
-			c.Set(h.IdentityKey, xRhIdentityRaw)
+			c.Set(h.Identity, xRhIdentityRaw)
 
 			// Store whether this a cert-auth based request.
 			if xRhIdentity.Identity.System.CommonName != "" {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -43,8 +43,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.XrhUserId, c.Request().Header.Get(h.XrhUserId))
 		}
 
-		if c.Request().Header.Get(h.InsightsRequestIdKey) != "" {
-			c.Set(h.InsightsRequestIdKey, c.Request().Header.Get(h.InsightsRequestIdKey))
+		if c.Request().Header.Get(h.InsightsRequestId) != "" {
+			c.Set(h.InsightsRequestId, c.Request().Header.Get(h.InsightsRequestId))
 		}
 
 		// id is the XrhId struct we will store in the context. The idea is: if no "x-rh-identity" header has been

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -35,8 +35,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.AccountNumberKey, c.Request().Header.Get(h.AccountNumberKey))
 		}
 
-		if c.Request().Header.Get(h.ORGID) != "" {
-			c.Set(h.ORGID, c.Request().Header.Get(h.ORGID))
+		if c.Request().Header.Get(h.OrgIdKey) != "" {
+			c.Set(h.OrgIdKey, c.Request().Header.Get(h.OrgIdKey))
 		}
 
 		if c.Request().Header.Get(h.PSK_USER) != "" {
@@ -53,7 +53,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		var id *identity.XRHID
 		xRhIdentityRaw := c.Request().Header.Get(h.XRHID)
 		if xRhIdentityRaw == "" {
-			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumberKey), c.Request().Header.Get(h.ORGID))
+			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumberKey), c.Request().Header.Get(h.OrgIdKey))
 
 			// Store the raw, base64 encoded "xRhIdentity" string.
 			c.Set(h.XRHID, generatedIdentity)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -43,8 +43,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.UserIdKey, c.Request().Header.Get(h.UserIdKey))
 		}
 
-		if c.Request().Header.Get(h.INSIGHTS_REQUEST_ID) != "" {
-			c.Set(h.INSIGHTS_REQUEST_ID, c.Request().Header.Get(h.INSIGHTS_REQUEST_ID))
+		if c.Request().Header.Get(h.InsightsRequestIdKey) != "" {
+			c.Set(h.InsightsRequestIdKey, c.Request().Header.Get(h.InsightsRequestIdKey))
 		}
 
 		// id is the XrhId struct we will store in the context. The idea is: if no "x-rh-identity" header has been

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -51,12 +51,12 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		// received, generate an identity struct from the given "OrgId" and "EBS account number". If the "x-rh-identity"
 		// header is present, simply decode it and use the decided identity.
 		var id *identity.XRHID
-		xRhIdentityRaw := c.Request().Header.Get(h.XRHID)
+		xRhIdentityRaw := c.Request().Header.Get(h.IdentityKey)
 		if xRhIdentityRaw == "" {
 			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumberKey), c.Request().Header.Get(h.OrgIdKey))
 
 			// Store the raw, base64 encoded "xRhIdentity" string.
-			c.Set(h.XRHID, generatedIdentity)
+			c.Set(h.IdentityKey, generatedIdentity)
 
 			// Generate the identity which we will store in the context.
 			genId, err := util.ParseXRHIDHeader(generatedIdentity)
@@ -72,7 +72,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			}
 
 			// Store the raw identity header to forward it latter.
-			c.Set(h.XRHID, xRhIdentityRaw)
+			c.Set(h.IdentityKey, xRhIdentityRaw)
 
 			// Store whether this a cert-auth based request.
 			if xRhIdentity.Identity.System.CommonName != "" {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -31,8 +31,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.PskKey, c.Request().Header.Get(h.PskKey))
 		}
 
-		if c.Request().Header.Get(h.ACCOUNT_NUMBER) != "" {
-			c.Set(h.ACCOUNT_NUMBER, c.Request().Header.Get(h.ACCOUNT_NUMBER))
+		if c.Request().Header.Get(h.AccountNumberKey) != "" {
+			c.Set(h.AccountNumberKey, c.Request().Header.Get(h.AccountNumberKey))
 		}
 
 		if c.Request().Header.Get(h.ORGID) != "" {
@@ -53,7 +53,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		var id *identity.XRHID
 		xRhIdentityRaw := c.Request().Header.Get(h.XRHID)
 		if xRhIdentityRaw == "" {
-			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.ACCOUNT_NUMBER), c.Request().Header.Get(h.ORGID))
+			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumberKey), c.Request().Header.Get(h.ORGID))
 
 			// Store the raw, base64 encoded "xRhIdentity" string.
 			c.Set(h.XRHID, generatedIdentity)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -27,8 +27,8 @@ import (
 func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// the PSK related headers - just storing them as raw strings.
-		if c.Request().Header.Get(h.PskKey) != "" {
-			c.Set(h.PskKey, c.Request().Header.Get(h.PskKey))
+		if c.Request().Header.Get(h.Psk) != "" {
+			c.Set(h.Psk, c.Request().Header.Get(h.Psk))
 		}
 
 		if c.Request().Header.Get(h.AccountNumberKey) != "" {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -31,8 +31,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.Psk, c.Request().Header.Get(h.Psk))
 		}
 
-		if c.Request().Header.Get(h.AccountNumberKey) != "" {
-			c.Set(h.AccountNumberKey, c.Request().Header.Get(h.AccountNumberKey))
+		if c.Request().Header.Get(h.AccountNumber) != "" {
+			c.Set(h.AccountNumber, c.Request().Header.Get(h.AccountNumber))
 		}
 
 		if c.Request().Header.Get(h.OrgIdKey) != "" {
@@ -53,7 +53,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		var id *identity.XRHID
 		xRhIdentityRaw := c.Request().Header.Get(h.IdentityKey)
 		if xRhIdentityRaw == "" {
-			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumberKey), c.Request().Header.Get(h.OrgIdKey))
+			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumber), c.Request().Header.Get(h.OrgIdKey))
 
 			// Store the raw, base64 encoded "xRhIdentity" string.
 			c.Set(h.IdentityKey, generatedIdentity)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -35,8 +35,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.AccountNumber, c.Request().Header.Get(h.AccountNumber))
 		}
 
-		if c.Request().Header.Get(h.OrgIdKey) != "" {
-			c.Set(h.OrgIdKey, c.Request().Header.Get(h.OrgIdKey))
+		if c.Request().Header.Get(h.OrgId) != "" {
+			c.Set(h.OrgId, c.Request().Header.Get(h.OrgId))
 		}
 
 		if c.Request().Header.Get(h.XrhUserIdKey) != "" {
@@ -53,7 +53,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		var id *identity.XRHID
 		xRhIdentityRaw := c.Request().Header.Get(h.IdentityKey)
 		if xRhIdentityRaw == "" {
-			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumber), c.Request().Header.Get(h.OrgIdKey))
+			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumber), c.Request().Header.Get(h.OrgId))
 
 			// Store the raw, base64 encoded "xRhIdentity" string.
 			c.Set(h.IdentityKey, generatedIdentity)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -82,7 +82,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			id = xRhIdentity
 		}
 
-		c.Set(h.PARSED_IDENTITY, id)
+		c.Set(h.ParsedIdentityKey, id)
 
 		return next(c)
 	}

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -1,7 +1,7 @@
 package headers
 
 const (
-	PskKey               = "x-rh-sources-psk"
+	Psk                  = "x-rh-sources-psk"
 	AccountNumberKey     = "x-rh-sources-account-number"
 	OrgIdKey             = "x-rh-sources-org-id"
 	XrhUserIdKey         = "x-rh-sources-user-id"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -7,7 +7,7 @@ const (
 	XrhUserId         = "x-rh-sources-user-id"
 	Identity          = "x-rh-identity"
 	InsightsRequestId = "x-rh-insights-request-id"
-	ParsedIdentityKey = "identity"
+	ParsedIdentity    = "identity"
 	TenantIdKey       = "tenantID"
 	UserIdKey         = "userID"
 )

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -4,7 +4,7 @@ const (
 	PskKey              = "x-rh-sources-psk"
 	AccountNumberKey    = "x-rh-sources-account-number"
 	OrgIdKey            = "x-rh-sources-org-id"
-	PSK_USER            = "x-rh-sources-user-id"
+	UserIdKey           = "x-rh-sources-user-id"
 	XRHID               = "x-rh-identity"
 	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"
 	PARSED_IDENTITY     = "identity"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -8,6 +8,6 @@ const (
 	IdentityKey          = "x-rh-identity"
 	InsightsRequestIdKey = "x-rh-insights-request-id"
 	ParsedIdentityKey    = "identity"
-	TENANTID             = "tenantID"
+	TenantIdKey          = "tenantID"
 	USERID               = "userID"
 )

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -3,7 +3,7 @@ package headers
 const (
 	PskKey              = "x-rh-sources-psk"
 	AccountNumberKey    = "x-rh-sources-account-number"
-	ORGID               = "x-rh-sources-org-id"
+	OrgIdKey            = "x-rh-sources-org-id"
 	PSK_USER            = "x-rh-sources-user-id"
 	XRHID               = "x-rh-identity"
 	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -2,7 +2,7 @@ package headers
 
 const (
 	Psk                  = "x-rh-sources-psk"
-	AccountNumberKey     = "x-rh-sources-account-number"
+	AccountNumber        = "x-rh-sources-account-number"
 	OrgIdKey             = "x-rh-sources-org-id"
 	XrhUserIdKey         = "x-rh-sources-user-id"
 	IdentityKey          = "x-rh-identity"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -5,7 +5,7 @@ const (
 	AccountNumberKey    = "x-rh-sources-account-number"
 	OrgIdKey            = "x-rh-sources-org-id"
 	UserIdKey           = "x-rh-sources-user-id"
-	XRHID               = "x-rh-identity"
+	IdentityKey         = "x-rh-identity"
 	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"
 	PARSED_IDENTITY     = "identity"
 	TENANTID            = "tenantID"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -5,7 +5,7 @@ const (
 	AccountNumber        = "x-rh-sources-account-number"
 	OrgId                = "x-rh-sources-org-id"
 	XrhUserId            = "x-rh-sources-user-id"
-	IdentityKey          = "x-rh-identity"
+	Identity             = "x-rh-identity"
 	InsightsRequestIdKey = "x-rh-insights-request-id"
 	ParsedIdentityKey    = "identity"
 	TenantIdKey          = "tenantID"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -9,5 +9,5 @@ const (
 	InsightsRequestId = "x-rh-insights-request-id"
 	ParsedIdentity    = "identity"
 	TenantId          = "tenantID"
-	UserIdKey         = "userID"
+	UserId            = "userID"
 )

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -1,13 +1,13 @@
 package headers
 
 const (
-	PskKey              = "x-rh-sources-psk"
-	AccountNumberKey    = "x-rh-sources-account-number"
-	OrgIdKey            = "x-rh-sources-org-id"
-	UserIdKey           = "x-rh-sources-user-id"
-	IdentityKey         = "x-rh-identity"
-	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"
-	PARSED_IDENTITY     = "identity"
-	TENANTID            = "tenantID"
-	USERID              = "userID"
+	PskKey               = "x-rh-sources-psk"
+	AccountNumberKey     = "x-rh-sources-account-number"
+	OrgIdKey             = "x-rh-sources-org-id"
+	UserIdKey            = "x-rh-sources-user-id"
+	IdentityKey          = "x-rh-identity"
+	InsightsRequestIdKey = "x-rh-insights-request-id"
+	PARSED_IDENTITY      = "identity"
+	TENANTID             = "tenantID"
+	USERID               = "userID"
 )

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -7,7 +7,7 @@ const (
 	UserIdKey            = "x-rh-sources-user-id"
 	IdentityKey          = "x-rh-identity"
 	InsightsRequestIdKey = "x-rh-insights-request-id"
-	PARSED_IDENTITY      = "identity"
+	ParsedIdentityKey    = "identity"
 	TENANTID             = "tenantID"
 	USERID               = "userID"
 )

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -4,7 +4,7 @@ const (
 	PskKey               = "x-rh-sources-psk"
 	AccountNumberKey     = "x-rh-sources-account-number"
 	OrgIdKey             = "x-rh-sources-org-id"
-	UserIdKey            = "x-rh-sources-user-id"
+	XrhUserIdKey         = "x-rh-sources-user-id"
 	IdentityKey          = "x-rh-identity"
 	InsightsRequestIdKey = "x-rh-insights-request-id"
 	ParsedIdentityKey    = "identity"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -8,6 +8,6 @@ const (
 	Identity          = "x-rh-identity"
 	InsightsRequestId = "x-rh-insights-request-id"
 	ParsedIdentity    = "identity"
-	TenantIdKey       = "tenantID"
+	TenantId          = "tenantID"
 	UserIdKey         = "userID"
 )

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -9,5 +9,5 @@ const (
 	InsightsRequestIdKey = "x-rh-insights-request-id"
 	ParsedIdentityKey    = "identity"
 	TenantIdKey          = "tenantID"
-	USERID               = "userID"
+	UserIdKey            = "userID"
 )

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -3,7 +3,7 @@ package headers
 const (
 	Psk                  = "x-rh-sources-psk"
 	AccountNumber        = "x-rh-sources-account-number"
-	OrgIdKey             = "x-rh-sources-org-id"
+	OrgId                = "x-rh-sources-org-id"
 	XrhUserIdKey         = "x-rh-sources-user-id"
 	IdentityKey          = "x-rh-identity"
 	InsightsRequestIdKey = "x-rh-insights-request-id"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -1,13 +1,13 @@
 package headers
 
 const (
-	Psk                  = "x-rh-sources-psk"
-	AccountNumber        = "x-rh-sources-account-number"
-	OrgId                = "x-rh-sources-org-id"
-	XrhUserId            = "x-rh-sources-user-id"
-	Identity             = "x-rh-identity"
-	InsightsRequestIdKey = "x-rh-insights-request-id"
-	ParsedIdentityKey    = "identity"
-	TenantIdKey          = "tenantID"
-	UserIdKey            = "userID"
+	Psk               = "x-rh-sources-psk"
+	AccountNumber     = "x-rh-sources-account-number"
+	OrgId             = "x-rh-sources-org-id"
+	XrhUserId         = "x-rh-sources-user-id"
+	Identity          = "x-rh-identity"
+	InsightsRequestId = "x-rh-insights-request-id"
+	ParsedIdentityKey = "identity"
+	TenantIdKey       = "tenantID"
+	UserIdKey         = "userID"
 )

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -1,7 +1,7 @@
 package headers
 
 const (
-	PSK                 = "x-rh-sources-psk"
+	PskKey              = "x-rh-sources-psk"
 	ACCOUNT_NUMBER      = "x-rh-sources-account-number"
 	ORGID               = "x-rh-sources-org-id"
 	PSK_USER            = "x-rh-sources-user-id"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -2,7 +2,7 @@ package headers
 
 const (
 	PskKey              = "x-rh-sources-psk"
-	ACCOUNT_NUMBER      = "x-rh-sources-account-number"
+	AccountNumberKey    = "x-rh-sources-account-number"
 	ORGID               = "x-rh-sources-org-id"
 	PSK_USER            = "x-rh-sources-user-id"
 	XRHID               = "x-rh-identity"

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -4,7 +4,7 @@ const (
 	Psk                  = "x-rh-sources-psk"
 	AccountNumber        = "x-rh-sources-account-number"
 	OrgId                = "x-rh-sources-org-id"
-	XrhUserIdKey         = "x-rh-sources-user-id"
+	XrhUserId            = "x-rh-sources-user-id"
 	IdentityKey          = "x-rh-identity"
 	InsightsRequestIdKey = "x-rh-insights-request-id"
 	ParsedIdentityKey    = "identity"

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -29,7 +29,7 @@ func TestParseAll(t *testing.T) {
 
 	c.Request().Header.Set(h.IdentityKey, xrhid)
 	c.Request().Header.Set(h.Psk, "test-psk")
-	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
+	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
 	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
 	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
 
@@ -46,8 +46,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get(h.Psk).(string), "test-psk")
 	}
 
-	if c.Get(h.AccountNumberKey).(string) != "test-ebs-account-number" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "test-ebs-account-number")
+	if c.Get(h.AccountNumber).(string) != "test-ebs-account-number" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "test-ebs-account-number")
 	}
 
 	if c.Get(h.XrhUserIdKey).(string) != "test-psk-user" {
@@ -83,7 +83,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 	)
 
 	c.Request().Header.Set(h.Psk, "test-psk")
-	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
+	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
 	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
 	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
 
@@ -100,8 +100,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get(h.Psk).(string), "test-psk")
 	}
 
-	if c.Get(h.AccountNumberKey).(string) != "test-ebs-account-number" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "test-ebs-account-number")
+	if c.Get(h.AccountNumber).(string) != "test-ebs-account-number" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "test-ebs-account-number")
 	}
 
 	if c.Get(h.XrhUserIdKey).(string) != "test-psk-user" {
@@ -134,7 +134,7 @@ func TestParseAccountNumber(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.AccountNumberKey, "9876")
+	c.Request().Header.Set(h.AccountNumber, "9876")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -145,8 +145,8 @@ func TestParseAccountNumber(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.AccountNumberKey).(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "9876")
+	if c.Get(h.AccountNumber).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "9876")
 	}
 }
 
@@ -210,7 +210,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 	)
 
 	c.Request().Header.Set(h.Psk, "1234")
-	c.Request().Header.Set(h.AccountNumberKey, "9876")
+	c.Request().Header.Set(h.AccountNumber, "9876")
 	c.Request().Header.Set(h.XrhUserIdKey, "555555")
 
 	err := parseOrElse204(c)
@@ -226,8 +226,8 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
 	}
 
-	if c.Get(h.AccountNumberKey).(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "9876")
+	if c.Get(h.AccountNumber).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "9876")
 	}
 
 	if c.Get(h.XrhUserIdKey).(string) != "555555" {

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -27,7 +27,7 @@ func TestParseAll(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.IdentityKey, xrhid)
+	c.Request().Header.Set(h.Identity, xrhid)
 	c.Request().Header.Set(h.Psk, "test-psk")
 	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
 	c.Request().Header.Set(h.XrhUserId, "test-psk-user")
@@ -158,7 +158,7 @@ func TestBadIdentityBase64(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.IdentityKey, "not valid base64")
+	c.Request().Header.Set(h.Identity, "not valid base64")
 
 	err := parseOrElse204(c)
 	if err == nil {
@@ -184,7 +184,7 @@ func TestBadIdentityJson(t *testing.T) {
 	)
 
 	// base64 for: {"not a real field": true}
-	c.Request().Header.Set(h.IdentityKey, "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
+	c.Request().Header.Set(h.Identity, "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
 
 	err := parseOrElse204(c)
 	if err == nil {

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -30,7 +30,7 @@ func TestParseAll(t *testing.T) {
 	c.Request().Header.Set(h.IdentityKey, xrhid)
 	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
-	c.Request().Header.Set(h.UserIdKey, "test-psk-user")
+	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
 	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
 
 	err := parseOrElse204(c)
@@ -50,8 +50,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "test-ebs-account-number")
 	}
 
-	if c.Get(h.UserIdKey).(string) != "test-psk-user" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.UserIdKey).(string), "test-psk-user")
+	if c.Get(h.XrhUserIdKey).(string) != "test-psk-user" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserIdKey).(string), "test-psk-user")
 	}
 
 	if c.Get(h.OrgIdKey).(string) != "test-orgid" {
@@ -84,7 +84,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 
 	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
-	c.Request().Header.Set(h.UserIdKey, "test-psk-user")
+	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
 	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
 
 	err := parseOrElse204(c)
@@ -104,8 +104,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "test-ebs-account-number")
 	}
 
-	if c.Get(h.UserIdKey).(string) != "test-psk-user" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.UserIdKey).(string), "test-psk-user")
+	if c.Get(h.XrhUserIdKey).(string) != "test-psk-user" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserIdKey).(string), "test-psk-user")
 	}
 
 	if c.Get(h.OrgIdKey).(string) != "test-orgid" {
@@ -211,7 +211,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 
 	c.Request().Header.Set(h.PskKey, "1234")
 	c.Request().Header.Set(h.AccountNumberKey, "9876")
-	c.Request().Header.Set(h.UserIdKey, "555555")
+	c.Request().Header.Set(h.XrhUserIdKey, "555555")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -230,7 +230,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "9876")
 	}
 
-	if c.Get(h.UserIdKey).(string) != "555555" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.UserIdKey).(string), "555555")
+	if c.Get(h.XrhUserIdKey).(string) != "555555" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserIdKey).(string), "555555")
 	}
 }

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -27,7 +27,7 @@ func TestParseAll(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.XRHID, xrhid)
+	c.Request().Header.Set(h.IdentityKey, xrhid)
 	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
 	c.Request().Header.Set(h.UserIdKey, "test-psk-user")
@@ -158,7 +158,7 @@ func TestBadIdentityBase64(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.XRHID, "not valid base64")
+	c.Request().Header.Set(h.IdentityKey, "not valid base64")
 
 	err := parseOrElse204(c)
 	if err == nil {
@@ -184,7 +184,7 @@ func TestBadIdentityJson(t *testing.T) {
 	)
 
 	// base64 for: {"not a real field": true}
-	c.Request().Header.Set(h.XRHID, "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
+	c.Request().Header.Set(h.IdentityKey, "eyJub3QgYSByZWFsIGZpZWxkIjogdHJ1ZX0gLW4K")
 
 	err := parseOrElse204(c)
 	if err == nil {

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -31,7 +31,7 @@ func TestParseAll(t *testing.T) {
 	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
-	c.Request().Header.Set(h.ORGID, "test-orgid")
+	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -54,8 +54,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "test-psk-user")
 	}
 
-	if c.Get(h.ORGID).(string) != "test-orgid" {
-		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.ORGID).(string))
+	if c.Get(h.OrgIdKey).(string) != "test-orgid" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgIdKey).(string))
 	}
 
 	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
@@ -85,7 +85,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
-	c.Request().Header.Set(h.ORGID, "test-orgid")
+	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -108,8 +108,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "test-psk-user")
 	}
 
-	if c.Get(h.ORGID).(string) != "test-orgid" {
-		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.ORGID).(string))
+	if c.Get(h.OrgIdKey).(string) != "test-orgid" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgIdKey).(string))
 	}
 
 	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -28,7 +28,7 @@ func TestParseAll(t *testing.T) {
 	)
 
 	c.Request().Header.Set(h.IdentityKey, xrhid)
-	c.Request().Header.Set(h.PskKey, "test-psk")
+	c.Request().Header.Set(h.Psk, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
 	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
 	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
@@ -42,8 +42,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.PskKey).(string) != "test-psk" {
-		t.Errorf("%v was set as psk instead of %v", c.Get(h.PskKey).(string), "test-psk")
+	if c.Get(h.Psk).(string) != "test-psk" {
+		t.Errorf("%v was set as psk instead of %v", c.Get(h.Psk).(string), "test-psk")
 	}
 
 	if c.Get(h.AccountNumberKey).(string) != "test-ebs-account-number" {
@@ -82,7 +82,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.PskKey, "test-psk")
+	c.Request().Header.Set(h.Psk, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
 	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
 	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
@@ -96,8 +96,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.PskKey).(string) != "test-psk" {
-		t.Errorf("%v was set as psk instead of %v", c.Get(h.PskKey).(string), "test-psk")
+	if c.Get(h.Psk).(string) != "test-psk" {
+		t.Errorf("%v was set as psk instead of %v", c.Get(h.Psk).(string), "test-psk")
 	}
 
 	if c.Get(h.AccountNumberKey).(string) != "test-ebs-account-number" {
@@ -209,7 +209,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.PskKey, "1234")
+	c.Request().Header.Set(h.Psk, "1234")
 	c.Request().Header.Set(h.AccountNumberKey, "9876")
 	c.Request().Header.Set(h.XrhUserIdKey, "555555")
 
@@ -222,7 +222,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.PskKey).(string) != "1234" {
+	if c.Get(h.Psk).(string) != "1234" {
 		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
 	}
 

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -58,9 +58,9 @@ func TestParseAll(t *testing.T) {
 		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgId).(string))
 	}
 
-	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
-		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get(h.ParsedIdentityKey)))
+		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get(h.ParsedIdentity)))
 	}
 
 	if id.Identity.AccountNumber != "12345" {
@@ -112,9 +112,9 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgId).(string))
 	}
 
-	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
-		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get(h.ParsedIdentityKey)))
+		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get(h.ParsedIdentity)))
 	}
 
 	if id.Identity.AccountNumber != "test-ebs-account-number" {

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -29,7 +29,7 @@ func TestParseAll(t *testing.T) {
 
 	c.Request().Header.Set(h.XRHID, xrhid)
 	c.Request().Header.Set(h.PskKey, "test-psk")
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
+	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
 	c.Request().Header.Set(h.ORGID, "test-orgid")
 
@@ -46,8 +46,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get(h.PskKey).(string), "test-psk")
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "test-ebs-account-number" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "test-ebs-account-number")
+	if c.Get(h.AccountNumberKey).(string) != "test-ebs-account-number" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "test-ebs-account-number")
 	}
 
 	if c.Get(h.PSK_USER).(string) != "test-psk-user" {
@@ -83,7 +83,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 	)
 
 	c.Request().Header.Set(h.PskKey, "test-psk")
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
+	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
 	c.Request().Header.Set(h.ORGID, "test-orgid")
 
@@ -100,8 +100,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get(h.PskKey).(string), "test-psk")
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "test-ebs-account-number" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "test-ebs-account-number")
+	if c.Get(h.AccountNumberKey).(string) != "test-ebs-account-number" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "test-ebs-account-number")
 	}
 
 	if c.Get(h.PSK_USER).(string) != "test-psk-user" {
@@ -134,7 +134,7 @@ func TestParseAccountNumber(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
+	c.Request().Header.Set(h.AccountNumberKey, "9876")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -145,8 +145,8 @@ func TestParseAccountNumber(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+	if c.Get(h.AccountNumberKey).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "9876")
 	}
 }
 
@@ -210,7 +210,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 	)
 
 	c.Request().Header.Set(h.PskKey, "1234")
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
+	c.Request().Header.Set(h.AccountNumberKey, "9876")
 	c.Request().Header.Set(h.PSK_USER, "555555")
 
 	err := parseOrElse204(c)
@@ -226,8 +226,8 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+	if c.Get(h.AccountNumberKey).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "9876")
 	}
 
 	if c.Get(h.PSK_USER).(string) != "555555" {

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -60,7 +60,7 @@ func TestParseAll(t *testing.T) {
 
 	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 	if !ok {
-		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
+		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get(h.ParsedIdentityKey)))
 	}
 
 	if id.Identity.AccountNumber != "12345" {
@@ -114,7 +114,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 
 	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 	if !ok {
-		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
+		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get(h.ParsedIdentityKey)))
 	}
 
 	if id.Identity.AccountNumber != "test-ebs-account-number" {

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -31,7 +31,7 @@ func TestParseAll(t *testing.T) {
 	c.Request().Header.Set(h.Psk, "test-psk")
 	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
 	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
-	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
+	c.Request().Header.Set(h.OrgId, "test-orgid")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -54,8 +54,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserIdKey).(string), "test-psk-user")
 	}
 
-	if c.Get(h.OrgIdKey).(string) != "test-orgid" {
-		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgIdKey).(string))
+	if c.Get(h.OrgId).(string) != "test-orgid" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgId).(string))
 	}
 
 	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
@@ -85,7 +85,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 	c.Request().Header.Set(h.Psk, "test-psk")
 	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
 	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
-	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
+	c.Request().Header.Set(h.OrgId, "test-orgid")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -108,8 +108,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserIdKey).(string), "test-psk-user")
 	}
 
-	if c.Get(h.OrgIdKey).(string) != "test-orgid" {
-		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgIdKey).(string))
+	if c.Get(h.OrgId).(string) != "test-orgid" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgId).(string))
 	}
 
 	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -28,7 +28,7 @@ func TestParseAll(t *testing.T) {
 	)
 
 	c.Request().Header.Set(h.XRHID, xrhid)
-	c.Request().Header.Set(h.PSK, "test-psk")
+	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
 	c.Request().Header.Set(h.ORGID, "test-orgid")
@@ -42,8 +42,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.PSK).(string) != "test-psk" {
-		t.Errorf("%v was set as psk instead of %v", c.Get(h.PSK).(string), "test-psk")
+	if c.Get(h.PskKey).(string) != "test-psk" {
+		t.Errorf("%v was set as psk instead of %v", c.Get(h.PskKey).(string), "test-psk")
 	}
 
 	if c.Get(h.ACCOUNT_NUMBER).(string) != "test-ebs-account-number" {
@@ -82,7 +82,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.PSK, "test-psk")
+	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
 	c.Request().Header.Set(h.ORGID, "test-orgid")
@@ -96,8 +96,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.PSK).(string) != "test-psk" {
-		t.Errorf("%v was set as psk instead of %v", c.Get(h.PSK).(string), "test-psk")
+	if c.Get(h.PskKey).(string) != "test-psk" {
+		t.Errorf("%v was set as psk instead of %v", c.Get(h.PskKey).(string), "test-psk")
 	}
 
 	if c.Get(h.ACCOUNT_NUMBER).(string) != "test-ebs-account-number" {
@@ -209,7 +209,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.PSK, "1234")
+	c.Request().Header.Set(h.PskKey, "1234")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
 	c.Request().Header.Set(h.PSK_USER, "555555")
 
@@ -222,7 +222,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.PSK).(string) != "1234" {
+	if c.Get(h.PskKey).(string) != "1234" {
 		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
 	}
 

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -30,7 +30,7 @@ func TestParseAll(t *testing.T) {
 	c.Request().Header.Set(h.IdentityKey, xrhid)
 	c.Request().Header.Set(h.Psk, "test-psk")
 	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
-	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
+	c.Request().Header.Set(h.XrhUserId, "test-psk-user")
 	c.Request().Header.Set(h.OrgId, "test-orgid")
 
 	err := parseOrElse204(c)
@@ -50,8 +50,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "test-ebs-account-number")
 	}
 
-	if c.Get(h.XrhUserIdKey).(string) != "test-psk-user" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserIdKey).(string), "test-psk-user")
+	if c.Get(h.XrhUserId).(string) != "test-psk-user" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserId).(string), "test-psk-user")
 	}
 
 	if c.Get(h.OrgId).(string) != "test-orgid" {
@@ -84,7 +84,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 
 	c.Request().Header.Set(h.Psk, "test-psk")
 	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
-	c.Request().Header.Set(h.XrhUserIdKey, "test-psk-user")
+	c.Request().Header.Set(h.XrhUserId, "test-psk-user")
 	c.Request().Header.Set(h.OrgId, "test-orgid")
 
 	err := parseOrElse204(c)
@@ -104,8 +104,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "test-ebs-account-number")
 	}
 
-	if c.Get(h.XrhUserIdKey).(string) != "test-psk-user" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserIdKey).(string), "test-psk-user")
+	if c.Get(h.XrhUserId).(string) != "test-psk-user" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserId).(string), "test-psk-user")
 	}
 
 	if c.Get(h.OrgId).(string) != "test-orgid" {
@@ -211,7 +211,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 
 	c.Request().Header.Set(h.Psk, "1234")
 	c.Request().Header.Set(h.AccountNumber, "9876")
-	c.Request().Header.Set(h.XrhUserIdKey, "555555")
+	c.Request().Header.Set(h.XrhUserId, "555555")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -230,7 +230,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "9876")
 	}
 
-	if c.Get(h.XrhUserIdKey).(string) != "555555" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserIdKey).(string), "555555")
+	if c.Get(h.XrhUserId).(string) != "555555" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.XrhUserId).(string), "555555")
 	}
 }

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -58,7 +58,7 @@ func TestParseAll(t *testing.T) {
 		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgIdKey).(string))
 	}
 
-	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 	if !ok {
 		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
 	}
@@ -112,7 +112,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgIdKey).(string))
 	}
 
-	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 	if !ok {
 		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
 	}

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -30,7 +30,7 @@ func TestParseAll(t *testing.T) {
 	c.Request().Header.Set(h.XRHID, xrhid)
 	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
-	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
+	c.Request().Header.Set(h.UserIdKey, "test-psk-user")
 	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
 
 	err := parseOrElse204(c)
@@ -50,8 +50,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "test-ebs-account-number")
 	}
 
-	if c.Get(h.PSK_USER).(string) != "test-psk-user" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "test-psk-user")
+	if c.Get(h.UserIdKey).(string) != "test-psk-user" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.UserIdKey).(string), "test-psk-user")
 	}
 
 	if c.Get(h.OrgIdKey).(string) != "test-orgid" {
@@ -84,7 +84,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 
 	c.Request().Header.Set(h.PskKey, "test-psk")
 	c.Request().Header.Set(h.AccountNumberKey, "test-ebs-account-number")
-	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
+	c.Request().Header.Set(h.UserIdKey, "test-psk-user")
 	c.Request().Header.Set(h.OrgIdKey, "test-orgid")
 
 	err := parseOrElse204(c)
@@ -104,8 +104,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "test-ebs-account-number")
 	}
 
-	if c.Get(h.PSK_USER).(string) != "test-psk-user" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "test-psk-user")
+	if c.Get(h.UserIdKey).(string) != "test-psk-user" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.UserIdKey).(string), "test-psk-user")
 	}
 
 	if c.Get(h.OrgIdKey).(string) != "test-orgid" {
@@ -211,7 +211,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 
 	c.Request().Header.Set(h.PskKey, "1234")
 	c.Request().Header.Set(h.AccountNumberKey, "9876")
-	c.Request().Header.Set(h.PSK_USER, "555555")
+	c.Request().Header.Set(h.UserIdKey, "555555")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -230,7 +230,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumberKey).(string), "9876")
 	}
 
-	if c.Get(h.PSK_USER).(string) != "555555" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "555555")
+	if c.Get(h.UserIdKey).(string) != "555555" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.UserIdKey).(string), "555555")
 	}
 }

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -16,7 +16,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		agent := c.Request().UserAgent()
 		acct := c.Get(h.AccountNumberKey)
 		orgid := c.Get(h.OrgIdKey)
-		uuid := c.Get(h.INSIGHTS_REQUEST_ID)
+		uuid := c.Get(h.InsightsRequestIdKey)
 
 		baseFields := logrus.Fields{
 			"uri":            uri,

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -14,7 +14,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		uri := c.Request().RequestURI
 		method := c.Request().Method
 		agent := c.Request().UserAgent()
-		acct := c.Get(h.ACCOUNT_NUMBER)
+		acct := c.Get(h.AccountNumberKey)
 		orgid := c.Get(h.ORGID)
 		uuid := c.Get(h.INSIGHTS_REQUEST_ID)
 

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -15,7 +15,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		method := c.Request().Method
 		agent := c.Request().UserAgent()
 		acct := c.Get(h.AccountNumberKey)
-		orgid := c.Get(h.ORGID)
+		orgid := c.Get(h.OrgIdKey)
 		uuid := c.Get(h.INSIGHTS_REQUEST_ID)
 
 		baseFields := logrus.Fields{

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -14,7 +14,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		uri := c.Request().RequestURI
 		method := c.Request().Method
 		agent := c.Request().UserAgent()
-		acct := c.Get(h.AccountNumberKey)
+		acct := c.Get(h.AccountNumber)
 		orgid := c.Get(h.OrgIdKey)
 		uuid := c.Get(h.InsightsRequestIdKey)
 

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -15,7 +15,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		method := c.Request().Method
 		agent := c.Request().UserAgent()
 		acct := c.Get(h.AccountNumber)
-		orgid := c.Get(h.OrgIdKey)
+		orgid := c.Get(h.OrgId)
 		uuid := c.Get(h.InsightsRequestIdKey)
 
 		baseFields := logrus.Fields{

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -16,7 +16,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		agent := c.Request().UserAgent()
 		acct := c.Get(h.AccountNumber)
 		orgid := c.Get(h.OrgId)
-		uuid := c.Get(h.InsightsRequestIdKey)
+		uuid := c.Get(h.InsightsRequestId)
 
 		baseFields := logrus.Fields{
 			"uri":            uri,

--- a/middleware/notifier.go
+++ b/middleware/notifier.go
@@ -21,7 +21,7 @@ func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
 			return fmt.Errorf("unable to find emailNotificationInfo instance in middleware")
 		}
 
-		xRhIdentity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+		xRhIdentity, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 		if !ok {
 			return fmt.Errorf("failed to fetch the identity header")
 		}

--- a/middleware/notifier.go
+++ b/middleware/notifier.go
@@ -21,7 +21,7 @@ func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
 			return fmt.Errorf("unable to find emailNotificationInfo instance in middleware")
 		}
 
-		xRhIdentity, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
+		xRhIdentity, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 		if !ok {
 			return fmt.Errorf("failed to fetch the identity header")
 		}

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -23,7 +23,7 @@ import (
 */
 func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TenantIdKey).(int64)
+		tenantId, ok := c.Get(h.TenantId).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
@@ -68,7 +68,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 
 func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TenantIdKey).(int64)
+		tenantId, ok := c.Get(h.TenantId).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -41,7 +41,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 		s := dao.GetSourceDao(requestParams)
 
 		if s.IsSuperkey(id) {
-			xrhid, ok := c.Get(h.IdentityKey).(string)
+			xrhid, ok := c.Get(h.Identity).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}
@@ -86,7 +86,7 @@ func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 		a := dao.GetApplicationDao(requestParams)
 
 		if a.IsSuperkey(id) {
-			xrhid, ok := c.Get(h.IdentityKey).(string)
+			xrhid, ok := c.Get(h.Identity).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -41,7 +41,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 		s := dao.GetSourceDao(requestParams)
 
 		if s.IsSuperkey(id) {
-			xrhid, ok := c.Get(h.XRHID).(string)
+			xrhid, ok := c.Get(h.IdentityKey).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}
@@ -86,7 +86,7 @@ func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 		a := dao.GetApplicationDao(requestParams)
 
 		if a.IsSuperkey(id) {
-			xrhid, ok := c.Get(h.XRHID).(string)
+			xrhid, ok := c.Get(h.IdentityKey).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull x-rh-identity from request")
 			}

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -23,7 +23,7 @@ import (
 */
 func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TENANTID).(int64)
+		tenantId, ok := c.Get(h.TenantIdKey).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
@@ -68,7 +68,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 
 func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TENANTID).(int64)
+		tenantId, ok := c.Get(h.TenantIdKey).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -57,7 +57,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// stored in the database.
 		c.Set(h.TENANTID, tenant.Id)
 		c.Set(h.AccountNumberKey, tenant.ExternalTenant)
-		c.Set(h.ORGID, tenant.OrgID)
+		c.Set(h.OrgIdKey, tenant.OrgID)
 
 		return next(c)
 	}

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -55,7 +55,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// This can cause issues with services we are integrated with —notifications, for example—, which will not
 		// accept EBS account numbers anymore. However, we can deal with that by forwarding the OrgId too if we have it
 		// stored in the database.
-		c.Set(h.TenantIdKey, tenant.Id)
+		c.Set(h.TenantId, tenant.Id)
 		c.Set(h.AccountNumber, tenant.ExternalTenant)
 		c.Set(h.OrgId, tenant.OrgID)
 

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -56,7 +56,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// accept EBS account numbers anymore. However, we can deal with that by forwarding the OrgId too if we have it
 		// stored in the database.
 		c.Set(h.TENANTID, tenant.Id)
-		c.Set(h.ACCOUNT_NUMBER, tenant.ExternalTenant)
+		c.Set(h.AccountNumberKey, tenant.ExternalTenant)
 		c.Set(h.ORGID, tenant.OrgID)
 
 		return next(c)

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -16,7 +16,7 @@ import (
 // account number or OrgId.
 func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+		id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 		if !ok {
 			return fmt.Errorf("invalid identity structure received: %#v", id)
 		}
@@ -46,7 +46,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// Update the identity struct with the tenancy data from the database.
 		id.Identity.OrgID = tenant.OrgID
 		id.Identity.AccountNumber = tenant.ExternalTenant
-		c.Set(h.PARSED_IDENTITY, id)
+		c.Set(h.ParsedIdentityKey, id)
 
 		// Store the ID, EBS account number and OrgId from what we've got in the database. Prior to this, we stored
 		// the contents of the incoming headers, but this had a problem: if we only received an EBS account number, we

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -55,7 +55,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// This can cause issues with services we are integrated with —notifications, for example—, which will not
 		// accept EBS account numbers anymore. However, we can deal with that by forwarding the OrgId too if we have it
 		// stored in the database.
-		c.Set(h.TENANTID, tenant.Id)
+		c.Set(h.TenantIdKey, tenant.Id)
 		c.Set(h.AccountNumberKey, tenant.ExternalTenant)
 		c.Set(h.OrgIdKey, tenant.OrgID)
 

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -16,7 +16,7 @@ import (
 // account number or OrgId.
 func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		id, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
+		id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 		if !ok {
 			return fmt.Errorf("invalid identity structure received: %#v", id)
 		}
@@ -46,7 +46,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// Update the identity struct with the tenancy data from the database.
 		id.Identity.OrgID = tenant.OrgID
 		id.Identity.AccountNumber = tenant.ExternalTenant
-		c.Set(h.ParsedIdentityKey, id)
+		c.Set(h.ParsedIdentity, id)
 
 		// Store the ID, EBS account number and OrgId from what we've got in the database. Prior to this, we stored
 		// the contents of the incoming headers, but this had a problem: if we only received an EBS account number, we

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -56,7 +56,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// accept EBS account numbers anymore. However, we can deal with that by forwarding the OrgId too if we have it
 		// stored in the database.
 		c.Set(h.TenantIdKey, tenant.Id)
-		c.Set(h.AccountNumberKey, tenant.ExternalTenant)
+		c.Set(h.AccountNumber, tenant.ExternalTenant)
 		c.Set(h.OrgIdKey, tenant.OrgID)
 
 		return next(c)

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -57,7 +57,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// stored in the database.
 		c.Set(h.TenantIdKey, tenant.Id)
 		c.Set(h.AccountNumber, tenant.ExternalTenant)
-		c.Set(h.OrgIdKey, tenant.OrgID)
+		c.Set(h.OrgId, tenant.OrgID)
 
 		return next(c)
 	}

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -77,7 +77,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 		}
 
 		{
-			id, ok := c.Get(headers.ParsedIdentityKey).(*identity.XRHID)
+			id, ok := c.Get(headers.ParsedIdentity).(*identity.XRHID)
 			if !ok {
 				t.Errorf("unable to correctly type cast the parsed identity from the context")
 			}

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -77,7 +77,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 		}
 
 		{
-			id, ok := c.Get(headers.PARSED_IDENTITY).(*identity.XRHID)
+			id, ok := c.Get(headers.ParsedIdentityKey).(*identity.XRHID)
 			if !ok {
 				t.Errorf("unable to correctly type cast the parsed identity from the context")
 			}

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -119,7 +119,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := tenantId
-			got := c.Get(headers.TenantIdKey)
+			got := c.Get(headers.TenantId)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s. Invalid tenant id set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%d", got "%v"`, key, value, want, got)

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -61,8 +61,8 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 	// Prepare the headers we will be testing this with. We will try with one at a time.
 	testHeaders := map[string]string{
-		headers.AccountNumberKey: accountNumber,
-		headers.OrgIdKey:         orgId,
+		headers.AccountNumber: accountNumber,
+		headers.OrgIdKey:      orgId,
 	}
 
 	for key, value := range testHeaders {
@@ -101,7 +101,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := accountNumber
-			got := c.Get(headers.AccountNumberKey)
+			got := c.Get(headers.AccountNumber)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s". Invalid account number set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%s", got "%s"`, key, value, want, got)

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -62,7 +62,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 	// Prepare the headers we will be testing this with. We will try with one at a time.
 	testHeaders := map[string]string{
 		headers.AccountNumber: accountNumber,
-		headers.OrgIdKey:      orgId,
+		headers.OrgId:         orgId,
 	}
 
 	for key, value := range testHeaders {
@@ -110,7 +110,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := orgId
-			got := c.Get(headers.OrgIdKey)
+			got := c.Get(headers.OrgId)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s. Invalid OrgId set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%s", got "%s"`, key, value, want, got)

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -61,7 +61,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 	// Prepare the headers we will be testing this with. We will try with one at a time.
 	testHeaders := map[string]string{
-		headers.ACCOUNT_NUMBER: accountNumber,
+		headers.AccountNumberKey: accountNumber,
 		headers.ORGID:          orgId,
 	}
 
@@ -101,7 +101,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := accountNumber
-			got := c.Get(headers.ACCOUNT_NUMBER)
+			got := c.Get(headers.AccountNumberKey)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s". Invalid account number set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%s", got "%s"`, key, value, want, got)

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -119,7 +119,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := tenantId
-			got := c.Get(headers.TENANTID)
+			got := c.Get(headers.TenantIdKey)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s. Invalid tenant id set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%d", got "%v"`, key, value, want, got)

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -62,7 +62,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 	// Prepare the headers we will be testing this with. We will try with one at a time.
 	testHeaders := map[string]string{
 		headers.AccountNumberKey: accountNumber,
-		headers.ORGID:          orgId,
+		headers.OrgIdKey:         orgId,
 	}
 
 	for key, value := range testHeaders {
@@ -110,7 +110,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := orgId
-			got := c.Get(headers.ORGID)
+			got := c.Get(headers.OrgIdKey)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s. Invalid OrgId set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%s", got "%s"`, key, value, want, got)

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -19,8 +19,8 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 		var userIDFromContext string
 
 		switch {
-		case c.Get(h.PSK_USER) != nil:
-			userID, ok := c.Get(h.PSK_USER).(string)
+		case c.Get(h.UserIdKey) != nil:
+			userID, ok := c.Get(h.UserIdKey).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull user id from request")
 			}

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -42,7 +42,7 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("unable to find or create user %v: %v", userIDFromContext, err)
 			}
 
-			c.Set(h.USERID, user.Id)
+			c.Set(h.UserIdKey, user.Id)
 		}
 
 		return next(c)

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -27,8 +27,8 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 
 			userIDFromContext = userID
 
-		case c.Get(h.ParsedIdentityKey) != nil:
-			xRhIdentity, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
+		case c.Get(h.ParsedIdentity) != nil:
+			xRhIdentity, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("failed to fetch the identity header")
 			}

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -19,8 +19,8 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 		var userIDFromContext string
 
 		switch {
-		case c.Get(h.XrhUserIdKey) != nil:
-			userID, ok := c.Get(h.XrhUserIdKey).(string)
+		case c.Get(h.XrhUserId) != nil:
+			userID, ok := c.Get(h.XrhUserId).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull user id from request")
 			}

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -11,7 +11,7 @@ import (
 
 func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TENANTID).(int64)
+		tenantId, ok := c.Get(h.TenantIdKey).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -19,8 +19,8 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 		var userIDFromContext string
 
 		switch {
-		case c.Get(h.UserIdKey) != nil:
-			userID, ok := c.Get(h.UserIdKey).(string)
+		case c.Get(h.XrhUserIdKey) != nil:
+			userID, ok := c.Get(h.XrhUserIdKey).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull user id from request")
 			}

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -11,7 +11,7 @@ import (
 
 func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TenantIdKey).(int64)
+		tenantId, ok := c.Get(h.TenantId).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -42,7 +42,7 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("unable to find or create user %v: %v", userIDFromContext, err)
 			}
 
-			c.Set(h.UserIdKey, user.Id)
+			c.Set(h.UserId, user.Id)
 		}
 
 		return next(c)

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -27,8 +27,8 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 
 			userIDFromContext = userID
 
-		case c.Get(h.PARSED_IDENTITY) != nil:
-			xRhIdentity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+		case c.Get(h.ParsedIdentityKey) != nil:
+			xRhIdentity, ok := c.Get(h.ParsedIdentityKey).(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("failed to fetch the identity header")
 			}

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -33,7 +33,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Set(h.TenantIdKey, tenantID)
+	c.Set(h.TenantId, tenantID)
 	c.Set(h.ParsedIdentity, identity)
 
 	err := catchUserOrElse204(c)
@@ -77,7 +77,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Set(h.TenantIdKey, tenantID)
+	c.Set(h.TenantId, tenantID)
 	c.Set(h.XrhUserId, testUserID)
 
 	err := catchUserOrElse204(c)

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -55,7 +55,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 		t.Errorf("unable to find user %v", testUserID)
 	}
 
-	if user.Id == 0 || c.Get(h.USERID) != user.Id {
+	if user.Id == 0 || c.Get(h.UserIdKey) != user.Id {
 		t.Errorf("unable to find user id %v in context", user.Id)
 	}
 
@@ -95,7 +95,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 		t.Error(err)
 	}
 
-	if user.Id == 0 || c.Get(h.USERID) != user.Id {
+	if user.Id == 0 || c.Get(h.UserIdKey) != user.Id {
 		t.Errorf("unable to find user id %v in context", user.Id)
 	}
 

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -55,7 +55,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 		t.Errorf("unable to find user %v", testUserID)
 	}
 
-	if user.Id == 0 || c.Get(h.UserIdKey) != user.Id {
+	if user.Id == 0 || c.Get(h.UserId) != user.Id {
 		t.Errorf("unable to find user id %v in context", user.Id)
 	}
 
@@ -95,7 +95,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 		t.Error(err)
 	}
 
-	if user.Id == 0 || c.Get(h.UserIdKey) != user.Id {
+	if user.Id == 0 || c.Get(h.UserId) != user.Id {
 		t.Errorf("unable to find user id %v in context", user.Id)
 	}
 

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -33,7 +33,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Set(h.TENANTID, tenantID)
+	c.Set(h.TenantIdKey, tenantID)
 	c.Set(h.ParsedIdentityKey, identity)
 
 	err := catchUserOrElse204(c)
@@ -77,7 +77,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Set(h.TENANTID, tenantID)
+	c.Set(h.TenantIdKey, tenantID)
 	c.Set(h.UserIdKey, testUserID)
 
 	err := catchUserOrElse204(c)

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -34,7 +34,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 	)
 
 	c.Set(h.TenantIdKey, tenantID)
-	c.Set(h.ParsedIdentityKey, identity)
+	c.Set(h.ParsedIdentity, identity)
 
 	err := catchUserOrElse204(c)
 	if err != nil {

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -78,7 +78,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 	)
 
 	c.Set(h.TENANTID, tenantID)
-	c.Set(h.PSK_USER, testUserID)
+	c.Set(h.UserIdKey, testUserID)
 
 	err := catchUserOrElse204(c)
 	if err != nil {

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -34,7 +34,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 	)
 
 	c.Set(h.TENANTID, tenantID)
-	c.Set(h.PARSED_IDENTITY, identity)
+	c.Set(h.ParsedIdentity, identity)
 
 	err := catchUserOrElse204(c)
 	if err != nil {

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -78,7 +78,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 	)
 
 	c.Set(h.TenantIdKey, tenantID)
-	c.Set(h.UserIdKey, testUserID)
+	c.Set(h.XrhUserIdKey, testUserID)
 
 	err := catchUserOrElse204(c)
 	if err != nil {

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -78,7 +78,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 	)
 
 	c.Set(h.TenantIdKey, tenantID)
-	c.Set(h.XrhUserIdKey, testUserID)
+	c.Set(h.XrhUserId, testUserID)
 
 	err := catchUserOrElse204(c)
 	if err != nil {

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -34,7 +34,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 	)
 
 	c.Set(h.TENANTID, tenantID)
-	c.Set(h.ParsedIdentity, identity)
+	c.Set(h.ParsedIdentityKey, identity)
 
 	err := catchUserOrElse204(c)
 	if err != nil {

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -22,7 +22,7 @@ type Tenant struct {
 
 func (t Tenant) GetHeadersWithGeneratedXRHID() []kafka.Header {
 	return append(t.GetHeaders(), kafka.Header{
-		Key: h.IdentityKey, Value: []byte(util.GeneratedXRhIdentity(t.ExternalTenant, t.OrgID)),
+		Key: h.Identity, Value: []byte(util.GeneratedXRhIdentity(t.ExternalTenant, t.OrgID)),
 	})
 }
 

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -22,7 +22,7 @@ type Tenant struct {
 
 func (t Tenant) GetHeadersWithGeneratedXRHID() []kafka.Header {
 	return append(t.GetHeaders(), kafka.Header{
-		Key: h.XRHID, Value: []byte(util.GeneratedXRhIdentity(t.ExternalTenant, t.OrgID)),
+		Key: h.IdentityKey, Value: []byte(util.GeneratedXRhIdentity(t.ExternalTenant, t.OrgID)),
 	})
 }
 

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -29,7 +29,7 @@ func (t Tenant) GetHeadersWithGeneratedXRHID() []kafka.Header {
 func (t Tenant) GetHeaders() []kafka.Header {
 	return []kafka.Header{
 		{Key: h.AccountNumberKey, Value: []byte(t.ExternalTenant)},
-		{Key: h.ORGID, Value: []byte(t.OrgID)},
+		{Key: h.OrgIdKey, Value: []byte(t.OrgID)},
 	}
 }
 

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -28,7 +28,7 @@ func (t Tenant) GetHeadersWithGeneratedXRHID() []kafka.Header {
 
 func (t Tenant) GetHeaders() []kafka.Header {
 	return []kafka.Header{
-		{Key: h.AccountNumberKey, Value: []byte(t.ExternalTenant)},
+		{Key: h.AccountNumber, Value: []byte(t.ExternalTenant)},
 		{Key: h.OrgIdKey, Value: []byte(t.OrgID)},
 	}
 }

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -29,7 +29,7 @@ func (t Tenant) GetHeadersWithGeneratedXRHID() []kafka.Header {
 func (t Tenant) GetHeaders() []kafka.Header {
 	return []kafka.Header{
 		{Key: h.AccountNumber, Value: []byte(t.ExternalTenant)},
-		{Key: h.OrgIdKey, Value: []byte(t.OrgID)},
+		{Key: h.OrgId, Value: []byte(t.OrgID)},
 	}
 }
 

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -28,7 +28,7 @@ func (t Tenant) GetHeadersWithGeneratedXRHID() []kafka.Header {
 
 func (t Tenant) GetHeaders() []kafka.Header {
 	return []kafka.Header{
-		{Key: h.ACCOUNT_NUMBER, Value: []byte(t.ExternalTenant)},
+		{Key: h.AccountNumberKey, Value: []byte(t.ExternalTenant)},
 		{Key: h.ORGID, Value: []byte(t.OrgID)},
 	}
 }

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -109,7 +109,7 @@ func TestSecretCreate(t *testing.T) {
 		stringMatcher(t, "secret auth type", secret.AuthType, authType)
 
 		if userScoped {
-			secretUserID, ok := c.Get(h.USERID).(int64)
+			secretUserID, ok := c.Get(h.UserIdKey).(int64)
 			if ok {
 				userID = &secretUserID
 			}

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -213,7 +213,7 @@ func createSecretRequest(t *testing.T, requestBody *m.SecretCreateRequest, tenan
 
 	testUserId := "testUser"
 	identityHeader := testutils.IdentityHeaderForUser(testUserId)
-	c.Set("identity", identityHeader)
+	c.Set(h.ParsedIdentityKey, identityHeader)
 
 	err = userCatcher(c)
 

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -213,7 +213,7 @@ func createSecretRequest(t *testing.T, requestBody *m.SecretCreateRequest, tenan
 
 	testUserId := "testUser"
 	identityHeader := testutils.IdentityHeaderForUser(testUserId)
-	c.Set(h.ParsedIdentityKey, identityHeader)
+	c.Set(h.ParsedIdentity, identityHeader)
 
 	err = userCatcher(c)
 

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -109,7 +109,7 @@ func TestSecretCreate(t *testing.T) {
 		stringMatcher(t, "secret auth type", secret.AuthType, authType)
 
 		if userScoped {
-			secretUserID, ok := c.Get(h.UserIdKey).(int64)
+			secretUserID, ok := c.Get(h.UserId).(int64)
 			if ok {
 				userID = &secretUserID
 			}

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -113,7 +113,7 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 		return
 	}
 
-	req.Header.Add(h.OrgIdKey, source.Tenant.OrgID)
+	req.Header.Add(h.OrgId, source.Tenant.OrgID)
 	req.Header.Add(h.AccountNumber, source.Tenant.ExternalTenant)
 	req.Header.Add(h.IdentityKey, util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -113,7 +113,7 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 		return
 	}
 
-	req.Header.Add("x-rh-sources-org-id", source.Tenant.OrgID)
+	req.Header.Add(h.OrgIdKey, source.Tenant.OrgID)
 	req.Header.Add(h.AccountNumberKey, source.Tenant.ExternalTenant)
 	req.Header.Add("x-rh-identity", util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -115,7 +115,7 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 
 	req.Header.Add(h.OrgIdKey, source.Tenant.OrgID)
 	req.Header.Add(h.AccountNumberKey, source.Tenant.ExternalTenant)
-	req.Header.Add("x-rh-identity", util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
+	req.Header.Add(h.IdentityKey, util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -187,7 +187,7 @@ func (acr availabilityCheckRequester) publishSatelliteMessage(writer *kafka.Writ
 	msg.AddHeaders([]kafka.Header{
 		{Key: "event_type", Value: []byte("Source.availability_check")},
 		{Key: "encoding", Value: []byte("json")},
-		{Key: "x-rh-identity", Value: []byte(util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))},
+		{Key: h.IdentityKey, Value: []byte(util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))},
 		{Key: h.AccountNumberKey, Value: []byte(endpoint.Tenant.ExternalTenant)},
 	})
 

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -114,7 +114,7 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 	}
 
 	req.Header.Add(h.OrgIdKey, source.Tenant.OrgID)
-	req.Header.Add(h.AccountNumberKey, source.Tenant.ExternalTenant)
+	req.Header.Add(h.AccountNumber, source.Tenant.ExternalTenant)
 	req.Header.Add(h.IdentityKey, util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
@@ -188,7 +188,7 @@ func (acr availabilityCheckRequester) publishSatelliteMessage(writer *kafka.Writ
 		{Key: "event_type", Value: []byte("Source.availability_check")},
 		{Key: "encoding", Value: []byte("json")},
 		{Key: h.IdentityKey, Value: []byte(util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))},
-		{Key: h.AccountNumberKey, Value: []byte(endpoint.Tenant.ExternalTenant)},
+		{Key: h.AccountNumber, Value: []byte(endpoint.Tenant.ExternalTenant)},
 	})
 
 	if err = kafka.Produce(writer, msg); err != nil {

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -115,7 +115,7 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 
 	req.Header.Add(h.OrgId, source.Tenant.OrgID)
 	req.Header.Add(h.AccountNumber, source.Tenant.ExternalTenant)
-	req.Header.Add(h.IdentityKey, util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
+	req.Header.Add(h.Identity, util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -187,7 +187,7 @@ func (acr availabilityCheckRequester) publishSatelliteMessage(writer *kafka.Writ
 	msg.AddHeaders([]kafka.Header{
 		{Key: "event_type", Value: []byte("Source.availability_check")},
 		{Key: "encoding", Value: []byte("json")},
-		{Key: h.IdentityKey, Value: []byte(util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))},
+		{Key: h.Identity, Value: []byte(util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))},
 		{Key: h.AccountNumber, Value: []byte(endpoint.Tenant.ExternalTenant)},
 	})
 

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -15,6 +15,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	l "github.com/RedHatInsights/sources-api-go/logger"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
@@ -113,7 +114,7 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 	}
 
 	req.Header.Add("x-rh-sources-org-id", source.Tenant.OrgID)
-	req.Header.Add("x-rh-sources-account-number", source.Tenant.ExternalTenant)
+	req.Header.Add(h.AccountNumberKey, source.Tenant.ExternalTenant)
 	req.Header.Add("x-rh-identity", util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
@@ -187,7 +188,7 @@ func (acr availabilityCheckRequester) publishSatelliteMessage(writer *kafka.Writ
 		{Key: "event_type", Value: []byte("Source.availability_check")},
 		{Key: "encoding", Value: []byte("json")},
 		{Key: "x-rh-identity", Value: []byte(util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))},
-		{Key: "x-rh-sources-account-number", Value: []byte(endpoint.Tenant.ExternalTenant)},
+		{Key: h.AccountNumberKey, Value: []byte(endpoint.Tenant.ExternalTenant)},
 	})
 
 	if err = kafka.Produce(writer, msg); err != nil {

--- a/service/events.go
+++ b/service/events.go
@@ -49,8 +49,8 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	}
 
 	// pulling the specified orgId if it exists
-	if c.Get(h.ORGID) != nil {
-		orgId, ok = c.Get(h.ORGID).(string)
+	if c.Get(h.OrgIdKey) != nil {
+		orgId, ok = c.Get(h.OrgIdKey).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
@@ -86,7 +86,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 		headers = append(headers, kafka.Header{Key: h.AccountNumberKey, Value: []byte(account)})
 	}
 	if orgId != "" {
-		headers = append(headers, kafka.Header{Key: h.ORGID, Value: []byte(orgId)})
+		headers = append(headers, kafka.Header{Key: h.OrgIdKey, Value: []byte(orgId)})
 	}
 
 	headers = append(headers, kafka.Header{Key: h.XRHID, Value: []byte(xrhid)})

--- a/service/events.go
+++ b/service/events.go
@@ -49,8 +49,8 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	}
 
 	// pulling the specified orgId if it exists
-	if c.Get(h.OrgIdKey) != nil {
-		orgId, ok = c.Get(h.OrgIdKey).(string)
+	if c.Get(h.OrgId) != nil {
+		orgId, ok = c.Get(h.OrgId).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
@@ -86,7 +86,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 		headers = append(headers, kafka.Header{Key: h.AccountNumber, Value: []byte(account)})
 	}
 	if orgId != "" {
-		headers = append(headers, kafka.Header{Key: h.OrgIdKey, Value: []byte(orgId)})
+		headers = append(headers, kafka.Header{Key: h.OrgId, Value: []byte(orgId)})
 	}
 
 	headers = append(headers, kafka.Header{Key: h.IdentityKey, Value: []byte(xrhid)})

--- a/service/events.go
+++ b/service/events.go
@@ -41,8 +41,8 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	var ok bool
 
 	// pulling the specified account if it exists
-	if c.Get(h.AccountNumberKey) != nil {
-		account, ok = c.Get(h.AccountNumberKey).(string)
+	if c.Get(h.AccountNumber) != nil {
+		account, ok = c.Get(h.AccountNumber).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
@@ -83,7 +83,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 
 	// need to check org_id + account since one or the other might not be there.
 	if account != "" {
-		headers = append(headers, kafka.Header{Key: h.AccountNumberKey, Value: []byte(account)})
+		headers = append(headers, kafka.Header{Key: h.AccountNumber, Value: []byte(account)})
 	}
 	if orgId != "" {
 		headers = append(headers, kafka.Header{Key: h.OrgIdKey, Value: []byte(orgId)})

--- a/service/events.go
+++ b/service/events.go
@@ -57,8 +57,8 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	}
 
 	// pull the xrhid OR generate one using the information from the PSK information.
-	if c.Get(h.IdentityKey) != nil {
-		rhid, ok := c.Get(h.IdentityKey).(string)
+	if c.Get(h.Identity) != nil {
+		rhid, ok := c.Get(h.Identity).(string)
 		if ok {
 			// set the xrhid to be passed on
 			xrhid = rhid
@@ -89,7 +89,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 		headers = append(headers, kafka.Header{Key: h.OrgId, Value: []byte(orgId)})
 	}
 
-	headers = append(headers, kafka.Header{Key: h.IdentityKey, Value: []byte(xrhid)})
+	headers = append(headers, kafka.Header{Key: h.Identity, Value: []byte(xrhid)})
 
 	return headers, nil
 }

--- a/service/events.go
+++ b/service/events.go
@@ -57,8 +57,8 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	}
 
 	// pull the xrhid OR generate one using the information from the PSK information.
-	if c.Get(h.XRHID) != nil {
-		rhid, ok := c.Get(h.XRHID).(string)
+	if c.Get(h.IdentityKey) != nil {
+		rhid, ok := c.Get(h.IdentityKey).(string)
 		if ok {
 			// set the xrhid to be passed on
 			xrhid = rhid
@@ -89,7 +89,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 		headers = append(headers, kafka.Header{Key: h.OrgIdKey, Value: []byte(orgId)})
 	}
 
-	headers = append(headers, kafka.Header{Key: h.XRHID, Value: []byte(xrhid)})
+	headers = append(headers, kafka.Header{Key: h.IdentityKey, Value: []byte(xrhid)})
 
 	return headers, nil
 }

--- a/service/events.go
+++ b/service/events.go
@@ -41,8 +41,8 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	var ok bool
 
 	// pulling the specified account if it exists
-	if c.Get(h.ACCOUNT_NUMBER) != nil {
-		account, ok = c.Get(h.ACCOUNT_NUMBER).(string)
+	if c.Get(h.AccountNumberKey) != nil {
+		account, ok = c.Get(h.AccountNumberKey).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
@@ -83,7 +83,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 
 	// need to check org_id + account since one or the other might not be there.
 	if account != "" {
-		headers = append(headers, kafka.Header{Key: h.ACCOUNT_NUMBER, Value: []byte(account)})
+		headers = append(headers, kafka.Header{Key: h.AccountNumberKey, Value: []byte(account)})
 	}
 	if orgId != "" {
 		headers = append(headers, kafka.Header{Key: h.ORGID, Value: []byte(orgId)})

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -108,7 +108,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 		orgIdHeader := headers[0]
 
 		{
-			want := "x-rh-sources-org-id"
+			want := h.OrgIdKey
 			got := orgIdHeader.Key
 
 			if want != got {
@@ -211,7 +211,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	{
 		orgIdHeader := headers[1]
 		{
-			want := "x-rh-sources-org-id"
+			want := h.OrgIdKey
 			got := orgIdHeader.Key
 
 			if want != got {
@@ -291,7 +291,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 		orgIdHeader := headers[0]
 
 		{
-			want := "x-rh-sources-org-id"
+			want := h.OrgIdKey
 			got := orgIdHeader.Key
 
 			if want != got {

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -87,7 +87,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	testOrgIdValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.OrgIdKey, testOrgIdValue)
+	context.Set(h.OrgId, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -108,7 +108,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 		orgIdHeader := headers[0]
 
 		{
-			want := h.OrgIdKey
+			want := h.OrgId
 			got := orgIdHeader.Key
 
 			if want != got {
@@ -211,7 +211,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	{
 		orgIdHeader := headers[1]
 		{
-			want := h.OrgIdKey
+			want := h.OrgId
 			got := orgIdHeader.Key
 
 			if want != got {
@@ -270,7 +270,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	testOrgIdValue := "12345"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.OrgIdKey, testOrgIdValue)
+	context.Set(h.OrgId, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -291,7 +291,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 		orgIdHeader := headers[0]
 
 		{
-			want := h.OrgIdKey
+			want := h.OrgId
 			got := orgIdHeader.Key
 
 			if want != got {

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -59,7 +59,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 	{
 		xRhIdHeader := headers[1]
 		{
-			want := "x-rh-identity"
+			want := h.IdentityKey
 			got := xRhIdHeader.Key
 			if want != got {
 				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
@@ -127,7 +127,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	{
 		xRhIdHeader := headers[1]
 		{
-			want := "x-rh-identity"
+			want := h.IdentityKey
 			got := xRhIdHeader.Key
 			if want != got {
 				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
@@ -169,7 +169,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 		t.Errorf(`unexpected error when marshalling the XRHID: %s`, err)
 	}
 
-	context.Set("x-rh-identity", base64.StdEncoding.EncodeToString(result))
+	context.Set(h.IdentityKey, base64.StdEncoding.EncodeToString(result))
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -232,7 +232,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 		xRhIdentityHeader := headers[2]
 
 		{
-			want := "x-rh-identity"
+			want := h.IdentityKey
 			got := xRhIdentityHeader.Key
 
 			if want != got {
@@ -312,7 +312,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 		xRhIdentityHeader := headers[1]
 
 		{
-			want := "x-rh-identity"
+			want := h.IdentityKey
 			got := xRhIdentityHeader.Key
 
 			if want != got {

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -40,7 +40,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 		pskHeader := headers[0]
 
 		{
-			want := "x-rh-sources-account-number"
+			want := h.AccountNumberKey
 			got := pskHeader.Key
 
 			if want != got {
@@ -189,7 +189,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	{
 		accountHeader := headers[0]
 		{
-			want := "x-rh-sources-account-number"
+			want := h.AccountNumberKey
 			got := accountHeader.Key
 
 			if want != got {

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -59,7 +59,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 	{
 		xRhIdHeader := headers[1]
 		{
-			want := h.IdentityKey
+			want := h.Identity
 			got := xRhIdHeader.Key
 			if want != got {
 				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
@@ -127,7 +127,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	{
 		xRhIdHeader := headers[1]
 		{
-			want := h.IdentityKey
+			want := h.Identity
 			got := xRhIdHeader.Key
 			if want != got {
 				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
@@ -169,7 +169,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 		t.Errorf(`unexpected error when marshalling the XRHID: %s`, err)
 	}
 
-	context.Set(h.IdentityKey, base64.StdEncoding.EncodeToString(result))
+	context.Set(h.Identity, base64.StdEncoding.EncodeToString(result))
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -232,7 +232,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 		xRhIdentityHeader := headers[2]
 
 		{
-			want := h.IdentityKey
+			want := h.Identity
 			got := xRhIdentityHeader.Key
 
 			if want != got {
@@ -312,7 +312,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 		xRhIdentityHeader := headers[1]
 
 		{
-			want := h.IdentityKey
+			want := h.Identity
 			got := xRhIdentityHeader.Key
 
 			if want != got {

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -87,7 +87,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	testOrgIdValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.ORGID, testOrgIdValue)
+	context.Set(h.OrgIdKey, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -270,7 +270,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	testOrgIdValue := "12345"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.ORGID, testOrgIdValue)
+	context.Set(h.OrgIdKey, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -19,7 +19,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 	testPskAccountValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.AccountNumberKey, testPskAccountValue)
+	context.Set(h.AccountNumber, testPskAccountValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -40,7 +40,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 		pskHeader := headers[0]
 
 		{
-			want := h.AccountNumberKey
+			want := h.AccountNumber
 			got := pskHeader.Key
 
 			if want != got {
@@ -189,7 +189,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	{
 		accountHeader := headers[0]
 		{
-			want := h.AccountNumberKey
+			want := h.AccountNumber
 			got := accountHeader.Key
 
 			if want != got {

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -19,7 +19,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 	testPskAccountValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.ACCOUNT_NUMBER, testPskAccountValue)
+	context.Set(h.AccountNumberKey, testPskAccountValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -2345,8 +2346,8 @@ func TestSourcePauseRaiseEventCheck(t *testing.T) {
 		"/api/sources/v3.1/sources/1/unpause",
 		nil,
 		map[string]interface{}{
-			"tenantID":      int64(1),
-			"x-rh-identity": util.GeneratedXRhIdentity("1234", "1234"),
+			"tenantID":    int64(1),
+			h.IdentityKey: util.GeneratedXRhIdentity("1234", "1234"),
 		},
 	)
 
@@ -2423,8 +2424,8 @@ func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
 		"/api/sources/v3.1/sources/1/unpause",
 		nil,
 		map[string]interface{}{
-			"tenantID":      int64(1),
-			"x-rh-identity": util.GeneratedXRhIdentity("1234", "1234"),
+			"tenantID":    int64(1),
+			h.IdentityKey: util.GeneratedXRhIdentity("1234", "1234"),
 		},
 	)
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1159,7 +1159,7 @@ func TestSourceEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(fmt.Sprintf("%d", source.ID))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
 	err := sourceEditHandlerWithNotifier(c)
@@ -1362,7 +1362,7 @@ func TestSourceEditNoNameRequest(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(fmt.Sprintf("%d", source.ID))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
 	err := sourceEditHandlerWithNotifier(c)

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -2346,8 +2346,8 @@ func TestSourcePauseRaiseEventCheck(t *testing.T) {
 		"/api/sources/v3.1/sources/1/unpause",
 		nil,
 		map[string]interface{}{
-			"tenantID":    int64(1),
-			h.IdentityKey: util.GeneratedXRhIdentity("1234", "1234"),
+			"tenantID": int64(1),
+			h.Identity: util.GeneratedXRhIdentity("1234", "1234"),
 		},
 	)
 
@@ -2424,8 +2424,8 @@ func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
 		"/api/sources/v3.1/sources/1/unpause",
 		nil,
 		map[string]interface{}{
-			"tenantID":    int64(1),
-			h.IdentityKey: util.GeneratedXRhIdentity("1234", "1234"),
+			"tenantID": int64(1),
+			h.Identity: util.GeneratedXRhIdentity("1234", "1234"),
 		},
 	)
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1159,7 +1159,7 @@ func TestSourceEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(fmt.Sprintf("%d", source.ID))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
+	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
 	err := sourceEditHandlerWithNotifier(c)
@@ -1362,7 +1362,7 @@ func TestSourceEditNoNameRequest(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(fmt.Sprintf("%d", source.ID))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
+	c.Set(h.ParsedIdentityKey, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
 	err := sourceEditHandlerWithNotifier(c)

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/types"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -418,7 +419,7 @@ func TestConsumeStatusMessage(t *testing.T) {
 	header := kafkaGo.Header{Key: "event_type", Value: []byte("availability_status")}
 	// {"identity":{"account_number":"12345","user": {"is_org_admin":true}}, "internal": {"org_id": "000001"}}
 	header2 := kafkaGo.Header{Key: "x-rh-identity", Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
-	header3 := kafkaGo.Header{Key: "x-rh-sources-account-number", Value: []byte("12345")}
+	header3 := kafkaGo.Header{Key: h.AccountNumberKey, Value: []byte("12345")}
 	headers := []kafkaGo.Header{header, header2, header3}
 	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	sourceTestData := TestData{StatusMessage: statusMessage, MessageHeaders: headers, RaiseEventCalled: true}

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -418,7 +418,7 @@ func TestConsumeStatusMessage(t *testing.T) {
 
 	header := kafkaGo.Header{Key: "event_type", Value: []byte("availability_status")}
 	// {"identity":{"account_number":"12345","user": {"is_org_admin":true}}, "internal": {"org_id": "000001"}}
-	header2 := kafkaGo.Header{Key: h.IdentityKey, Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
+	header2 := kafkaGo.Header{Key: h.Identity, Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
 	header3 := kafkaGo.Header{Key: h.AccountNumber, Value: []byte("12345")}
 	headers := []kafkaGo.Header{header, header2, header3}
 	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -418,7 +418,7 @@ func TestConsumeStatusMessage(t *testing.T) {
 
 	header := kafkaGo.Header{Key: "event_type", Value: []byte("availability_status")}
 	// {"identity":{"account_number":"12345","user": {"is_org_admin":true}}, "internal": {"org_id": "000001"}}
-	header2 := kafkaGo.Header{Key: "x-rh-identity", Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
+	header2 := kafkaGo.Header{Key: h.IdentityKey, Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
 	header3 := kafkaGo.Header{Key: h.AccountNumberKey, Value: []byte("12345")}
 	headers := []kafkaGo.Header{header, header2, header3}
 	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -419,7 +419,7 @@ func TestConsumeStatusMessage(t *testing.T) {
 	header := kafkaGo.Header{Key: "event_type", Value: []byte("availability_status")}
 	// {"identity":{"account_number":"12345","user": {"is_org_admin":true}}, "internal": {"org_id": "000001"}}
 	header2 := kafkaGo.Header{Key: h.IdentityKey, Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
-	header3 := kafkaGo.Header{Key: h.AccountNumberKey, Value: []byte("12345")}
+	header3 := kafkaGo.Header{Key: h.AccountNumber, Value: []byte("12345")}
 	headers := []kafkaGo.Header{header, header2, header3}
 	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	sourceTestData := TestData{StatusMessage: statusMessage, MessageHeaders: headers, RaiseEventCalled: true}

--- a/util/echo/echo_context.go
+++ b/util/echo/echo_context.go
@@ -49,7 +49,7 @@ func GetUserFromEchoContext(c echo.Context) (*int64, error) {
 // GetTenantFromEchoContext tries to extract the tenant from the echo context. If the "tenantID" is missing from the
 // context, then a default value and nil are returned as the int64 and error values.
 func GetTenantFromEchoContext(c echo.Context) (int64, error) {
-	tenantValue := c.Get(h.TenantIdKey)
+	tenantValue := c.Get(h.TenantId)
 
 	// If no tenant is found in the context, that shouldn't imply an error.
 	if tenantValue == nil {

--- a/util/echo/echo_context.go
+++ b/util/echo/echo_context.go
@@ -30,7 +30,7 @@ func (sc *SourcesContext) Logger() echo.Logger {
 }
 
 func GetUserFromEchoContext(c echo.Context) (*int64, error) {
-	userValue := c.Get(h.UserIdKey)
+	userValue := c.Get(h.UserId)
 	if userValue == nil {
 		return nil, nil
 	}

--- a/util/echo/echo_context.go
+++ b/util/echo/echo_context.go
@@ -49,7 +49,7 @@ func GetUserFromEchoContext(c echo.Context) (*int64, error) {
 // GetTenantFromEchoContext tries to extract the tenant from the echo context. If the "tenantID" is missing from the
 // context, then a default value and nil are returned as the int64 and error values.
 func GetTenantFromEchoContext(c echo.Context) (int64, error) {
-	tenantValue := c.Get(h.TENANTID)
+	tenantValue := c.Get(h.TenantIdKey)
 
 	// If no tenant is found in the context, that shouldn't imply an error.
 	if tenantValue == nil {

--- a/util/echo/echo_context.go
+++ b/util/echo/echo_context.go
@@ -30,7 +30,7 @@ func (sc *SourcesContext) Logger() echo.Logger {
 }
 
 func GetUserFromEchoContext(c echo.Context) (*int64, error) {
-	userValue := c.Get(h.USERID)
+	userValue := c.Get(h.UserIdKey)
 	if userValue == nil {
 		return nil, nil
 	}

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	xrhAccountNumberKey string = "x-rh-sources-account-number"
-	xrhIdentityKey      string = "x-rh-identity"
+	xrhIdentityKey string = "x-rh-identity"
 )
 
 func ParseXRHIDHeader(inputIdentity string) (*identity.XRHID, error) {
@@ -39,7 +38,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 	var outputIdentity identity.Identity
 
 	for _, header := range headers {
-		if header.Key == xrhAccountNumberKey {
+		if header.Key == h.AccountNumberKey {
 			outputIdentity.AccountNumber = string(header.Value)
 		}
 
@@ -58,7 +57,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 	}
 
 	if outputIdentity.AccountNumber == "" && outputIdentity.OrgID == "" {
-		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", xrhAccountNumberKey, xrhIdentityKey)
+		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", h.AccountNumberKey, xrhIdentityKey)
 	}
 
 	return &outputIdentity, nil

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -11,10 +11,6 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-const (
-	xrhIdentityKey string = "x-rh-identity"
-)
-
 func ParseXRHIDHeader(inputIdentity string) (*identity.XRHID, error) {
 	var XRHIdentity *identity.XRHID
 	decodedIdentity, err := base64.StdEncoding.DecodeString(inputIdentity)
@@ -46,7 +42,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 			outputIdentity.OrgID = string(header.Value)
 		}
 
-		if header.Key == xrhIdentityKey {
+		if header.Key == h.IdentityKey {
 			xRhIdentity, err := ParseXRHIDHeader(string(header.Value))
 			if err != nil {
 				return nil, err
@@ -57,7 +53,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 	}
 
 	if outputIdentity.AccountNumber == "" && outputIdentity.OrgID == "" {
-		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", h.AccountNumberKey, xrhIdentityKey)
+		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", h.AccountNumberKey, h.IdentityKey)
 	}
 
 	return &outputIdentity, nil

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -42,7 +42,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 			outputIdentity.AccountNumber = string(header.Value)
 		}
 
-		if header.Key == h.ORGID {
+		if header.Key == h.OrgIdKey {
 			outputIdentity.OrgID = string(header.Value)
 		}
 

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -34,7 +34,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 	var outputIdentity identity.Identity
 
 	for _, header := range headers {
-		if header.Key == h.AccountNumberKey {
+		if header.Key == h.AccountNumber {
 			outputIdentity.AccountNumber = string(header.Value)
 		}
 
@@ -53,7 +53,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 	}
 
 	if outputIdentity.AccountNumber == "" && outputIdentity.OrgID == "" {
-		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", h.AccountNumberKey, h.IdentityKey)
+		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", h.AccountNumber, h.IdentityKey)
 	}
 
 	return &outputIdentity, nil

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -42,7 +42,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 			outputIdentity.OrgID = string(header.Value)
 		}
 
-		if header.Key == h.IdentityKey {
+		if header.Key == h.Identity {
 			xRhIdentity, err := ParseXRHIDHeader(string(header.Value))
 			if err != nil {
 				return nil, err
@@ -53,7 +53,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 	}
 
 	if outputIdentity.AccountNumber == "" && outputIdentity.OrgID == "" {
-		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", h.AccountNumber, h.IdentityKey)
+		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", h.AccountNumber, h.Identity)
 	}
 
 	return &outputIdentity, nil

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -38,7 +38,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 			outputIdentity.AccountNumber = string(header.Value)
 		}
 
-		if header.Key == h.OrgIdKey {
+		if header.Key == h.OrgId {
 			outputIdentity.OrgID = string(header.Value)
 		}
 

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -131,7 +131,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 	// Lastly test with the "x-rh-account-number" and "x-rh-sources-org-id" header.
 	headers = []kafka.Header{
 		{
-			Key:   h.AccountNumberKey,
+			Key:   h.AccountNumber,
 			Value: []byte(accountNumber),
 		},
 		{

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -135,7 +135,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 			Value: []byte(accountNumber),
 		},
 		{
-			Key:   h.OrgIdKey,
+			Key:   h.OrgId,
 			Value: []byte(orgId),
 		},
 	}

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -135,7 +135,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 			Value: []byte(accountNumber),
 		},
 		{
-			Key:   h.ORGID,
+			Key:   h.OrgIdKey,
 			Value: []byte(orgId),
 		},
 	}

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -101,7 +101,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 
 	headers := []kafka.Header{
 		{
-			Key:   xrhIdentityKey,
+			Key:   h.IdentityKey,
 			Value: []byte(base64Identity),
 		},
 	}

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -101,7 +101,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 
 	headers := []kafka.Header{
 		{
-			Key:   h.IdentityKey,
+			Key:   h.Identity,
 			Value: []byte(base64Identity),
 		},
 	}

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -131,7 +131,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 	// Lastly test with the "x-rh-account-number" and "x-rh-sources-org-id" header.
 	headers = []kafka.Header{
 		{
-			Key:   xrhAccountNumberKey,
+			Key:   h.AccountNumberKey,
 			Value: []byte(accountNumber),
 		},
 		{


### PR DESCRIPTION
this PR contains:
- rename of constants from headers.go from upper case style into camel case style
- replacing strings with existing constants (only related with constants from headers.go)

refactor of rest of constants will be solved in next PRs

**JIRA:** [RHCLOUD-21109](https://issues.redhat.com/browse/RHCLOUD-21109)