### PR TITLE
add empty line to fix the formatting of imports to prevent a golangci-lint complaint

### DIFF
--- a/dao/request_params.go
+++ b/dao/request_params.go
@@ -2,6 +2,7 @@ package dao
 
 import (
 	"context"
+
 	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )


### PR DESCRIPTION
without JIRA ticket

after last PR merge the golangci-lint is complaining that dao/request_params.go doesn't meet the formatting rules