### PR TITLE
[RHCLOUD-21109]  Constant OrgID refactor

### DIFF
--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -90,7 +90,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 		t.Errorf("Headers not set properly from RaiseEvent")
 	}
 
-	expected := []string{"event_type", h.XRHID, "x-rh-sources-account-number", "x-rh-sources-org-id"}
+	expected := []string{"event_type", h.XRHID, "x-rh-sources-account-number", h.OrgID}
 	for _, h := range s.Headers {
 		if !util.SliceContainsString(expected, h.Key) {
 			t.Errorf("Got bad header: [%v: %v]", h.Key, h.Value)

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -35,8 +35,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.ACCOUNT_NUMBER, c.Request().Header.Get(h.ACCOUNT_NUMBER))
 		}
 
-		if c.Request().Header.Get(h.ORGID) != "" {
-			c.Set(h.ORGID, c.Request().Header.Get(h.ORGID))
+		if c.Request().Header.Get(h.OrgID) != "" {
+			c.Set(h.OrgID, c.Request().Header.Get(h.OrgID))
 		}
 
 		if c.Request().Header.Get(h.PSKUserID) != "" {
@@ -53,7 +53,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		var id *identity.XRHID
 		xRhIdentityRaw := c.Request().Header.Get(h.XRHID)
 		if xRhIdentityRaw == "" {
-			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.ACCOUNT_NUMBER), c.Request().Header.Get(h.ORGID))
+			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.ACCOUNT_NUMBER), c.Request().Header.Get(h.OrgID))
 
 			// Store the raw, base64 encoded "xRhIdentity" string.
 			c.Set(h.XRHID, generatedIdentity)

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -3,7 +3,7 @@ package headers
 const (
 	PSK                 = "x-rh-sources-psk"
 	ACCOUNT_NUMBER      = "x-rh-sources-account-number"
-	ORGID               = "x-rh-sources-org-id"
+	OrgID               = "x-rh-sources-org-id"
 	PSKUserID           = "x-rh-sources-user-id"
 	XRHID               = "x-rh-identity"
 	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -31,7 +31,7 @@ func TestParseAll(t *testing.T) {
 	c.Request().Header.Set(h.PSK, "test-psk")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSKUserID, "test-psk-user")
-	c.Request().Header.Set(h.ORGID, "test-orgid")
+	c.Request().Header.Set(h.OrgID, "test-orgid")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -54,8 +54,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSKUserID).(string), "test-psk-user")
 	}
 
-	if c.Get(h.ORGID).(string) != "test-orgid" {
-		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.ORGID).(string))
+	if c.Get(h.OrgID).(string) != "test-orgid" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgID).(string))
 	}
 
 	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
@@ -85,7 +85,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 	c.Request().Header.Set(h.PSK, "test-psk")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
 	c.Request().Header.Set(h.PSKUserID, "test-psk-user")
-	c.Request().Header.Set(h.ORGID, "test-orgid")
+	c.Request().Header.Set(h.OrgID, "test-orgid")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -108,8 +108,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSKUserID).(string), "test-psk-user")
 	}
 
-	if c.Get(h.ORGID).(string) != "test-orgid" {
-		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.ORGID).(string))
+	if c.Get(h.OrgID).(string) != "test-orgid" {
+		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgID).(string))
 	}
 
 	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -15,7 +15,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		method := c.Request().Method
 		agent := c.Request().UserAgent()
 		acct := c.Get(h.ACCOUNT_NUMBER)
