### PR TITLE
Fail gracefully when cloudwatch fails to be set up

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -72,7 +72,7 @@ func cloudWatchLogrusHook(config *appconf.SourcesApiConfig) *lc.Hook {
 		awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
 		hook, err := lc.NewBatchingHook(group, stream, awsconf, 10*time.Second)
 		if err != nil {
-			Log.Info(err)
+			Log.Fatal(err)
 		}
 
 		return hook


### PR DESCRIPTION
Similar to: https://github.com/RedHatInsights/sources-superkey-worker/pull/63

>Currently getting a panic due to a nil pointer on stage when the cloudwatch logs are failing to get set up, I would like to fail if cloudwatch fails still but instead of a stacktrace lets just print the error and exit.

This will just do the same thing for sources-(api|availability-status-listener|background-worker).