### PR TITLE
[RHCLOUD-21398] Fix of TestApplicationDeleteWithOwnership() and TestSourceListInternal()

### DIFF
--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -2292,7 +2292,18 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 			t.Errorf("unable to get application authentication, there is err %s", err)
 		}
 
+		// Clean all created resources
+		err = cleanSourceForTenant(suiteData.SourceUserA().Name, suiteData.TenantID())
+		if err != nil {
+			return err
+		}
+
 		err = cleanSourceForTenant(suiteData.SourceUserB().Name, suiteData.TenantID())
+		if err != nil {
+			return err
+		}
+
+		err = cleanSourceForTenant(suiteData.SourceNoUser().Name, suiteData.TenantID())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
once upon the time 😁

I found that `TestSourceListInternal()` is skipped and needs to be fixed. There was inconsistency between wanted and returned list of sources. One reason was that items in lists had different order. Another reason was there were unexpected new records in the db. It looked like some test create new source and doesn't remove it in the end.

So I identified this test and added the removing of created resources in the end of the `TestApplicationDeleteWithOwnership()`.
And then I changed a little bit the logic for check that returned list is what we want in `TestSourceListInternal()`.

**JIRA:** [RHCLOUD-21398](https://issues.redhat.com/browse/RHCLOUD-21398)
