### PR TITLE
[RHCLOUD-21109] Constant TenantID refactor

### DIFF
--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -18,7 +18,7 @@ func BulkCreate(c echo.Context) error {
 		return err
 	}
 
-	tenantID, ok := c.Get(h.TENANTID).(int64)
+	tenantID, ok := c.Get(h.TenantID).(int64)
 	if !ok {
 		return fmt.Errorf("failed to pull tenant from request")
 	}

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -8,6 +8,6 @@ const (
 	XRHID               = "x-rh-identity"
 	INSIGHTS_REQUEST_ID = "x-rh-insights-request-id"
 	PARSED_IDENTITY     = "identity"
-	TENANTID            = "tenantID"
+	TenantID            = "tenantID"
 	UserID              = "userID"
 )

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -23,7 +23,7 @@ import (
 */
 func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TENANTID).(int64)
+		tenantId, ok := c.Get(h.TenantID).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}
@@ -68,7 +68,7 @@ func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 
 func SuperKeyDestroyApplication(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TENANTID).(int64)
+		tenantId, ok := c.Get(h.TenantID).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -55,7 +55,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		// This can cause issues with services we are integrated with —notifications, for example—, which will not
 		// accept EBS account numbers anymore. However, we can deal with that by forwarding the OrgId too if we have it
 		// stored in the database.
-		c.Set(h.TENANTID, tenant.Id)
+		c.Set(h.TenantID, tenant.Id)
 		c.Set(h.ACCOUNT_NUMBER, tenant.ExternalTenant)
 		c.Set(h.ORGID, tenant.OrgID)
 

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -119,7 +119,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		{
 			want := tenantId
-			got := c.Get(headers.TENANTID)
+			got := c.Get(headers.TenantID)
 
 			if want != got {
 				t.Errorf(`"%s" header set with value "%s. Invalid tenant id set when going through the "ParseHeaders" and "Tenancy" middlewares. Want "%d", got "%v"`, key, value, want, got)

--- a/middleware/user.go
+++ b/middleware/user.go
@@ -11,7 +11,7 @@ import (
 
 func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		tenantId, ok := c.Get(h.TENANTID).(int64)
+		tenantId, ok := c.Get(h.TenantID).(int64)
 		if !ok {
 			return fmt.Errorf("failed to pull tenant from request")
 		}

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -33,7 +33,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Set(h.TENANTID, tenantID)
+	c.Set(h.TenantID, tenantID)
 	c.Set(h.PARSED_IDENTITY, identity)
 
 	err := catchUserOrElse204(c)
@@ -77,7 +77,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	c.Set(h.TENANTID, tenantID)
+	c.Set(h.TenantID, tenantID)
 	c.Set(h.PSKUserID, testUserID)
 
 	err := catchUserOrElse204(c)

--- a/util/echo/echo_context.go
+++ b/util/echo/echo_context.go
@@ -49,7 +49,7 @@ func GetUserFromEchoContext(c echo.Context) (*int64, error) {
 // GetTenantFromEchoContext tries to extract the tenant from the echo context. If the "tenantID" is missing from the
 // context, then a default value and nil are returned as the int64 and error values.
 func GetTenantFromEchoContext(c echo.Context) (int64, error) {
-	tenantValue := c.Get(h.TENANTID)
+	tenantValue := c.Get(h.TenantID)
 
 	// If no tenant is found in the context, that shouldn't imply an error.
 	if tenantValue == nil {


### PR DESCRIPTION
after discussion in #562 I decided to create PR for each constant from middleware/headers/headers.go 
- to have smaller PRs and 
- to not have chaos in repo commit history

this PR contains changes related with constant TENANTID

all PRs related with this constant refactor will be registered in #570

**JIRA:** [RHCLOUD-21109](https://issues.redhat.com/browse/RHCLOUD-21109)