### PR TITLE
[RHCLOUD-21109] refactor: string 'x-rh-sources-psk' in event_stream_test.go replaced by existing constant

### DIFF
--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -60,8 +60,8 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 	s := mocks.MockSender{}
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: &s} }
 	c, rec := request.CreateTestContext(http.MethodGet, "/", nil, map[string]interface{}{
-		"x-rh-sources-psk": "1234",
-		h.XRHID:            util.GeneratedXRhIdentity("1234", "1234"),
+		h.PSK:   "1234",
+		h.XRHID: util.GeneratedXRhIdentity("1234", "1234"),
 	})
 
 	f := raiseMiddleware(func(c echo.Context) error {


### PR DESCRIPTION
after discussion in #562 I decided to create PR for each constant from middleware/headers/headers.go 
- to have smaller PRs and 
- to not have chaos in repo commit history

this PR contains changes related with first constant PSK which is not needed to rename so I only found all places where we use string "x-rh-sources-psk" and I used there this constant

all PRs related with this constant refactor will be registered in https://github.com/RedHatInsights/sources-api-go/issues/570

**JIRA:** [RHCLOUD-21109](https://issues.redhat.com/browse/RHCLOUD-21109)