### PR TITLE
[RHCLOUD-21549] Source parse in bulk create - add missing tests

### DIFF
--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -368,3 +368,34 @@ func TestParseSourcesBadRequestMissingSourceType(t *testing.T) {
 		t.Error("ghost infected the return")
 	}
 }
+
+// TestParseSourcesBadRequestValidationFails tests that bad request is returned
+// when validation of source create request fails
+func TestParseSourcesBadRequestValidationFails(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	sourceTypeName := "google"
+	var reqSources = []model.BulkCreateSource{
+		{
+			SourceCreateRequest: model.SourceCreateRequest{
+				AvailabilityStatus: model.Available,
+			},
+			SourceTypeName: sourceTypeName,
+		},
+	}
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	// Parse the sources and check the results
+	var err error
+	sources, err := parseSources(reqSources, &tenant, &userResource)
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("expected bad request error, got <%s>", err)
+	}
+
+	if sources != nil {
+		t.Error("ghost infected the return")
+	}
+}

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -338,3 +338,33 @@ func TestParseSourcesBadRequestInvalidSourceTypeName(t *testing.T) {
 		t.Error("ghost infected the return")
 	}
 }
+
+// TestParseSourcesBadRequestMissingSourceType tests that bad request is returned
+// when source type id or name is missing in the request
+func TestParseSourcesBadRequestMissingSourceType(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	sourceName := "Source for TestParseSources()"
+	var reqSources = []model.BulkCreateSource{
+		{
+			SourceCreateRequest: model.SourceCreateRequest{
+				Name: util.StringRef(sourceName),
+			},
+		},
+	}
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	// Parse the sources and check the results
+	var err error
+	sources, err := parseSources(reqSources, &tenant, &userResource)
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf("expected bad request error, got <%s>", err)
+	}
+
+	if sources != nil {
+		t.Error("ghost infected the return")
+	}
+}


### PR DESCRIPTION
this PR added some missing tests for parseSources() in service/bulk_create.go
now we have 100% test coverage for parseSources() 

**JIRA:** [RHCLOUD-21549](https://issues.redhat.com/browse/RHCLOUD-21549)