### PR TITLE
[RHCLOUD-21109]  Constant PSKUserID refactor

### DIFF
--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -39,8 +39,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.ORGID, c.Request().Header.Get(h.ORGID))
 		}
 
-		if c.Request().Header.Get(h.PSK_USER) != "" {
-			c.Set(h.PSK_USER, c.Request().Header.Get(h.PSK_USER))
+		if c.Request().Header.Get(h.PSKUserID) != "" {
+			c.Set(h.PSKUserID, c.Request().Header.Get(h.PSKUserID))
 		}
 
 		if c.Request().Header.Get(h.INSIGHTS_REQUEST_ID) != "" {

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -4,7 +4,7 @@ const (
 	PSK                 = "x-rh-sources-psk"
 	ACCOUNT_NUMBER      = "x-rh-sources-account-number"
 	ORGID               = "x-rh-sources-org-id"
-	PSK_USER            = "x-rh-sources-user-id"
+	PSKUserID           = "x-rh-sources-user-id"
 	XRHID               = "x-rh-identity"
 	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"
 	PARSED_IDENTITY     = "identity"

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -30,7 +30,7 @@ func TestParseAll(t *testing.T) {
 	c.Request().Header.Set(h.XRHID, xrhid)
 	c.Request().Header.Set(h.PSK, "test-psk")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
-	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
+	c.Request().Header.Set(h.PSKUserID, "test-psk-user")
 	c.Request().Header.Set(h.ORGID, "test-orgid")
 
 	err := parseOrElse204(c)
@@ -50,8 +50,8 @@ func TestParseAll(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "test-ebs-account-number")
 	}
 
-	if c.Get(h.PSK_USER).(string) != "test-psk-user" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "test-psk-user")
+	if c.Get(h.PSKUserID).(string) != "test-psk-user" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSKUserID).(string), "test-psk-user")
 	}
 
 	if c.Get(h.ORGID).(string) != "test-orgid" {
@@ -84,7 +84,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 
 	c.Request().Header.Set(h.PSK, "test-psk")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "test-ebs-account-number")
-	c.Request().Header.Set(h.PSK_USER, "test-psk-user")
+	c.Request().Header.Set(h.PSKUserID, "test-psk-user")
 	c.Request().Header.Set(h.ORGID, "test-orgid")
 
 	err := parseOrElse204(c)
@@ -104,8 +104,8 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "test-ebs-account-number")
 	}
 
-	if c.Get(h.PSK_USER).(string) != "test-psk-user" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "test-psk-user")
+	if c.Get(h.PSKUserID).(string) != "test-psk-user" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSKUserID).(string), "test-psk-user")
 	}
 
 	if c.Get(h.ORGID).(string) != "test-orgid" {
@@ -211,7 +211,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 
 	c.Request().Header.Set(h.PSK, "1234")
 	c.Request().Header.Set(h.ACCOUNT_NUMBER, "9876")
-	c.Request().Header.Set(h.PSK_USER, "555555")
+	c.Request().Header.Set(h.PSKUserID, "555555")
 
 	err := parseOrElse204(c)
 	if err != nil {
@@ -230,7 +230,7 @@ func TestOnlyPskHeaders(t *testing.T) {
 		t.Errorf("%v was set as psk-account instead of %v", c.Get(h.ACCOUNT_NUMBER).(string), "9876")
 	}
 
-	if c.Get(h.PSK_USER).(string) != "555555" {
-		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSK_USER).(string), "555555")
+	if c.Get(h.PSKUserID).(string) != "555555" {
+		t.Errorf("%v was set as x-rh-sources-user-id instead of %v", c.Get(h.PSKUserID).(string), "555555")
 	}
 }

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -19,8 +19,8 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 		var userIDFromContext string
 
 		switch {
-		case c.Get(h.PSK_USER) != nil:
-			userID, ok := c.Get(h.PSK_USER).(string)
+		case c.Get(h.PSKUserID) != nil:
+			userID, ok := c.Get(h.PSKUserID).(string)
 			if !ok {
 				return fmt.Errorf("failed to pull user id from request")
 			}

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -78,7 +78,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 	)
 
 	c.Set(h.TENANTID, tenantID)
-	c.Set(h.PSK_USER, testUserID)
+	c.Set(h.PSKUserID, testUserID)
 
 	err := catchUserOrElse204(c)
 	if err != nil {


### PR DESCRIPTION
after discussion in #562 I decided to create PR for each constant from middleware/headers/headers.go 
- to have smaller PRs and 
- to not have chaos in repo commit history

this PR contains changes related with constant PSK_USER

all PRs related with this constant refactor will be registered in #570

**JIRA:** [RHCLOUD-21109](https://issues.redhat.com/browse/RHCLOUD-21109)