### PR TITLE
updated TestSourceListSatellite()

### DIFF
--- a/internal/testutils/fixtures/source.go
+++ b/internal/testutils/fixtures/source.go
@@ -10,6 +10,7 @@ var (
 	uid3 = "36be1c27-ef96-42b0-9a13-72240b18cf83"
 	uid4 = "1c8b6c9a-af40-11ec-b909-0242ac120002"
 	uid5 = "5cbb40a8-f66a-4efb-8ed2-5f18c59ff7ca"
+	uid6 = "f6d1e4ae-781c-4be0-a4ed-8935af5d9f47"
 )
 
 var TestSourceData = []m.Source{
@@ -52,5 +53,13 @@ var TestSourceData = []m.Source{
 		TenantID:           1,
 		AvailabilityStatus: "available",
 		Uid:                &uid5,
+	},
+	{
+		ID:                 6,
+		Name:               "Source6 Satellite",
+		SourceTypeID:       5,
+		TenantID:           1,
+		AvailabilityStatus: "available",
+		Uid:                &uid6,
 	},
 }

--- a/internal/testutils/fixtures/source_type.go
+++ b/internal/testutils/fixtures/source_type.go
@@ -23,4 +23,8 @@ var TestSourceTypeData = []m.SourceType{
 		Id:   100,
 		Name: "source type without sources in fixtures",
 	},
+	{
+		Id:   5,
+		Name: "satellite",
+	},
 }

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -850,8 +850,17 @@ func TestSourceListSatellite(t *testing.T) {
 		t.Error("offset not set correctly")
 	}
 
-	if len(out.Data) != 0 {
+	if len(out.Data) != 1 {
 		t.Error("Objects were not filtered out of request")
+	}
+
+	sourceOut, ok := out.Data[0].(map[string]interface{})
+	if !ok {
+		t.Error("model did not deserialize as a source")
+	}
+
+	if sourceOut["name"] != "Source6 Satellite" {
+		t.Error("ghosts infected the return")
 	}
 
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)


### PR DESCRIPTION
this PR adds new data into fixtures so now the TestSourceListSatellite() can check that one source of source type = satellite is returned

without JIRA ticket