### PR TITLE
[RHCLOUD-21422] Revert "feature: Kafka consumer to "LastOffest"" to default

### DIFF
--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -68,12 +68,7 @@ func GetReader(conf *Options) (*Reader, error) {
 
 	readerConfig := kafka.ReaderConfig{
 		Brokers: []string{fmt.Sprintf("%s:%d", conf.BrokerConfig.Hostname, *conf.BrokerConfig.Port)},
-		// Make the consumer reset the offset to the latest one available in the server. This makes the offset to be
-		// reset to the latest one available on the server. Check the Jira ticket below for more information.
-		//
-		// * https://issues.redhat.com/browse/RHCLOUD-21422
-		StartOffset: kafka.LastOffset,
-		Topic:       conf.Topic,
+		Topic:   conf.Topic,
 	}
 
 	// set up the logger


### PR DESCRIPTION
The default setting is "FirstOffset", and I am reverting the consumer to that setting since flipping it to "LastOffset" did not achieve anything in order to solve the issue we have at hand.

Reverts commit a3273989e24df007a5186d157c4ec6c9ad2b2f81.

## Links

[[RHCLOUD-21422]](https://issues.redhat.com/browse/RHCLOUD-21422)