### PR TITLE
Add default ordering for collections and subcollections queries

### DIFF
--- a/graph/arguments.go
+++ b/graph/arguments.go
@@ -32,6 +32,9 @@ func parseSortBy(sortBy []*generated_model.SortBy) []util.Filter {
 		sorts[i] = filter
 	}
 
+	if len(sorts) == 0 {
+		sorts = append(sorts, util.Filter{Operation: "sort_by", Value: []string{"id ASC"}})
+	}
 	return sorts
 }
 

--- a/middleware/filtering.go
+++ b/middleware/filtering.go
@@ -76,5 +76,5 @@ func parseSorting(c echo.Context) *util.Filter {
 		}
 	}
 
-	return nil
+	return &util.Filter{Operation: "sort_by", Value: []string{"id ASC"}}
 }


### PR DESCRIPTION
We don't have default ordering on API endpoints which could cause that resulted collection has random order. 

### Links

https://issues.redhat.com/browse/RHCLOUD-20048