### PR TITLE
Revert "feature: log the events to help debugging issues"

### DIFF
--- a/service/events.go
+++ b/service/events.go
@@ -10,7 +10,6 @@ import (
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
-	"github.com/sirupsen/logrus"
 )
 
 // Producer instance used to send messages - default just an empty instance of the struct.
@@ -18,32 +17,16 @@ var Producer = func() events.Sender { return events.EventStreamProducer{Sender: 
 
 // RaiseEvent raises an event with the provided resource.
 func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) error {
-	// Prepare the log fields to be able to log anything related to events. This will help debug issues with
-	// applications that may not receive certain events due to some error.
-	logFields := logrus.WithFields(
-		logrus.Fields{
-			"event_type": eventType,
-			"resource":   resource,
-			"headers":    headers,
-		},
-	)
-
 	msg, err := json.Marshal(resource.ToEvent())
 	if err != nil {
-		logFields.WithField("error", err).Error("unable to raise event due to a marshalling error")
-
 		return fmt.Errorf("failed to marshal %+v as event: %v", resource, err)
 	}
 
 	headers = append(headers, kafka.Header{Key: "event_type", Value: []byte(eventType)})
 	err = Producer().RaiseEvent(eventType, msg, headers)
 	if err != nil {
-		logFields.WithField("error", err).Error("unable to raise an event")
-
 		return fmt.Errorf("failed to raise event to kafka: %v", err)
 	}
-
-	logFields.Debug("event raised")
 
 	return nil
 }


### PR DESCRIPTION
After checking the logs on Kibana, I saw that they don't show much information. Basically the inner structs are shown as references, and the other data isn't as helpful to look at.

Also, the vast majority of the times "Raise" is called, if an error occurs, it gets logged by the caller function, so these log statements end up just duplicating the messages and making everything harder to follow.

This reverts commit d1f95029007ab6195d7fc8bc286c032a00943408.