### PR TITLE
[RHCLOUD-21562] Application parse - bulk create - return bad request for invalid app type id raw + another tests

### DIFF
--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -481,7 +481,7 @@ func applicationFromBulkCreateApplication(reqApplication *m.BulkCreateApplicatio
 		// look up by id if an id was specified
 		id, err := util.InterfaceToInt64(reqApplication.ApplicationTypeIDRaw)
 		if err != nil {
-			return nil, err
+			return nil, util.NewErrBadRequest("application type id cannot be converted to an integer")
 		}
 
 		appType, err := dao.GetApplicationTypeDao(&tenant.Id).GetById(&id)

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -669,3 +669,39 @@ func TestParseApplicationsAppTypeIdNotFound(t *testing.T) {
 		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
 	}
 }
+
+// TestParseApplicationsBadRequestInvalidAppTypeName tests that bad request is returned
+// for invalid application type name in the request
+func TestParseApplicationsBadRequestInvalidAppTypeName(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	source := fixtures.TestSourceData[0]
+	anotherSource := fixtures.TestSourceData[1]
+	appTypeName := "not existing app type name"
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	bulkCreateOutput := model.BulkCreateOutput{
+		Sources: []model.Source{anotherSource},
+	}
+
+	reqApplications := []model.BulkCreateApplication{
+		{
+			ApplicationTypeName: appTypeName,
+			SourceName:          source.Name,
+		},
+	}
+
+	// Parse the applications
+	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
+	}
+
+	// Check the results
+	if apps != nil {
+		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
+	}
+}

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -559,3 +559,37 @@ func TestParseApplicationsBadRequestApplicationNotLinked(t *testing.T) {
 		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
 	}
 }
+
+// TestParseApplicationsBadRequestWithoutAppType tests that bad request is returned
+// when application type id or name is missing in the request
+func TestParseApplicationsBadRequestWithoutAppType(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	source := fixtures.TestSourceData[0]
+	anotherSource := fixtures.TestSourceData[1]
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	bulkCreateOutput := model.BulkCreateOutput{
+		Sources: []model.Source{anotherSource},
+	}
+
+	reqApplications := []model.BulkCreateApplication{
+		{
+			SourceName: source.Name,
+		},
+	}
+
+	// Parse the applications
+	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
+	}
+
+	// Check the results
+	if apps != nil {
+		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
+	}
+}

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -631,3 +631,41 @@ func TestParseApplicationsBadRequestInvalidAppTypeId(t *testing.T) {
 		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
 	}
 }
+
+// TestParseApplicationsAppTypeIdNotFound tests that not found is returned
+// for not existing application type id
+func TestParseApplicationsAppTypeIdNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	source := fixtures.TestSourceData[0]
+	anotherSource := fixtures.TestSourceData[1]
+	appTypeIdRaw := "1000"
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	bulkCreateOutput := model.BulkCreateOutput{
+		Sources: []model.Source{anotherSource},
+	}
+
+	reqApplications := []model.BulkCreateApplication{
+		{
+			ApplicationCreateRequest: model.ApplicationCreateRequest{
+				ApplicationTypeIDRaw: appTypeIdRaw,
+			},
+			SourceName: source.Name,
+		},
+	}
+
+	// Parse the applications
+	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
+	if !errors.Is(err, util.ErrNotFoundEmpty) {
+		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
+	}
+
+	// Check the results
+	if apps != nil {
+		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
+	}
+}

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -593,3 +593,41 @@ func TestParseApplicationsBadRequestWithoutAppType(t *testing.T) {
 		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
 	}
 }
+
+// TestParseApplicationsBadRequestInvalidAppTypeId tests that bad request is returned
+// for invalid application type raw id in the request
+func TestParseApplicationsBadRequestInvalidAppTypeId(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	source := fixtures.TestSourceData[0]
+	anotherSource := fixtures.TestSourceData[1]
+	appTypeIdRaw := "amazon"
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	bulkCreateOutput := model.BulkCreateOutput{
+		Sources: []model.Source{anotherSource},
+	}
+
+	reqApplications := []model.BulkCreateApplication{
+		{
+			ApplicationCreateRequest: model.ApplicationCreateRequest{
+				ApplicationTypeIDRaw: appTypeIdRaw,
+			},
+			SourceName: source.Name,
+		},
+	}
+
+	// Parse the applications
+	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
+	}
+
+	// Check the results
+	if apps != nil {
+		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
+	}
+}


### PR DESCRIPTION
when we have invalid app type id raw in bulk create
```
{
  "sources": [
    {
      "name": "test source amazon4",
      "source_type_name": "amazon"
    }
  ],
  "applications": [
    {
      "source_name": "test source amazon4",
      "application_type_id": "amazon"
    }
  ]
}
```

before we got in response:
```
{
    "errors": [
        {
            "detail": "Internal Server Error: strconv.ParseInt: parsing \"amazon\": invalid syntax",
            "status": "500"
        }
    ]
}
```

now we get:
```
{
    "errors": [
        {
            "detail": "bad request: application type id cannot be converted to an integer",
            "status": "400"
        }
    ]
}
```

+ I added some missing tests


**JIRA:** [RHCLOUD-21562](https://issues.redhat.com/browse/RHCLOUD-21562)