### PR TITLE
[RHCLOUD-21109] Const AccountNumber refactor

### DIFF
--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -90,7 +90,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", h.XRHID, "x-rh-sources-account-number", h.OrgID}
+	expected := []string{"event_type", h.XRHID, h.AccountNumber, h.OrgID}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -31,8 +31,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.PSK, c.Request().Header.Get(h.PSK))
 		}
 
-		if c.Request().Header.Get(h.ACCOUNT_NUMBER) != "" {
-			c.Set(h.ACCOUNT_NUMBER, c.Request().Header.Get(h.ACCOUNT_NUMBER))
+		if c.Request().Header.Get(h.AccountNumber) != "" {
+			c.Set(h.AccountNumber, c.Request().Header.Get(h.AccountNumber))
 		}
 
 		if c.Request().Header.Get(h.OrgID) != "" {
@@ -53,7 +53,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		var id *identity.XRHID
 		xRhIdentityRaw := c.Request().Header.Get(h.XRHID)
 		if xRhIdentityRaw == "" {
-			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.ACCOUNT_NUMBER), c.Request().Header.Get(h.OrgID))
+			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumber), c.Request().Header.Get(h.OrgID))
 
 			// Store the raw, base64 encoded "xRhIdentity" string.
 			c.Set(h.XRHID, generatedIdentity)

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -2,7 +2,7 @@ package headers
 
 const (
 	PSK               = "x-rh-sources-psk"
-	ACCOUNT_NUMBER    = "x-rh-sources-account-number"
+	AccountNumber     = "x-rh-sources-account-number"
 	OrgID             = "x-rh-sources-org-id"
 	PSKUserID         = "x-rh-sources-user-id"
 	XRHID             = "x-rh-identity"

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -29,7 +29,7 @@ func TestParseAll(t *testing.T) {
 
 	c.Request().Header.Set(h.XRHID, xrhid)
 	c.Request().Header.Set(h.PSK, "test-psk")
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
+	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSKUserID, "test-psk-user")
 	c.Request().Header.Set(h.OrgID, "test-orgid")
 
@@ -46,8 +46,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get(h.PSK).(string), "test-psk")
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "test-ebs-account-number" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "test-ebs-account-number")
+	if c.Get(h.AccountNumber).(string) != "test-ebs-account-number" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "test-ebs-account-number")
 	}
 
 	if c.Get(h.PSKUserID).(string) != "test-psk-user" {
@@ -83,7 +83,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 	)
 
 	c.Request().Header.Set(h.PSK, "test-psk")
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
+	c.Request().Header.Set(h.AccountNumber, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSKUserID, "test-psk-user")
 	c.Request().Header.Set(h.OrgID, "test-orgid")
 
@@ -100,8 +100,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get(h.PSK).(string), "test-psk")
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "test-ebs-account-number" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "test-ebs-account-number")
+	if c.Get(h.AccountNumber).(string) != "test-ebs-account-number" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "test-ebs-account-number")
 	}
 
 	if c.Get(h.PSKUserID).(string) != "test-psk-user" {
@@ -134,7 +134,7 @@ func TestParseAccountNumber(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
+	c.Request().Header.Set(h.AccountNumber, "9876")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -145,8 +145,8 @@ func TestParseAccountNumber(t *testing.T) {
 		t.Errorf("%v was returned instead of %v", rec.Code, 204)
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+	if c.Get(h.AccountNumber).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "9876")
 	}
 }
 
@@ -210,7 +210,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 	)
 
 	c.Request().Header.Set(h.PSK, "1234")
-	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
+	c.Request().Header.Set(h.AccountNumber, "9876")
 	c.Request().Header.Set(h.PSKUserID, "555555")
 
 	err := parseOrElse204(c)
@@ -226,8 +226,8 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was set as psk instead of %v", c.Get("psk").(string), "1234")
 	}
 
