### PR TITLE
[RHCLOUD-21422] feature: Kafka consumer to "LastOffest"

### DIFF
--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -68,7 +68,12 @@ func GetReader(conf *Options) (*Reader, error) {
 
 	readerConfig := kafka.ReaderConfig{
 		Brokers: []string{fmt.Sprintf("%s:%d", conf.BrokerConfig.Hostname, *conf.BrokerConfig.Port)},
-		Topic:   conf.Topic,
+		// Make the consumer reset the offset to the latest one available in the server. This makes the offset to be
+		// reset to the latest one available on the server. Check the Jira ticket below for more information.
+		//
+		// * https://issues.redhat.com/browse/RHCLOUD-21422
+		StartOffset: kafka.LastOffset,
+		Topic:       conf.Topic,
 	}
 
 	// set up the logger


### PR DESCRIPTION
This will make the offset to be the latest one available on the Kafka server, which hopefully will make the following error go away:

"error initializing the kafka reader for partition 0 of platform-mq-stage.platform.sources.superkey-requests: [1] Offset Out Of Range: the requested offset is outside the range of offsets maintained by the server for the given topic/partition"

## Links

[[RHCLOUD-21422]](https://issues.redhat.com/browse/RHCLOUD-21422)