### PR TITLE
[RHCLOUD-21109] Constant InsightsRequestID refactor

### DIFF
--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -25,7 +25,7 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 				message = util.ErrorDocWithoutLogging(err.Error(), "400")
 			default:
 				c.Logger().Error(err)
-				uuid, ok := c.Get(h.INSIGHTS_REQUEST_ID).(string)
+				uuid, ok := c.Get(h.InsightsRequestID).(string)
 				if !ok {
 					uuid = ""
 				}

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -43,8 +43,8 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.PSKUserID, c.Request().Header.Get(h.PSKUserID))
 		}
 
-		if c.Request().Header.Get(h.INSIGHTS_REQUEST_ID) != "" {
-			c.Set(h.INSIGHTS_REQUEST_ID, c.Request().Header.Get(h.INSIGHTS_REQUEST_ID))
+		if c.Request().Header.Get(h.InsightsRequestID) != "" {
+			c.Set(h.InsightsRequestID, c.Request().Header.Get(h.InsightsRequestID))
 		}
 
 		// id is the XrhId struct we will store in the context. The idea is: if no "x-rh-identity" header has been

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -1,13 +1,13 @@
 package headers
 
 const (
-	PSK                 = "x-rh-sources-psk"
-	ACCOUNT_NUMBER      = "x-rh-sources-account-number"
-	OrgID               = "x-rh-sources-org-id"
-	PSKUserID           = "x-rh-sources-user-id"
-	XRHID               = "x-rh-identity"
-	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"
-	ParsedIdentity      = "identity"
-	TenantID            = "tenantID"
-	UserID              = "userID"
+	PSK               = "x-rh-sources-psk"
+	ACCOUNT_NUMBER    = "x-rh-sources-account-number"
+	OrgID             = "x-rh-sources-org-id"
+	PSKUserID         = "x-rh-sources-user-id"
+	XRHID             = "x-rh-identity"
+	InsightsRequestID = "x-rh-insights-request-id"
+	ParsedIdentity    = "identity"
+	TenantID          = "tenantID"
+	UserID            = "userID"
 )

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -16,7 +16,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		agent := c.Request().UserAgent()
 		acct := c.Get(h.ACCOUNT_NUMBER)
 		orgid := c.Get(h.OrgID)
-		uuid := c.Get(h.INSIGHTS_REQUEST_ID)
+		uuid := c.Get(h.InsightsRequestID)
 
 		baseFields := logrus.Fields{
 			"uri":            uri,


### PR DESCRIPTION
after discussion in #562 I decided to create PR for each constant from middleware/headers/headers.go 
- to have smaller PRs and 
- to not have chaos in repo commit history

this PR contains changes related with constant INSIGHTS_REQUEST_ID

all PRs related with this constant refactor will be registered in #570

**JIRA:** [RHCLOUD-21109](https://issues.redhat.com/browse/RHCLOUD-21109)