### PR TITLE
Availability check 'scheduled' URL flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,14 +17,14 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/vault/api v1.1.1
 	github.com/iancoleman/strcase v0.2.0
-	github.com/jackc/pgconn v1.11.0 // indirect
+	github.com/jackc/pgconn v1.11.0
 	github.com/jackc/pgx/v4 v4.15.0
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/labstack/echo-contrib v0.12.0
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/labstack/gommon v0.3.1
 	github.com/lib/pq v1.10.2 // indirect
-	github.com/lindgrenj6/logrus_zinc v0.0.0-20220822152658-d8a0b604f3f9 // indirect
+	github.com/lindgrenj6/logrus_zinc v0.0.0-20220822152658-d8a0b604f3f9
 	github.com/prometheus/client_golang v1.12.1
 	github.com/redhatinsights/app-common-go v1.6.3
 	github.com/redhatinsights/platform-go-middlewares v0.19.0

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -358,6 +358,15 @@ func SourceCheckAvailability(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
+	scheduledParam := c.QueryParam("scheduled")
+	if scheduledParam == "" {
+		scheduledParam = "false"
+	}
+	scheduled, err := strconv.ParseBool(scheduledParam)
+	if err != nil {
+		scheduled = false
+	}
+
 	exists, err := sourceDao.Exists(sourceID)
 	if !exists || err != nil {
 		cancel()
@@ -386,7 +395,7 @@ func SourceCheckAvailability(c echo.Context) error {
 			c.Logger().Warn(err)
 			return
 		}
-		service.RequestAvailabilityCheck(c, src, h)
+		service.RequestAvailabilityCheck(c, src, scheduled, h)
 		cancel()
 	}()
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1718,6 +1718,52 @@ func TestAvailabilityStatusCheck(t *testing.T) {
 	}
 }
 
+func TestScheduledAvailabilityStatusCheck(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/check_availability",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("source_id", "scheduled")
+	c.SetParamValues("1", "true")
+
+	err := SourceCheckAvailability(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 202 {
+		t.Errorf("Wrong code, got %v, expected %v", rec.Code, 202)
+	}
+}
+
+func TestUserAvailabilityStatusCheck(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/1/check_availability",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(1),
+		},
+	)
+
+	c.SetParamNames("source_id", "scheduled")
+	c.SetParamValues("1", "false")
+
+	err := SourceCheckAvailability(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 202 {
+		t.Errorf("Wrong code, got %v, expected %v", rec.Code, 202)
+	}
+}
+
 // TestAvailabilityStatusCheckInvalidTenant tests availability status check
 // with a tenant who doesn't own the source
 func TestAvailabilityStatusCheckInvalidTenant(t *testing.T) {


### PR DESCRIPTION
A new 'scheduled' flag is accepted for the availability flag which is passed to applications over HTTP in the JSON payload. A followup PR for the background scheduler will be created to set this flag for all scheduled checks. Applications can now decide to perform immediate actions or increase checking priority when the flag is missing (or false), meaning the request was not made from the scheduled job.