-		orgid := c.Get(h.ORGID)
+		orgid := c.Get(h.OrgID)
 		uuid := c.Get(h.INSIGHTS_REQUEST_ID)
 
 		baseFields := logrus.Fields{

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -57,7 +57,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// stored in the database.
 		c.Set(h.TENANTID, tenant.Id)
 		c.Set(h.ACCOUNT_NUMBER, tenant.ExternalTenant)
-		c.Set(h.ORGID, tenant.OrgID)
+		c.Set(h.OrgID, tenant.OrgID)
 
 		return next(c)
 	}

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -62,7 +62,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 	// Prepare the headers we will be testing this with. We will try with one at a time.
 	testHeaders := map[string]string{
 		headers.ACCOUNT_NUMBER: accountNumber,
-		headers.ORGID:          orgId,
+		headers.OrgID:          orgId,
 	}
 
 	for key, value := range testHeaders {
@@ -110,7 +110,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := orgId
-			got := c.Get(headers.ORGID)
+			got := c.Get(headers.OrgID)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s. Invalid OrgId set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%s", got "%s"`, key, value, want, got)

--- a/model/tenant.go
+++ b/model/tenant.go
@@ -29,7 +29,7 @@ func (t Tenant) GetHeadersWithGeneratedXRHID() []kafka.Header {
 func (t Tenant) GetHeaders() []kafka.Header {
 	return []kafka.Header{
 		{Key: h.ACCOUNT_NUMBER, Value: []byte(t.ExternalTenant)},
-		{Key: h.ORGID, Value: []byte(t.OrgID)},
+		{Key: h.OrgID, Value: []byte(t.OrgID)},
 	}
 }
 

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -113,7 +113,7 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 		return
 	}
 
-	req.Header.Add("x-rh-sources-org-id", source.Tenant.OrgID)
+	req.Header.Add(h.OrgID, source.Tenant.OrgID)
 	req.Header.Add("x-rh-sources-account-number", source.Tenant.ExternalTenant)
 	req.Header.Add(h.XRHID, util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")

--- a/service/events.go
+++ b/service/events.go
@@ -49,8 +49,8 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	}
 
 	// pulling the specified orgId if it exists
-	if c.Get(h.ORGID) != nil {
-		orgId, ok = c.Get(h.ORGID).(string)
+	if c.Get(h.OrgID) != nil {
+		orgId, ok = c.Get(h.OrgID).(string)
 		if !ok {
 			return nil, fmt.Errorf("failed to cast psk-account to string")
 		}
@@ -86,7 +86,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 		headers = append(headers, kafka.Header{Key: h.ACCOUNT_NUMBER, Value: []byte(account)})
 	}
 	if orgId != "" {
-		headers = append(headers, kafka.Header{Key: h.ORGID, Value: []byte(orgId)})
+		headers = append(headers, kafka.Header{Key: h.OrgID, Value: []byte(orgId)})
 	}
 
 	headers = append(headers, kafka.Header{Key: h.XRHID, Value: []byte(xrhid)})

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -87,7 +87,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 	testOrgIdValue := "abcde"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.ORGID, testOrgIdValue)
+	context.Set(h.OrgID, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)
@@ -270,7 +270,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 	testOrgIdValue := "12345"
 
 	context, _ := request.CreateTestContext("GET", "https://example.org/hello", nil, nil)
-	context.Set(h.ORGID, testOrgIdValue)
+	context.Set(h.OrgID, testOrgIdValue)
 
 	// Call the function under test.
 	headers, err := ForwadableHeaders(context)

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -108,7 +108,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 		orgIdHeader := headers[0]
 
 		{
-			want := "x-rh-sources-org-id"
+			want := h.OrgID
 			got := orgIdHeader.Key
 
 			if want != got {
@@ -211,7 +211,7 @@ func TestForwadableHeadersXrhId(t *testing.T) {
 	{
 		orgIdHeader := headers[1]
 		{
-			want := "x-rh-sources-org-id"
+			want := h.OrgID
 			got := orgIdHeader.Key
 
 			if want != got {
@@ -291,7 +291,7 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 		orgIdHeader := headers[0]
 
 		{
-			want := "x-rh-sources-org-id"
+			want := h.OrgID
 			got := orgIdHeader.Key
 
 			if want != got {

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -42,7 +42,7 @@ func IdentityFromKafkaHeaders(headers []kafka.Header) (*identity.Identity, error
 			outputIdentity.AccountNumber = string(header.Value)
 		}
 
-		if header.Key == h.ORGID {
+		if header.Key == h.OrgID {
 			outputIdentity.OrgID = string(header.Value)
 		}
 

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -135,7 +135,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 			Value: []byte(accountNumber),
 		},
 		{
-			Key:   h.ORGID,
+			Key:   h.OrgID,
 			Value: []byte(orgId),
 		},
 	}


### PR DESCRIPTION
after discussion in #562 I decided to create PR for each constant from middleware/headers/headers.go 
- to have smaller PRs and 
- to not have chaos in repo commit history

this PR contains changes related with constant ORGID

all PRs related with this constant refactor will be registered in #570

**JIRA:** [RHCLOUD-21109](https://issues.redhat.com/browse/RHCLOUD-21109)