### PR TITLE
[RHCLOUD-21109] Constant ParsedIdentity refactor

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -833,7 +834,7 @@ func TestApplicationEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(strconv.Itoa(int(applicationID)))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	appEditHandlerWithNotifier := middleware.Notifier(ApplicationEdit)
 	err = appEditHandlerWithNotifier(c)

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -502,7 +503,7 @@ func TestAuthenticationEdit(t *testing.T) {
 	c.SetParamNames("uid")
 	c.SetParamValues(uid)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	authEditHandlerWithNotifier := middleware.Notifier(AuthenticationEdit)
 	err = authEditHandlerWithNotifier(c)

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -27,7 +27,7 @@ func BulkCreate(c echo.Context) error {
 	if !ok {
 		c.Logger().Warnf("bad xrhid %v", c.Get(h.XRHID))
 	}
-	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
 		c.Logger().Warnf("failed to pull identity from request")
 		return fmt.Errorf("failed to pull identity from request")

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -41,7 +41,7 @@ func TestBulkCreateMissingSourceType(t *testing.T) {
 		},
 	)
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	user, err := dao.GetUserDao(&fixtures.TestTenantData[0].Id).FindOrCreate(testUserId)
 	if err != nil {
@@ -89,7 +89,7 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", identityHeader)
+	c.Set(h.ParsedIdentity, identityHeader)
 
 	var user m.User
 	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).First(&user).Error
@@ -199,7 +199,7 @@ func TestBulkCreate(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", identityHeader)
+	c.Set(h.ParsedIdentity, identityHeader)
 
 	err = BulkCreate(c)
 	if err != nil {
@@ -285,7 +285,7 @@ func TestBulkCreateSourceValidationBadRequest(t *testing.T) {
 	)
 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	badRequestBulkCreate := ErrorHandlingContext(BulkCreate)
 	err = badRequestBulkCreate(c)

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/templates"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -755,7 +756,7 @@ func TestEndpointEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues("1")
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(EndpointEdit)
 	err := sourceEditHandlerWithNotifier(c)

--- a/helpers.go
+++ b/helpers.go
@@ -80,7 +80,7 @@ func setEventStreamResource(c echo.Context, model m.Event) {
 }
 
 func getAccountNumberFromEchoContext(c echo.Context) (string, error) {
-	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
 		return "", fmt.Errorf("failed to pull identity from context")
 	}

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -51,7 +51,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			// first check the identity (already parsed) to see if it contains
 			// the system key and if it does do some extra checks to authorize
 			// based on some internal rules (operator + satellite)
-			id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+			id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("error casting identity to struct: %+v", c.Get("identity"))
 			}

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -53,7 +53,7 @@ func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 			// based on some internal rules (operator + satellite)
 			id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 			if !ok {
-				return fmt.Errorf("error casting identity to struct: %+v", c.Get("identity"))
+				return fmt.Errorf("error casting identity to struct: %+v", c.Get(h.ParsedIdentity))
 			}
 
 			// checking to see if we're going to change the results since

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -112,7 +112,7 @@ func TestSystemClusterID(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.XRHID: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						ClusterId: "test_cluster",
@@ -139,7 +139,7 @@ func TestSystemCN(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.XRHID: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -166,7 +166,7 @@ func TestSystemPatch(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.XRHID: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -193,7 +193,7 @@ func TestSystemDelete(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.XRHID: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -220,7 +220,7 @@ func TestSystemDeleteSource(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.XRHID: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -247,7 +247,7 @@ func TestSystemDeleteSourceVersioned(t *testing.T) {
 		nil,
 		map[string]interface{}{
 			h.XRHID: "dummy",
-			"identity": &identity.XRHID{
+			h.ParsedIdentity: &identity.XRHID{
 				Identity: identity.Identity{
 					System: identity.System{
 						CommonName: "test_cert",
@@ -289,8 +289,8 @@ func TestRbacWithAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.XRHID:    "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity": &identity.XRHID{Identity: identity.Identity{}},
+			h.XRHID:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentity: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -312,8 +312,8 @@ func TestRbacWithoutAccess(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.XRHID:    "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity": &identity.XRHID{Identity: identity.Identity{}},
+			h.XRHID:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentity: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 
@@ -335,8 +335,8 @@ func TestRbacNoConnection(t *testing.T) {
 		"/",
 		nil,
 		map[string]interface{}{
-			h.XRHID:    "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
-			"identity": &identity.XRHID{Identity: identity.Identity{}},
+			h.XRHID:          "a wild xrhid - i mean eyJlbnRpdGxlbWVudHMiOnsiaW5zaWdodHMiOnsiaXNfZW50aXRsZWQiOnRydWV9LCJtaWdyYXRpb25zIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwiaHlicmlkX2Nsb3VkIjp7ImlzX2VudGl0bGVkIjp0cnVlfSwib3BlbnNoaWZ0Ijp7ImlzX2VudGl0bGVkIjp0cnVlfSwic21hcnRfbWFuYWdlbWVudCI6eyJpc19lbnRpdGxlZCI6dHJ1Z",
+			h.ParsedIdentity: &identity.XRHID{Identity: identity.Identity{}},
 		},
 	)
 

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -82,7 +82,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			id = xRhIdentity
 		}
 
-		c.Set(h.PARSED_IDENTITY, id)
+		c.Set(h.ParsedIdentity, id)
 
 		return next(c)
 	}

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -7,7 +7,7 @@ const (
 	PSKUserID           = "x-rh-sources-user-id"
 	XRHID               = "x-rh-identity"
 	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"
-	PARSED_IDENTITY     = "identity"
+	ParsedIdentity      = "identity"
 	TenantID            = "tenantID"
 	UserID              = "userID"
 )

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -60,7 +60,7 @@ func TestParseAll(t *testing.T) {
 
 	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
-		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
+		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get(h.ParsedIdentity)))
 	}
 
 	if id.Identity.AccountNumber != "12345" {
@@ -114,7 +114,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 
 	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
-		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
+		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get(h.ParsedIdentity)))
 	}
 
 	if id.Identity.AccountNumber != "test-ebs-account-number" {

--- a/middleware/headers_test.go
+++ b/middleware/headers_test.go
@@ -58,7 +58,7 @@ func TestParseAll(t *testing.T) {
 		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgID).(string))
 	}
 
-	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
 		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
 	}
@@ -112,7 +112,7 @@ func TestParseWithoutXrhid(t *testing.T) {
 		t.Errorf(`invalid org id set. Want "%s", got "%s"`, "abcde", c.Get(h.OrgID).(string))
 	}
 
-	id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
 		t.Errorf(`unexpected type of identity received. Want "*identity.XRHID", got "%s"`, reflect.TypeOf(c.Get("identity")))
 	}

--- a/middleware/notifier.go
+++ b/middleware/notifier.go
@@ -21,7 +21,7 @@ func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
 			return fmt.Errorf("unable to find emailNotificationInfo instance in middleware")
 		}
 
-		xRhIdentity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+		xRhIdentity, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 		if !ok {
 			return fmt.Errorf("failed to fetch the identity header")
 		}

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -16,7 +16,7 @@ import (
 // account number or OrgId.
 func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		id, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+		id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 		if !ok {
 			return fmt.Errorf("invalid identity structure received: %#v", id)
 		}
@@ -46,7 +46,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// Update the identity struct with the tenancy data from the database.
 		id.Identity.OrgID = tenant.OrgID
 		id.Identity.AccountNumber = tenant.ExternalTenant
-		c.Set(h.PARSED_IDENTITY, id)
+		c.Set(h.ParsedIdentity, id)
 
 		// Store the ID, EBS account number and OrgId from what we've got in the database. Prior to this, we stored
 		// the contents of the incoming headers, but this had a problem: if we only received an EBS account number, we

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -77,7 +77,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 		}
 
 		{
-			id, ok := c.Get(headers.PARSED_IDENTITY).(*identity.XRHID)
+			id, ok := c.Get(headers.ParsedIdentity).(*identity.XRHID)
 			if !ok {
 				t.Errorf("unable to correctly type cast the parsed identity from the context")
 			}

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -27,8 +27,8 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 
 			userIDFromContext = userID
 
-		case c.Get(h.PARSED_IDENTITY) != nil:
-			xRhIdentity, ok := c.Get(h.PARSED_IDENTITY).(*identity.XRHID)
+		case c.Get(h.ParsedIdentity) != nil:
+			xRhIdentity, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 			if !ok {
 				return fmt.Errorf("failed to fetch the identity header")
 			}

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -34,7 +34,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 	)
 
 	c.Set(h.TenantID, tenantID)
-	c.Set(h.PARSED_IDENTITY, identity)
+	c.Set(h.ParsedIdentity, identity)
 
 	err := catchUserOrElse204(c)
 	if err != nil {

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -213,7 +213,7 @@ func createSecretRequest(t *testing.T, requestBody *m.SecretCreateRequest, tenan
 
 	testUserId := "testUser"
 	identityHeader := testutils.IdentityHeaderForUser(testUserId)
-	c.Set("identity", identityHeader)
+	c.Set(h.ParsedIdentity, identityHeader)
 
 	err = userCatcher(c)
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1159,7 +1159,7 @@ func TestSourceEdit(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(fmt.Sprintf("%d", source.ID))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
 	err := sourceEditHandlerWithNotifier(c)
@@ -1362,7 +1362,7 @@ func TestSourceEditNoNameRequest(t *testing.T) {
 	c.SetParamNames("id")
 	c.SetParamValues(fmt.Sprintf("%d", source.ID))
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
-	c.Set("identity", &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
+	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
 	err := sourceEditHandlerWithNotifier(c)


### PR DESCRIPTION
after discussion in #562 I decided to create PR for each constant from middleware/headers/headers.go 
- to have smaller PRs and 
- to not have chaos in repo commit history

this PR contains changes related with constant PARSED_IDENTITY

all PRs related with this constant refactor will be registered in #570

**JIRA:** [RHCLOUD-21109](https://issues.redhat.com/browse/RHCLOUD-21109)