### PR TITLE
Force Database SSL if settings present in Clowder

### DIFF
--- a/dao/db.go
+++ b/dao/db.go
@@ -135,12 +135,14 @@ func Init() {
 
 func dbString() string {
 	return fmt.Sprintf(
-		"user=%s password=%s dbname=%s host=%s port=%d sslmode=disable",
+		"user=%s password=%s dbname=%s host=%s port=%d sslmode=%s sslrootcert=%s",
 		config.Get().DatabaseUser,
 		config.Get().DatabasePassword,
 		config.Get().DatabaseName,
 		config.Get().DatabaseHost,
 		config.Get().DatabasePort,
+		config.Get().DatabaseSSLMode,
+		config.Get().DatabaseCert,
 	)
 }
 
@@ -148,11 +150,13 @@ func dbString() string {
 // any management operations like creating or deleting a database.
 func dbStringDefaultDb() string {
 	return fmt.Sprintf(
-		"user=%s password=%s dbname=postgres host=%s port=%d sslmode=disable",
+		"user=%s password=%s dbname=postgres host=%s port=%d sslmode=%s sslrootcert=%s",
 		config.Get().DatabaseUser,
 		config.Get().DatabasePassword,
 		config.Get().DatabaseHost,
 		config.Get().DatabasePort,
+		config.Get().DatabaseSSLMode,
+		config.Get().DatabaseCert,
 	)
 }
 


### PR DESCRIPTION
Looks like we were keeping `sslmode=disable` throughout stage/prod and we don't want to do that. 

Luckily our RDS instances force SSL - so we were probably fine except for the fact we were validating with only the public CA rather than the rds CA. 

This PR pulls the CA from clowder, writes it to a file, and passes along the sslmode + cert location to the db connection strings. 