### PR TITLE
Add liveness/readiness probes to AvailabilityStatusListener deployment

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -85,6 +85,17 @@ objects:
           requests:
             cpu: ${AVAILABILITY_LISTENER_CPU_REQUEST}
             memory: ${AVAILABILITY_LISTENER_MEMORY_REQUEST}
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 10
+          periodSeconds: 30
     - name: svc
       minReplicas: ${{MIN_REPLICAS}}
       webServices:

--- a/statuslistener/statuslistener_test.go
+++ b/statuslistener/statuslistener_test.go
@@ -446,7 +446,10 @@ func TestConsumeStatusMessage(t *testing.T) {
 
 		sender := MockEventStreamSender{TestSuite: t, StatusMessage: testEntry.StatusMessage}
 		esp := &events.EventStreamProducer{Sender: &sender}
-		avs := AvailabilityStatusListener{EventStreamProducer: esp}
+
+		avs := AvailabilityStatusListener{EventStreamProducer: esp, healthcheck: make(chan struct{}, 10)}
+		go avs.healthCheckConsumer()
+
 		message, _ := json.Marshal(testEntry)
 		avs.ConsumeStatusMessage(kafka.Message{Value: message, Headers: testEntry.MessageHeaders})
 


### PR DESCRIPTION
@Ellen-Yi-Dong and I paired on this today after @lpichler found out that we were missing the liveness/readiness probes on 2 deployments:
- availability status listener
- background worker

This PR adds the probes for the availability status listener, but not the background worker. That will be done in a followup PR by Ellen.

