### PR TITLE
[RHCLOUD-19437] feature: superkey metadata for the provisioning app

### DIFF
--- a/dao/seeds/app_metadata.yml
+++ b/dao/seeds/app_metadata.yml
@@ -26,6 +26,8 @@ stage:
     aws_wizard_account_number: "998366406740"
     azure_lighthouse_template: "https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fcloudigrade-stage-azure-offer-cloudigrade-stage.apps.crcs02ue1.urby.p1.openshiftapps.com%2Fapi%2Fcloudigrade%2Fv2%2Fazure-offer-template%2F"
     retry_source_creation: true
+  "/insights/platform/provisioning":
+    aws_wizard_account_number: "351356922033"
 prod:
   "/insights/platform/cost-management":
     gcp_service_account: billing-export@red-hat-cost-management.iam.gserviceaccount.com
@@ -35,3 +37,5 @@ prod:
     aws_wizard_account_number: "998366406740"
     azure_lighthouse_template: "https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fconsole.redhat.com%2Fapi%2Fcloudigrade%2Fv2%2Fazure-offer-template%2F"
     retry_source_creation: true
+  "/insights/platform/provisioning":
+    aws_wizard_account_number: "296389277756"

--- a/dao/seeds/superkey_metadata.yml
+++ b/dao/seeds/superkey_metadata.yml
@@ -136,3 +136,60 @@
     name: bind_role
     payload: {}
     substitutions: {}
+
+"/insights/platform/provisioning":
+  steps:
+    - step: 1
+      name: policy
+      payload:
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "RedHatProvisioning",
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:CreateKeyPair",
+                  "ec2:CreateTags",
+                  "ec2:DeleteKeyPair",
+                  "ec2:DeleteTags",
+                  "ec2:DescribeAvailabilityZones",
+                  "ec2:DescribeImages",
+                  "ec2:DescribeInstanceTypes",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeKeyPairs",
+                  "ec2:DescribeRegions",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeSnapshotAttribute",
+                  "ec2:DescribeTags",
+                  "ec2:ImportKeyPair",
+                  "ec2:RunInstances",
+                  "ec2:StartInstances"
+              ],
+              "Resource": "*"
+            }
+          ]
+        }
+      substitutions: {}
+    - step: 2
+      name: role
+      payload:
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::ACCOUNT:role"
+              },
+              "Action": "sts:AssumeRole",
+              "Condition": {}
+            }
+          ]
+        }
+      substitutions:
+        ACCOUNT: get_account
+    - step: 3
+      name: bind_role
+      payload: {}
+      substitutions: {}


### PR DESCRIPTION
In order for the superkey worker to be able to pick up any work from a provisioning app, this metadata must be added to the YAML file.

The metadata has been grabbed from their documentation[1].

[1]: https://github.com/RHEnVision/provisioning-backend/blob/95694ba7b0db92262406212fe715668aa9f4a295/docs/configure-amazon-role.md

## Links

[[RHCLOUD-19437]](https://issues.redhat.com/browse/RHCLOUD-19437)