### PR TITLE
OpenAPI: Add provisioning auth types to authtype enum

### DIFF
--- a/public/openapi-3-v3.1.json
+++ b/public/openapi-3-v3.1.json
@@ -2540,6 +2540,7 @@
             "type": "string"
           },
           "authtype": {
+            "type": "string",
             "description": "The type of the authentication",
             "enum": [
               "access_key_secret_key",
@@ -2558,7 +2559,10 @@
               "receptor_node",
               "tenant_id_client_id_client_secret",
               "token",
-              "username_password"
+              "username_password",
+              "provisioning-arn",
+              "provisioning_lighthouse_subscription_id",
+              "provisioning_project_id"
             ]
           },
           "username": {
@@ -2603,6 +2607,7 @@
             "type": "string"
           },
           "authtype": {
+            "type": "string",
             "description": "The type of the authentication",
             "enum": [
               "access_key_secret_key",
@@ -2621,7 +2626,10 @@
               "receptor_node",
               "tenant_id_client_id_client_secret",
               "token",
-              "username_password"
+              "username_password",
+              "provisioning-arn",
+              "provisioning_lighthouse_subscription_id",
+              "provisioning_project_id"
             ]
           },
           "username": {
@@ -2698,6 +2706,7 @@
             "type": "string"
           },
           "authtype": {
+            "type": "string",
             "description": "The type of the authentication",
             "enum": [
               "access_key_secret_key",
@@ -2716,7 +2725,10 @@
               "receptor_node",
               "tenant_id_client_id_client_secret",
               "token",
-              "username_password"
+              "username_password",
+              "provisioning-arn",
+              "provisioning_lighthouse_subscription_id",
+              "provisioning_project_id"
             ]
           },
           "username": {
@@ -3842,7 +3854,10 @@
                     "receptor_node",
                     "tenant_id_client_id_client_secret",
                     "token",
-                    "username_password"
+                    "username_password",
+                    "provisioning-arn",
+                    "provisioning_lighthouse_subscription_id",
+                    "provisioning_project_id"
                   ],
                   "example": "arn",
                   "type": "string"


### PR DESCRIPTION
The new provisioning authtypes are missing from the OpenAPI enum. This itself would not be a huge issue, but what is really important is the missing OpenAPI type (string). Go client generated from the OpenAPI does not unmarshal any unknown (`interface{}` or `any`) types, this leads to be this field to be `nil` and unusable.

This patch fixes that too.