### PR TITLE
Fix formats in comments

### DIFF
--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -326,7 +326,8 @@ func TestApplicationNotExists(t *testing.T) {
 }
 
 // TestApplicationSubcollectionListWithOffsetAndLimit tests that SubCollectionList() in application dao returns
-//  correct count value and correct count of returned objects
+//
+//	correct count value and correct count of returned objects
 func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -326,8 +326,7 @@ func TestApplicationNotExists(t *testing.T) {
 }
 
 // TestApplicationSubcollectionListWithOffsetAndLimit tests that SubCollectionList() in application dao returns
-//
-//	correct count value and correct count of returned objects
+// correct count value and correct count of returned objects
 func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 // TestApplicationTypeSubCollectionListOffsetAndLimit tests that SubCollectionList() in application type dao returns
-//
-//	correct count value and correct count of returned objects
+// correct count value and correct count of returned objects
 func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 // TestApplicationTypeSubCollectionListOffsetAndLimit tests that SubCollectionList() in application type dao returns
-//  correct count value and correct count of returned objects
+//
+//	correct count value and correct count of returned objects
 func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")

--- a/dao/common.go
+++ b/dao/common.go
@@ -75,12 +75,12 @@ func GetAvailabilityStatusFromStatusMessage(tenantID int64, resourceID string, r
 }
 
 /*
-	Method generates bulk message for Source record.
-	authentication - specify resource (ResourceID and ResourceType) of
-                     which authentications are fetched to BulkMessage
-                   - specify application_authentications in BulkMessage otherwise
-                     application_authentications are obtained from authentications UIDs
-					 in BulkMessage
+		Method generates bulk message for Source record.
+		authentication - specify resource (ResourceID and ResourceType) of
+	                     which authentications are fetched to BulkMessage
+	                   - specify application_authentications in BulkMessage otherwise
+	                     application_authentications are obtained from authentications UIDs
+						 in BulkMessage
 */
 func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (map[string]interface{}, error) {
 	result := DB.

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -149,8 +149,7 @@ func TestEndpointListOffsetAndLimit(t *testing.T) {
 }
 
 // TestEndpointSubCollectionListOffsetAndLimit tests that SubCollectionList() in endpoint dao returns
-//
-//	correct count value and correct count of returned objects
+// correct count value and correct count of returned objects
 func TestEndpointSubCollectionListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -149,7 +149,8 @@ func TestEndpointListOffsetAndLimit(t *testing.T) {
 }
 
 // TestEndpointSubCollectionListOffsetAndLimit tests that SubCollectionList() in endpoint dao returns
-//  correct count value and correct count of returned objects
+//
+//	correct count value and correct count of returned objects
 func TestEndpointSubCollectionListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -386,9 +386,9 @@ func TestDeleteSourceNotExists(t *testing.T) {
 
 // TestDeleteCascade is a long test function, but very simple in essence. Essentially what it does is:
 //
-//- It creates source with subresources (apps, endpoints, rhc-connections ...).
-//- Cascade deletes the source with the function under test.
-//- Checks that the deleted subresources and source are the ones that have been created in this very same test.
+// - It creates source with subresources (apps, endpoints, rhc-connections ...).
+// - Cascade deletes the source with the function under test.
+// - Checks that the deleted subresources and source are the ones that have been created in this very same test.
 func TestDeleteCascade(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
@@ -687,7 +687,8 @@ func TestSourceNotExists(t *testing.T) {
 }
 
 // TestSourceSubcollectionListWithOffsetAndLimit tests that SubCollectionList() in source dao returns
-//  correct count value and correct count of returned objects
+//
+//	correct count value and correct count of returned objects
 func TestSourceSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")
@@ -796,7 +797,8 @@ func TestSourceListInternalOffsetAndLimit(t *testing.T) {
 }
 
 // TestSourceListForRhcConnectionWithOffsetAndLimit tests that ListForRhcConnection() in source dao returns
-//  correct count value and correct count of returned objects
+//
+//	correct count value and correct count of returned objects
 func TestSourceListForRhcConnectionWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -687,8 +687,7 @@ func TestSourceNotExists(t *testing.T) {
 }
 
 // TestSourceSubcollectionListWithOffsetAndLimit tests that SubCollectionList() in source dao returns
-//
-//	correct count value and correct count of returned objects
+// correct count value and correct count of returned objects
 func TestSourceSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")
@@ -797,8 +796,7 @@ func TestSourceListInternalOffsetAndLimit(t *testing.T) {
 }
 
 // TestSourceListForRhcConnectionWithOffsetAndLimit tests that ListForRhcConnection() in source dao returns
-//
-//	correct count value and correct count of returned objects
+// correct count value and correct count of returned objects
 func TestSourceListForRhcConnectionWithOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")

--- a/dao/type_cache.go
+++ b/dao/type_cache.go
@@ -10,11 +10,11 @@ import (
 var Static typeCache
 
 /*
-	typeCache is a small struct that just contains the map between
-	application/source types and their keys in the database.
+typeCache is a small struct that just contains the map between
+application/source types and their keys in the database.
 
-	The cache is populated at startup so one can fetch foreign keys when
-	building objects easily.
+The cache is populated at startup so one can fetch foreign keys when
+building objects easily.
 */
 type typeCache struct {
 	sourceTypes      map[string]int64
@@ -39,11 +39,11 @@ func (tc *typeCache) GetSourceTypeName(id int64) string {
 }
 
 /*
-    Returns the application type id for a given name, 0 if not found.
+	    Returns the application type id for a given name, 0 if not found.
 
-	Can search via name or display name for application types, there is also a
-	shortcut for the last place in the "path" of the name e.g. `/this/is/a/type`
-	is also available as `type`
+		Can search via name or display name for application types, there is also a
+		shortcut for the last place in the "path" of the name e.g. `/this/is/a/type`
+		is also available as `type`
 */
 func (tc *typeCache) GetApplicationTypeId(name string) int64 {
 	return tc.applicationTypes[name]
@@ -73,9 +73,9 @@ func (tc *typeCache) GetApplicationTypeFullName(id int64) string {
 }
 
 /*
-	Fetches every Source+Application Type record from the database and builds
-	out the cache. Returns an error if it fails (e.g. the app shouldn't be
-	running then)
+Fetches every Source+Application Type record from the database and builds
+out the cache. Returns an error if it fails (e.g. the app shouldn't be
+running then)
 */
 func PopulateStaticTypeCache() error {
 	tc := typeCache{}

--- a/jobs/scheduled_jobs.go
+++ b/jobs/scheduled_jobs.go
@@ -10,8 +10,9 @@ import (
 // schedule.
 //
 // it has 2 fields:
-// 		Interval: how often to run the job
-// 		Job: self-explanatory.
+//
+//	Interval: how often to run the job
+//	Job: self-explanatory.
 type ScheduledJob struct {
 	Interval time.Duration
 	Job      Job

--- a/jobs/types.go
+++ b/jobs/types.go
@@ -3,19 +3,19 @@ package jobs
 import "time"
 
 /*
-	Interface to codify jobs against, mostly consisting of a few methods:
+Interface to codify jobs against, mostly consisting of a few methods:
 
-	1. Delay, how long to wait before executing. Will mostly be a method that
-	   returns 0 for jobs that don't need to be delayed, otherwise it'll be a
-	   set amount of time.
+ 1. Delay, how long to wait before executing. Will mostly be a method that
+    returns 0 for jobs that don't need to be delayed, otherwise it'll be a
+    set amount of time.
 
-	2. Arguments, for pretty logging
+2. Arguments, for pretty logging
 
-	3. Name, for pretty logging
+3. Name, for pretty logging
 
-	4. Run, what do we do?
+4. Run, what do we do?
 
-	5. ToJSON, serialize the job into a byte array for sending off to redis
+5. ToJSON, serialize the job into a byte array for sending off to redis
 */
 type Job interface {
 	// how long to wait until performing (just do a sleep)

--- a/logger/echo_logger.go
+++ b/logger/echo_logger.go
@@ -25,7 +25,7 @@ type EchoLogger struct {
 	*logrus.Entry
 }
 
-/// Wrapping _level_j methods
+// / Wrapping _level_j methods
 func (el EchoLogger) Printj(j log.JSON) { el.Logger.Printf("%+v", j) }
 func (el EchoLogger) Debugj(j log.JSON) { el.Logger.Debugf("%+v", j) }
 func (el EchoLogger) Infoj(j log.JSON)  { el.Logger.Infof("%+v", j) }
@@ -34,11 +34,11 @@ func (el EchoLogger) Warnj(j log.JSON)  { el.Logger.Warnf("%+v", j) }
 func (el EchoLogger) Fatalj(j log.JSON) { el.Logger.Fatalf("%+v", j) }
 func (el EchoLogger) Panicj(j log.JSON) { el.Logger.Panicf("%+v", j) }
 
-/// output is easy
+// / output is easy
 func (el EchoLogger) SetOutput(out io.Writer) { el.Logger.SetOutput(out) }
 func (el EchoLogger) Output() io.Writer       { return el.Logger.Out }
 
-/// we don't use the "set level" on the echo logger since we're using a single unified logger
+// / we don't use the "set level" on the echo logger since we're using a single unified logger
 func (el EchoLogger) SetLevel(log.Lvl) {
 	panic("DON'T USE THIS METHOD - SET IT ON THE LOGRUS LOGGER")
 }
@@ -46,9 +46,9 @@ func (el EchoLogger) Level() log.Lvl {
 	panic("DON'T USE THIS METHOD - SET IT ON THE LOGRUS LOGGER")
 }
 
-/// we don't set a prefix ever on the logger
+// / we don't set a prefix ever on the logger
 func (el EchoLogger) SetPrefix(string) { panic("DON'T USE THIS METHOD") }
 func (el EchoLogger) Prefix() string   { panic("DON'T USE THIS METHOD") }
 
-/// we don't set a header on the logger either
+// / we don't set a header on the logger either
 func (el EchoLogger) SetHeader(_ string) { panic("DON'T USE THIS METHOD") }

--- a/logger/echo_logger.go
+++ b/logger/echo_logger.go
@@ -25,7 +25,7 @@ type EchoLogger struct {
 	*logrus.Entry
 }
 
-// / Wrapping _level_j methods
+// Wrapping _level_j methods
 func (el EchoLogger) Printj(j log.JSON) { el.Logger.Printf("%+v", j) }
 func (el EchoLogger) Debugj(j log.JSON) { el.Logger.Debugf("%+v", j) }
 func (el EchoLogger) Infoj(j log.JSON)  { el.Logger.Infof("%+v", j) }
@@ -34,11 +34,11 @@ func (el EchoLogger) Warnj(j log.JSON)  { el.Logger.Warnf("%+v", j) }
 func (el EchoLogger) Fatalj(j log.JSON) { el.Logger.Fatalf("%+v", j) }
 func (el EchoLogger) Panicj(j log.JSON) { el.Logger.Panicf("%+v", j) }
 
-// / output is easy
+// output is easy
 func (el EchoLogger) SetOutput(out io.Writer) { el.Logger.SetOutput(out) }
 func (el EchoLogger) Output() io.Writer       { return el.Logger.Out }
 
-// / we don't use the "set level" on the echo logger since we're using a single unified logger
+// we don't use the "set level" on the echo logger since we're using a single unified logger
 func (el EchoLogger) SetLevel(log.Lvl) {
 	panic("DON'T USE THIS METHOD - SET IT ON THE LOGRUS LOGGER")
 }
@@ -46,9 +46,9 @@ func (el EchoLogger) Level() log.Lvl {
 	panic("DON'T USE THIS METHOD - SET IT ON THE LOGRUS LOGGER")
 }
 
-// / we don't set a prefix ever on the logger
+// we don't set a prefix ever on the logger
 func (el EchoLogger) SetPrefix(string) { panic("DON'T USE THIS METHOD") }
 func (el EchoLogger) Prefix() string   { panic("DON'T USE THIS METHOD") }
 
-// / we don't set a header on the logger either
+// we don't set a header on the logger either
 func (el EchoLogger) SetHeader(_ string) { panic("DON'T USE THIS METHOD") }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -113,9 +113,9 @@ func stringContainAnySubString(stringToSearch string, subStrings []string) bool 
 }
 
 /*
-  example:
-	functionNameFromPath("github.com/RedHatInsights/sources-api-go/middleware.Timing.func1")
-	=> "middleware.Timing.func1"
+	  example:
+		functionNameFromPath("github.com/RedHatInsights/sources-api-go/middleware.Timing.func1")
+		=> "middleware.Timing.func1"
 */
 func functionNameFromPath(functionWithPath string) string {
 	functionPathParts := strings.Split(functionWithPath, "/")
@@ -149,7 +149,7 @@ type LogFormatter struct {
 	LogType  string
 }
 
-//Marshaler is an interface any type can implement to change its output in our production logs.
+// Marshaler is an interface any type can implement to change its output in our production logs.
 type Marshaler interface {
 	MarshalLog() map[string]interface{}
 }

--- a/marketplace/utils_test.go
+++ b/marketplace/utils_test.go
@@ -96,9 +96,9 @@ func (mtcnc *marketplaceTokenCacherNotCached) CacheToken(token *BearerToken) err
 	return errors.New("unexpected caching error")
 }
 
-//---
+// ---
 // Provider mocks
-//---
+// ---
 // marketplaceTokenProviderSuccessful acts as if requesting a token to the marketplace returned a proper response.
 type marketplaceTokenProviderSuccessful struct {
 	ApiKey *string

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -23,14 +23,14 @@ var (
 )
 
 /*
-	Takes the information stored in the context and returns a 401 if we do not
-	have authorization to perform "write" things such as POST/PATCH/DELETE.
+Takes the information stored in the context and returns a 401 if we do not
+have authorization to perform "write" things such as POST/PATCH/DELETE.
 
-	1. Checks for PSK (if present) and if it is there and matches any of the
-	   PSKs we approve, lets it through.
+ 1. Checks for PSK (if present) and if it is there and matches any of the
+    PSKs we approve, lets it through.
 
-	2. Sends the x-rh-identity header off to rbac to get an ACL list, and
-	   returns whether or not it contains the correct `sources:*:*` permission.
+ 2. Sends the x-rh-identity header off to rbac to get an ACL list, and
+    returns whether or not it contains the correct `sources:*:*` permission.
 */
 func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -10,19 +10,19 @@ import (
 )
 
 /*
-   Parse the required headers for processing this request. Currently this
-   involves _three_ major headers:
+Parse the required headers for processing this request. Currently this
+involves _three_ major headers:
 
-   1. `x-rh-identity`: contains the account number and various other information
-      about the request. This is set by 3scale.
+ 1. `x-rh-identity`: contains the account number and various other information
+    about the request. This is set by 3scale.
 
-   2. `x-rh-sources-psk`: a pre-shared-key (psk) which is used internally to
-      authenticate from within the CRC cluster. This is checked against a list
-      of known keys which are set in vault, if it matches any of them the
-      request is authorized.
+ 2. `x-rh-sources-psk`: a pre-shared-key (psk) which is used internally to
+    authenticate from within the CRC cluster. This is checked against a list
+    of known keys which are set in vault, if it matches any of them the
+    request is authorized.
 
-    3. `x-rh-sources-account-number`: used with a PSK to access a certain
-       account. Only accessible from within the CRC cluster.
+ 3. `x-rh-sources-account-number`: used with a PSK to access a certain
+    account. Only accessible from within the CRC cluster.
 */
 func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {

--- a/middleware/superkey_destroy.go
+++ b/middleware/superkey_destroy.go
@@ -14,12 +14,12 @@ import (
 )
 
 /*
-	This middleware intercepts a superkey-related source on its way through the
-	stack and handles whether the requested resource is superkey related.
+This middleware intercepts a superkey-related source on its way through the
+stack and handles whether the requested resource is superkey related.
 
-	If it is then we will queue up a job that sends the request over to the
-	worker (to delete the resources in amazon), wait 15 seconds, then destroy
-	the actual resources.
+If it is then we will queue up a job that sends the request over to the
+worker (to delete the resources in amazon), wait 15 seconds, then destroy
+the actual resources.
 */
 func SuperKeyDestroySource(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {

--- a/model/bulk_create_http.go
+++ b/model/bulk_create_http.go
@@ -1,11 +1,11 @@
 package model
 
 /*
-	Bulk Create Request is a request creating 1..n resources in Sources API
-	which does all of the linking between resources automatically.
+Bulk Create Request is a request creating 1..n resources in Sources API
+which does all of the linking between resources automatically.
 
-	This outer request just contains slices of the possible resources that can
-	be created.
+This outer request just contains slices of the possible resources that can
+be created.
 */
 type BulkCreateRequest struct {
 	Sources         []BulkCreateSource         `json:"sources"`
@@ -55,7 +55,7 @@ type BulkCreateAuthentication struct {
 }
 
 /*
-	Output from the BulkCreate operation - stores the parsed resources that have been validated.
+Output from the BulkCreate operation - stores the parsed resources that have been validated.
 */
 type BulkCreateOutput struct {
 	Sources                    []Source

--- a/service/application_validation.go
+++ b/service/application_validation.go
@@ -14,10 +14,10 @@ import (
 var AppTypeDao = dao.GetApplicationTypeDao(nil)
 
 /*
-	Go through and validate the application create request.
+Go through and validate the application create request.
 
-	Really not much here other than validating the application type is
-	compatible with the specified source type.
+Really not much here other than validating the application type is
+compatible with the specified source type.
 */
 func ValidateApplicationCreateRequest(requestParams *dao.RequestParams, appReq *m.ApplicationCreateRequest) error {
 	// need both source id + application type id

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -17,19 +17,19 @@ import (
 )
 
 /*
-	Oh boy. The big one.
+Oh boy. The big one.
 
-	So basically this function goes through a the parsed BulkCreateRequest model
-	and creates the resources in this order:
+So basically this function goes through a the parsed BulkCreateRequest model
+and creates the resources in this order:
 
-	1. Sources
-	2. Endpoints/Applications
+1. Sources
+2. Endpoints/Applications
 
-	It dynamically looks up both the SourceType as well as ApplicationType if
-	given the *_type_name paremeters.
+It dynamically looks up both the SourceType as well as ApplicationType if
+given the *_type_name paremeters.
 
-	3. Saving the Authentications
-	4. Saving the ApplicationAuthentications if necessary
+3. Saving the Authentications
+4. Saving the ApplicationAuthentications if necessary
 */
 func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.BulkCreateOutput, error) {
 	// the output from this request.

--- a/service/events.go
+++ b/service/events.go
@@ -32,9 +32,9 @@ func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) 
 }
 
 // ForwadableHeaders fetches the required identity headers from the request that are needed to forward along:
-// 	1. x-rh-identity -- a generated one if it wasn't passed along (e.g. psk)
-//	2. x-rh-sources-account-number -- always passed if present, and used for generation.
-//	3. x-rh-sources-org-id -- always passed if present, and used for generation.
+//  1. x-rh-identity -- a generated one if it wasn't passed along (e.g. psk)
+//  2. x-rh-sources-account-number -- always passed if present, and used for generation.
+//  3. x-rh-sources-org-id -- always passed if present, and used for generation.
 func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	headers := make([]kafka.Header, 0)
 	var account, orgId, xrhid string

--- a/util/echo/binder.go
+++ b/util/echo/binder.go
@@ -13,11 +13,11 @@ import (
 type NoUnknownFieldsBinder struct{}
 
 /*
-	The single "Bind" method implements the echo.Binder interface.
+The single "Bind" method implements the echo.Binder interface.
 
-	For our custom binder we want to not allow any fields that aren't declared
-	on the `*CreateRequest` structs. This is easily achieved by switching on the
-	`DisallowUnknownFields` Decoder setting for unmarshaling json.
+For our custom binder we want to not allow any fields that aren't declared
+on the `*CreateRequest` structs. This is easily achieved by switching on the
+`DisallowUnknownFields` Decoder setting for unmarshaling json.
 */
 func (binder *NoUnknownFieldsBinder) Bind(i interface{}, c echo.Context) error {
 	// Close the request's body after we're done with it.

--- a/util/echo/main_test.go
+++ b/util/echo/main_test.go
@@ -14,7 +14,7 @@ import (
 
 var echoInstance = echo.New()
 
-//duplicating helper function CreateTestContext() from internal/testutils/request/request.go in order to
+// duplicating helper function CreateTestContext() from internal/testutils/request/request.go in order to
 // effectively test and importing this to other packages to prevent import cycle
 func CreateTestContext(method string, path string, body io.Reader, context map[string]interface{}) (echo.Context, *httptest.ResponseRecorder) {
 	echoInstance.Binder = &NoUnknownFieldsBinder{}


### PR DESCRIPTION
Changes were generated by

```
golangci-lint run -E gofmt --fix
```

When I ran `make lint` - it is displaying errors related to gofmt.

I am not sure - why this is not in PR checks - I tried it with go1.17.-1.19.
