### PR TITLE
[RHCLOUD-21547] Source parse in bulk create

### DIFF
--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -144,7 +144,7 @@ func parseSources(reqSources []m.BulkCreateSource, tenant *m.Tenant, userResourc
 			// look up by id if an id was specified
 			id, err := util.InterfaceToInt64(source.SourceTypeIDRaw)
 			if err != nil {
-				return nil, err
+				return nil, util.NewErrBadRequest(fmt.Sprintf("invalid source type id, original error: %s", err))
 			}
 
 			sourceType, err = dao.GetSourceTypeDao().GetById(&id)

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
@@ -129,5 +130,123 @@ func TestParseEndpointsTestRegression(t *testing.T) {
 		if want != got {
 			t.Errorf(`wrong endpoint source id parsed. Want "%d", got "%d"`, want, got)
 		}
+	}
+}
+
+// TestParseSources tests that correct output is returned for valid inputs
+func TestParseSources(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	sourceTypeFixture := fixtures.TestSourceTypeData[0]
+	sourceName := "Source for TestParseSources()"
+	var reqSources = []model.BulkCreateSource{
+		{
+			SourceCreateRequest: model.SourceCreateRequest{
+				Name:            util.StringRef(sourceName),
+				SourceTypeIDRaw: sourceTypeFixture.Id,
+			},
+		},
+	}
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	// Parse the sources
+	var err error
+	sources, err := parseSources(reqSources, &tenant, &userResource)
+	if err != nil {
+		t.Errorf(`unexpected error when parsing the sources from bulk create: %s`, err)
+	}
+
+	// Check the results
+	if len(sources) != 1 {
+		t.Errorf("expected 1 source returned from parseSources() but got %d", len(sources))
+	}
+
+	sourceOut := sources[0]
+
+	if sourceOut.AvailabilityStatus != model.InProgress {
+		t.Errorf("expected availability status 'in_progress', got %s", sourceOut.AvailabilityStatus)
+	}
+
+	if sourceOut.SourceTypeID != sourceTypeFixture.Id {
+		t.Errorf("expected source type id %d, got %d", sourceTypeFixture.Id, sourceOut.SourceTypeID)
+	}
+
+	if sourceOut.Name != sourceName {
+		t.Errorf("expected source name %s, got %s", sourceName, sourceOut.Name)
+	}
+
+	if sourceOut.TenantID != tenant.Id {
+		t.Errorf("expected tenant id %d, got %d", tenant.Id, sourceOut.TenantID)
+	}
+
+	if sourceOut.UserID != nil {
+		t.Errorf("expected user id = nil, got %d", sourceOut.UserID)
+	}
+}
+
+// TestParseSourcesBadRequestInvalidSourceTypeId tests that bad request is returned
+// for invalid source type id
+func TestParseSourcesBadRequestInvalidSourceTypeId(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	sourceTypeId := "wrong id"
+	sourceName := "Source for TestParseSources()"
+	var reqSources = []model.BulkCreateSource{
+		{
+			SourceCreateRequest: model.SourceCreateRequest{
+				Name:            util.StringRef(sourceName),
+				SourceTypeIDRaw: sourceTypeId,
+			},
+		},
+	}
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	// Parse the sources and check the results
+	var err error
+	sources, err := parseSources(reqSources, &tenant, &userResource)
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("expected bad request error, got <%s>", err)
+	}
+
+	if sources != nil {
+		t.Error("ghost infected the return")
+	}
+}
+
+// TestParseSourcesNotFoundInvalidSourceTypeId tests that not found is returned
+// for not existing source type id
+func TestParseSourcesNotFoundInvalidSourceTypeId(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	sourceTypeId := "1000"
+	sourceName := "Source for TestParseSources()"
+	var reqSources = []model.BulkCreateSource{
+		{
+			SourceCreateRequest: model.SourceCreateRequest{
+				Name:            util.StringRef(sourceName),
+				SourceTypeIDRaw: sourceTypeId,
+			},
+		},
+	}
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	// Parse the sources and check the results
+	var err error
+	sources, err := parseSources(reqSources, &tenant, &userResource)
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf("expected not found error, got <%s>", err)
+	}
+
+	if sources != nil {
+		t.Error("ghost infected the return")
 	}
 }


### PR DESCRIPTION
In bulk create request when invalid raw source type id is provided for the source, then a bad request should be returned

example of invalid bulk create request:
```
{
  "sources": [
    {
      "name": "test source amazon4",
      "source_type_id": "amazon"
    }
  ],
  "applications": [
    {
      "source_name": "test source amazon4",
      "application_type_name": "provisioning"
    }
  ]
}
```

response before: 
```
500 Internal Server Error
{
    "errors": [
        {
            "detail": "Internal Server Error: strconv.ParseInt: parsing \"amazon\": invalid syntax",
            "status": "500"
        }
    ]
}
```

response now:
```
400 Bad Request
{
    "errors": [
        {
            "detail": "bad request: invalid source type id, original error: strconv.ParseInt: parsing \"amazon\": invalid syntax",
            "status": "400"
        }
    ]
}
```

**JIRA:** [RHCLOUD-21547](https://issues.redhat.com/browse/RHCLOUD-21547)