### PR TITLE
Add a key to kafka messages on the event-stream to ensure ordering per-orgid

### DIFF
--- a/internal/events/event_stream_producer.go
+++ b/internal/events/event_stream_producer.go
@@ -53,6 +53,7 @@ func (esp *EventStreamSender) RaiseEvent(eventType string, payload []byte, heade
 
 	m.AddHeaders(headers)
 	m.AddValue(payload)
+	m.SetKeyFromHeaders()
 
 	if err := kafka.Produce(kf, m); err != nil {
 		return err

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -141,13 +141,7 @@ func Produce(writer *Writer, message *Message) error {
 	}
 
 	if !message.isEmpty() {
-		err := writer.WriteMessages(
-			context.Background(),
-			kafka.Message{
-				Headers: message.Headers,
-				Value:   message.Value,
-			},
-		)
+		err := writer.WriteMessages(context.Background(), kafka.Message(*message))
 
 		if err != nil {
 			headersMap := make(map[string]string)

--- a/kafka/message.go
+++ b/kafka/message.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"encoding/json"
 
+	"github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/segmentio/kafka-go"
 )
 
@@ -45,6 +46,23 @@ func (message *Message) AddValueAsJSON(record interface{}) error {
 	message.AddValue(out)
 
 	return nil
+}
+
+/*
+Set the key on the kafka message from the headers, using this precedence:
+1. OrgID, every req _should_ have one of these.
+2. EBS Account Number, fallback
+3. XRHID, if we have neither...hopefully there is a x-rh-identity we can use!
+*/
+func (message *Message) SetKeyFromHeaders() {
+	var k string
+	if k = message.GetHeader(headers.OrgID); k != "" {
+		message.Key = []byte(k)
+	} else if k = message.GetHeader(headers.AccountNumber); k != "" {
+		message.Key = []byte(k)
+	} else if k = message.GetHeader(headers.XRHID); k != "" {
+		message.Key = []byte(k)
+	}
 }
 
 func (message *Message) isEmpty() bool {

--- a/kafka/message_test.go
+++ b/kafka/message_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/segmentio/kafka-go/protocol"
 )
 
@@ -48,5 +49,62 @@ func TestIsEmpty(t *testing.T) {
 
 	if m.isEmpty() {
 		t.Error("Message#IsEmpty showed empty even though it is not an empty struct")
+	}
+}
+
+func TestSetKeyFromHeadersOrgId(t *testing.T) {
+	m := Message{Headers: []protocol.Header{
+		{Key: headers.OrgID, Value: []byte("one")},
+		{Key: headers.AccountNumber, Value: []byte("two")},
+		{Key: headers.XRHID, Value: []byte("three")},
+	}}
+	m.SetKeyFromHeaders()
+
+	if m.Key == nil || len(m.Key) == 0 {
+		t.Error("key was not set")
+	}
+
+	if string(m.Key) != "one" {
+		t.Error("key did not match")
+	}
+}
+
+func TestSetKeyFromHeadersAcctNumber(t *testing.T) {
+	m := Message{Headers: []protocol.Header{
+		{Key: headers.AccountNumber, Value: []byte("two")},
+		{Key: headers.XRHID, Value: []byte("three")},
+	}}
+	m.SetKeyFromHeaders()
+
+	if m.Key == nil || len(m.Key) == 0 {
+		t.Error("key was not set")
+	}
+
+	if string(m.Key) != "two" {
+		t.Error("key did not match")
+	}
+}
+
+func TestSetKeyFromHeadersXrhid(t *testing.T) {
+	m := Message{Headers: []protocol.Header{
+		{Key: headers.XRHID, Value: []byte("three")},
+	}}
+	m.SetKeyFromHeaders()
+
+	if m.Key == nil || len(m.Key) == 0 {
+		t.Error("key was not set")
+	}
+
+	if string(m.Key) != "three" {
+		t.Error("key did not match")
+	}
+}
+
+func TestSetKeyFromHeadersNone(t *testing.T) {
+	m := Message{Headers: []protocol.Header{}}
+	m.SetKeyFromHeaders()
+
+	if m.Key != nil || len(m.Key) != 0 {
+		t.Error("key was set when it should not have been set")
 	}
 }


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/RHCLOUD-21370

This has the potential to fix the out-of-order messaging problems that our sub-apps have been seeing.

The tl;dr is that kafka has the ability to set a `key` on each message - this controls which partition the messages get sent to thus controlling ordering. The problem is that when I read about this feature the first time and was looking into it I thought we'd set the key to the same string every time (e.g. `event-stream`) which would lock ALL messages to one partition and we'd lose the ability to scale.

After approaching the problem again and brainstorming with GM it became apparent that we could use the orgID and various other identifiers per-tenant to ensure that each tenant's messages would be sent and arrive in order, so we'd lose the scaling per-tenant, but still be spreading the load across available partitions. 

---

I am going to throw together a program to validate that this fixes the issue before un-wipping it. 

EDIT: Testing program here: https://gist.github.com/lindgrenj6/f463a85267d89f330a736a5d1795ec35

Video demonstrating: 

https://user-images.githubusercontent.com/5856504/192583258-502fae04-6c6c-4ef6-b843-9c66e7099d23.mp4