-	if c.Get(h.ACCOUNT_NUMBER).(string) != "9876" {
-		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
+	if c.Get(h.AccountNumber).(string) != "9876" {
+		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.AccountNumber).(string), "9876")
 	}
 
 	if c.Get(h.PSKUserID).(string) != "555555" {

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -14,7 +14,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		uri := c.Request().RequestURI
 		method := c.Request().Method
 		agent := c.Request().UserAgent()
-		acct := c.Get(h.ACCOUNT_NUMBER)
+		acct := c.Get(h.AccountNumber)
 		orgid := c.Get(h.OrgID)
 		uuid := c.Get(h.InsightsRequestID)
 

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -56,7 +56,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// accept EBS account numbers anymore. However, we can deal with that by forwarding the OrgId too if we have it
 		// stored in the database.
 		c.Set(h.TenantID, tenant.Id)
-		c.Set(h.ACCOUNT_NUMBER, tenant.ExternalTenant)
+		c.Set(h.AccountNumber, tenant.ExternalTenant)
 		c.Set(h.OrgID, tenant.OrgID)
 
 		return next(c)

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -61,8 +61,8 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 	// Prepare the headers we will be testing this with. We will try with one at a time.
 	testHeaders := map[string]string{
-		headers.ACCOUNT_NUMBER: accountNumber,
-		headers.OrgID:          orgId,
+		headers.AccountNumber: accountNumber,
+		headers.OrgID:         orgId,
 	}
 
 	for key, value := range testHeaders {
@@ -101,7 +101,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := accountNumber
-			got := c.Get(headers.ACCOUNT_NUMBER)
+			got := c.Get(headers.AccountNumber)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s". Invalid account number set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%s", got "%s"`, key, value, want, got)

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -28,7 +28,7 @@ func (t Tenant) GetHeadersWithGeneratedXRHID() []kafka.Header {
 
 func (t Tenant) GetHeaders() []kafka.Header {
 	return []kafka.Header{
-		{Key: h.ACCOUNT_NUMBER, Value: []byte(t.ExternalTenant)},
+		{Key: h.AccountNumber, Value: []byte(t.ExternalTenant)},
 		{Key: h.OrgID, Value: []byte(t.OrgID)},
 	}
 }

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -114,7 +114,7 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 	}
 
 	req.Header.Add(h.OrgID, source.Tenant.OrgID)
-	req.Header.Add("x-rh-sources-account-number", source.Tenant.ExternalTenant)
+	req.Header.Add(h.AccountNumber, source.Tenant.ExternalTenant)
 	req.Header.Add(h.XRHID, util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
@@ -188,7 +188,7 @@ func (acr availabilityCheckRequester) publishSatelliteMessage(writer *kafka.Writ
 		{Key: "event_type", Value: []byte("Source.availability_check")},
 		{Key: "encoding", Value: []byte("json")},
 		{Key: h.XRHID, Value: []byte(util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))},
-		{Key: "x-rh-sources-account-number", Value: []byte(endpoint.Tenant.ExternalTenant)},
+		{Key: h.AccountNumber, Value: []byte(endpoint.Tenant.ExternalTenant)},
 	})
 
 	if err = kafka.Produce(writer, msg); err != nil {

--- a/service/events.go
+++ b/service/events.go
@@ -41,8 +41,8 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	var ok bool
 
 	// pulling the specified account if it exists
-	if c.Get(h.ACCOUNT_NUMBER) != nil {
-		account, ok = c.Get(h.ACCOUNT_NUMBER).(string)
+	if c.Get(h.AccountNumber) != nil {
+		account, ok = c.Get(h.AccountNumber).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
@@ -83,7 +83,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 
 	// need to check org_id + account since one or the other might not be there.
 	if account != "" {
-		headers = append(headers, kafka.Header{Key: h.ACCOUNT_NUMBER, Value: []byte(account)})
+		headers = append(headers, kafka.Header{Key: h.AccountNumber, Value: []byte(account)})
 	}
 	if orgId != "" {
 		headers = append(headers, kafka.Header{Key: h.OrgID, Value: []byte(orgId)})

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -40,7 +40,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 		pskHeader := headers[0]
 
 		{
-			want := "x-rh-sources-account-number"
+			want := h.AccountNumber
 			got := pskHeader.Key
 
 			if want != got {
@@ -189,7 +189,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	{
 		accountHeader := headers[0]
 		{
-			want := "x-rh-sources-account-number"
+			want := h.AccountNumber
 			got := accountHeader.Key
 
 			if want != got {

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -19,7 +19,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 	testPskAccountValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.ACCOUNT_NUMBER, testPskAccountValue)
+	context.Set(h.AccountNumber, testPskAccountValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -419,7 +419,7 @@ func TestConsumeStatusMessage(t *testing.T) {
 	header := kafkaGo.Header{Key: "event_type", Value: []byte("availability_status")}
 	// {"identity":{"account_number":"12345","user": {"is_org_admin":true}}, "internal": {"org_id": "000001"}}
 	header2 := kafkaGo.Header{Key: h.XRHID, Value: []byte("eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQ1IiwidXNlciI6IHsiaXNfb3JnX2FkbWluIjp0cnVlfX0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjAwMDAwMSJ9fQo=")}
-	header3 := kafkaGo.Header{Key: "x-rh-sources-account-number", Value: []byte("12345")}
+	header3 := kafkaGo.Header{Key: h.AccountNumber, Value: []byte("12345")}
 	headers := []kafkaGo.Header{header, header2, header3}
 	statusMessage := types.StatusMessage{ResourceType: "Source", ResourceID: "1", ResourceIDRaw: "1", Status: m.Available}
 	sourceTestData := TestData{StatusMessage: statusMessage, MessageHeaders: headers, RaiseEventCalled: true}

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -11,10 +11,6 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-const (
-	xrhAccountNumberKey string = "x-rh-sources-account-number"
-)
-
 func ParseXRHIDHeader(inputIdentity string) (*identity.XRHID, error) {
 	var XRHIdentity *identity.XRHID
 	decodedIdentity, err := base64.StdEncoding.DecodeString(inputIdentity)
@@ -38,7 +34,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 	var outputIdentity identity.Identity
 
 	for _, header := range headers {
-		if header.Key == xrhAccountNumberKey {
+		if header.Key == h.AccountNumber {
 			outputIdentity.AccountNumber = string(header.Value)
 		}
 
@@ -57,7 +53,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 	}
 
 	if outputIdentity.AccountNumber == "" && outputIdentity.OrgID == "" {
-		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", xrhAccountNumberKey, h.XRHID)
+		return nil, fmt.Errorf("unable to get identity number from headers, %s and %s are missing", h.AccountNumber, h.XRHID)
 	}
 
 	return &outputIdentity, nil

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -131,7 +131,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 	// Lastly test with the "x-rh-account-number" and "x-rh-sources-org-id" header.
 	headers = []kafka.Header{
 		{
-			Key:   xrhAccountNumberKey,
+			Key:   h.AccountNumber,
 			Value: []byte(accountNumber),
 		},
 		{


### PR DESCRIPTION
after discussion in #562 I decided to create PR for each constant from middleware/headers/headers.go 
- to have smaller PRs and 
- to not have chaos in repo commit history

this PR contains changes related with constant ACCOUNT_NUMBER

all PRs related with this constant refactor will be registered in https://github.com/RedHatInsights/sources-api-go/issues/570

**JIRA:** [RHCLOUD-21109](https://issues.redhat.com/browse/RHCLOUD-21109)