### PR TITLE
[RHCLOUD-21084] Add Secret-Store specific helper functions

### DIFF
--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -1,17 +1,14 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
 
-	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/marketplace"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
-	"gorm.io/datatypes"
 )
 
 var getAuthenticationDao func(c echo.Context) (dao.AuthenticationDao, error)
@@ -99,29 +96,20 @@ func AuthenticationCreate(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
-	var extra map[string]interface{}
-	var extraDb datatypes.JSON
-
-	if config.IsVaultOn() {
-		extra = createRequest.Extra
-	} else {
-		extraDb, err = json.Marshal(createRequest.Extra)
-
-		if err != nil {
-			return util.NewErrBadRequest(`invalid JSON given in "extra" field`)
-		}
-	}
-
 	auth := &m.Authentication{
 		Name:         createRequest.Name,
 		AuthType:     createRequest.AuthType,
 		Username:     createRequest.Username,
 		Password:     createRequest.Password,
-		Extra:        extra,
-		ExtraDb:      extraDb,
 		ResourceType: createRequest.ResourceType,
 		ResourceID:   createRequest.ResourceID,
 	}
+
+	err = auth.SetExtra(createRequest.Extra)
+	if err != nil {
+		return util.NewErrBadRequest(err)
+	}
+
 	err = authDao.Create(auth)
 	if err != nil {
 		return util.NewErrBadRequest(err)

--- a/config/config.go
+++ b/config/config.go
@@ -225,9 +225,9 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("MarketplaceHost", os.Getenv("MARKETPLACE_HOST"))
 	options.SetDefault("SlowSQLThreshold", 2) //seconds
 	options.SetDefault("BypassRbac", os.Getenv("BYPASS_RBAC") == "true")
-	// The secret store defaults to the database in case an empty or an incorrect value are provided.
 	secretStore := os.Getenv("SECRET_STORE")
-	if secretStore != "database" && secretStore != "vault" {
+	// The secret store defaults to the database in case an empty string
+	if secretStore == "" {
 		secretStore = "database"
 	}
 	options.SetDefault("SecretStore", secretStore)

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,10 @@ import (
 const (
 	KafkaGroupId  = "sources-api-go"
 	RdsCaLocation = "/app/rdsca.cert"
+
+	DatabaseStore       = "database"
+	VaultStore          = "vault"
+	SecretsManagerStore = "secrets-manager"
 )
 
 var parsedConfig *SourcesApiConfig
@@ -319,6 +323,7 @@ func (sourceConfig *SourcesApiConfig) KafkaTopic(requestedTopic string) string {
 }
 
 // IsVaultOn returns true if the authentications are backed by Vault. False, if they are backed by the database.
+// DEPRECATED: should be using methods on the authentication object instead of checking the config directly.
 func IsVaultOn() bool {
 	return parsedConfig.SecretStore == "vault"
 }

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -29,10 +29,15 @@ var GetAuthenticationDao func(daoParams *RequestParams) AuthenticationDao
 
 // getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
 func getDefaultAuthenticationDao(daoParams *RequestParams) AuthenticationDao {
-	if config.IsVaultOn() {
-		return &authenticationDaoImpl{RequestParams: daoParams}
-	} else {
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
 		return &authenticationDaoDbImpl{RequestParams: daoParams}
+	case config.VaultStore:
+		return &authenticationDaoImpl{RequestParams: daoParams}
+	case config.SecretsManagerStore:
+		panic(m.ErrBadSecretStore)
+	default:
+		panic(m.ErrBadSecretStore)
 	}
 }
 

--- a/dao/authentication_dao.go
+++ b/dao/authentication_dao.go
@@ -35,9 +35,9 @@ func getDefaultAuthenticationDao(daoParams *RequestParams) AuthenticationDao {
 	case config.VaultStore:
 		return &authenticationDaoImpl{RequestParams: daoParams}
 	case config.SecretsManagerStore:
-		panic(m.ErrBadSecretStore)
+		return &noSecretStoreAuthenticationDao{}
 	default:
-		panic(m.ErrBadSecretStore)
+		return &noSecretStoreAuthenticationDao{}
 	}
 }
 

--- a/dao/authentication_no_secret_store_dao.go
+++ b/dao/authentication_no_secret_store_dao.go
@@ -1,0 +1,102 @@
+package dao
+
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+// implement the auth dao but return errors everywhere that will bubble up to the end user.
+type noSecretStoreAuthenticationDao struct{}
+
+func (a *noSecretStoreAuthenticationDao) List(limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	return nil, 0, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) GetById(id string) (*m.Authentication, error) {
+	return nil, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) ListForSource(sourceID int64, limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	return nil, 0, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) ListForApplication(applicationID int64, limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	return nil, 0, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) ListForApplicationAuthentication(appAuthID int64, limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	return nil, 0, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) ListForEndpoint(endpointID int64, limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	return nil, 0, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) Create(src *m.Authentication) error {
+	return m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) BulkCreate(src *m.Authentication) error {
+	return m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) Update(src *m.Authentication) error {
+	return m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) Delete(id string) (*m.Authentication, error) {
+	return nil, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) Tenant() *int64 {
+	return new(int64)
+}
+
+func (a *noSecretStoreAuthenticationDao) AuthenticationsByResource(authentication *m.Authentication) ([]m.Authentication, error) {
+	return nil, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
+	return nil, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) (interface{}, error) {
+	return nil, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) ToEventJSON(resource util.Resource) ([]byte, error) {
+	return nil, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) ListIdsForResource(resourceType string, resourceIds []int64) ([]m.Authentication, error) {
+	return nil, m.ErrBadSecretStore
+}
+
+func (a *noSecretStoreAuthenticationDao) BulkDelete(authentications []m.Authentication) ([]m.Authentication, error) {
+	return nil, m.ErrBadSecretStore
+}
+
+// implement the secrets dao interface, embedding the parent so we only have to implement the overridden names
+type noSecretStoreSecretsDao struct {
+	noSecretStoreAuthenticationDao
+}
+
+func (n *noSecretStoreSecretsDao) Delete(id *int64) error {
+	return m.ErrBadSecretStore
+}
+
+func (n *noSecretStoreSecretsDao) NameExistsInCurrentTenant(name string) bool {
+	return false
+}
+
+func (n *noSecretStoreSecretsDao) GetById(id *int64) (*m.Authentication, error) {
+	return n.noSecretStoreAuthenticationDao.GetById("")
+}
+
+func (n *noSecretStoreSecretsDao) List(limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+	return n.noSecretStoreAuthenticationDao.List(limit, offset, filters)
+}
+
+func (n *noSecretStoreSecretsDao) Update(src *m.Authentication) error {
+	return n.noSecretStoreAuthenticationDao.Update(src)
+}

--- a/dao/secret_dao.go
+++ b/dao/secret_dao.go
@@ -3,6 +3,7 @@ package dao
 import (
 	"fmt"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"gorm.io/gorm"
@@ -17,7 +18,16 @@ type secretDaoDbImpl struct {
 }
 
 func getDefaultSecretDao(daoParams *RequestParams) SecretDao {
-	return &secretDaoDbImpl{RequestParams: daoParams}
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
+		return &secretDaoDbImpl{RequestParams: daoParams}
+	case config.VaultStore:
+		return &noSecretStoreSecretsDao{}
+	case config.SecretsManagerStore:
+		return &noSecretStoreSecretsDao{}
+	default:
+		return &noSecretStoreSecretsDao{}
+	}
 }
 
 func init() {

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/graph/generated"
 	generated_model "github.com/RedHatInsights/sources-api-go/graph/model"
@@ -80,11 +79,7 @@ func (r *applicationTypeResolver) Sources(ctx context.Context, obj *model.Applic
 }
 
 func (r *authenticationResolver) ID(ctx context.Context, obj *model.Authentication) (string, error) {
-	if config.IsVaultOn() {
-		return obj.ID, nil
-	} else {
-		return strconv.FormatInt(obj.DbID, 10), nil
-	}
+	return obj.GetID(), nil
 }
 
 func (r *authenticationResolver) ResourceID(ctx context.Context, obj *model.Authentication) (string, error) {

--- a/marketplace/utils_test.go
+++ b/marketplace/utils_test.go
@@ -386,7 +386,7 @@ func TestAuthFromDbExtraNoContent(t *testing.T) {
 		t.Errorf("want no error, got %s", err)
 	}
 
-	want, err := json.Marshal(setUpBearerToken())
+	want, err := json.Marshal(map[string]interface{}{"marketplace": setUpBearerToken()})
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -1,11 +1,7 @@
 package model
 
 import (
-	"encoding/json"
 	"time"
-
-	"github.com/RedHatInsights/sources-api-go/config"
-	"github.com/RedHatInsights/sources-api-go/util"
 )
 
 type AuthenticationResponse struct {
@@ -73,23 +69,16 @@ func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest)
 		auth.Username = update.Username
 	}
 	if update.Password != nil {
-		encrypted, err := util.Encrypt(*update.Password)
+		err := auth.SetPassword(*update.Password)
 		if err != nil {
 			return err
 		}
-		auth.Password = &encrypted
 	}
 
 	if update.Extra != nil {
-		if config.IsVaultOn() {
-			auth.Extra = *update.Extra
-		} else {
-			var err error
-			auth.ExtraDb, err = json.Marshal(*update.Extra)
-
-			if err != nil {
-				return err
-			}
+		err := auth.SetExtra(*update.Extra)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -109,16 +98,14 @@ func (auth *Authentication) UpdateSecretFromRequest(update *SecretEditRequest) e
 	}
 
 	if update.Password != nil {
-		encrypted, err := util.Encrypt(*update.Password)
+		err := auth.SetPassword(*update.Password)
 		if err != nil {
 			return err
 		}
-		auth.Password = &encrypted
 	}
 
 	if update.Extra != nil {
-		var err error
-		auth.ExtraDb, err = json.Marshal(*update.Extra)
+		err := auth.SetExtra(*update.Extra)
 		if err != nil {
 			return err
 		}

--- a/model/secret_store_util.go
+++ b/model/secret_store_util.go
@@ -1,0 +1,165 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/RedHatInsights/sources-api-go/config"
+	l "github.com/RedHatInsights/sources-api-go/logger"
+	"github.com/RedHatInsights/sources-api-go/util"
+)
+
+var ErrBadSecretStore = fmt.Errorf("invalid secret-store: %s", config.Get().SecretStore)
+
+// fetches the secret-store dependent ID from the authentication
+func (auth *Authentication) GetID() string {
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
+		return strconv.FormatInt(auth.DbID, 10)
+
+	case config.VaultStore:
+		return auth.ID
+
+	case config.SecretsManagerStore:
+		return ""
+
+	default:
+		panic(ErrBadSecretStore)
+	}
+}
+
+// fetches the secret-store dependent extra field from the authentication
+func (auth *Authentication) GetExtra() map[string]interface{} {
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
+		var extra map[string]interface{}
+
+		if auth.ExtraDb != nil {
+			err := json.Unmarshal(auth.ExtraDb, &extra)
+			if err != nil {
+				l.Log.Warnf("failed to unmarshal extra: %v", err)
+			}
+		}
+
+		return extra
+
+	case config.VaultStore:
+		return auth.Extra
+
+	case config.SecretsManagerStore:
+		return nil
+
+	default:
+		panic(ErrBadSecretStore)
+	}
+}
+
+// self-explanatory, the password can be in a different format based on the
+// secret-store.
+func (auth *Authentication) GetPassword() (*string, error) {
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
+		if auth.Password == nil {
+			return nil, nil
+		}
+
+		decrypted, err := util.Decrypt(*auth.Password)
+		return &decrypted, err
+
+	case config.VaultStore:
+		return auth.Password, nil
+
+	case config.SecretsManagerStore:
+		return nil, ErrBadSecretStore
+
+	default:
+		return nil, ErrBadSecretStore
+	}
+}
+
+// set the extra field on the authentication struct based on which secret store we're using
+func (auth *Authentication) SetExtra(extra map[string]interface{}) error {
+	if extra == nil {
+		return nil
+	}
+
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
+		var err error
+		auth.ExtraDb, err = json.Marshal(extra)
+		if err != nil {
+			return err
+		}
+
+	case config.VaultStore:
+		auth.Extra = extra
+
+	case config.SecretsManagerStore:
+		return ErrBadSecretStore
+
+	default:
+		return ErrBadSecretStore
+	}
+
+	return nil
+}
+
+// sets a field on the extra column, changing how to get to the field based on
+// the secret store.
+func (auth *Authentication) SetExtraField(key string, value interface{}) error {
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
+		var err error
+		var extra = make(map[string]interface{})
+
+		if auth.ExtraDb != nil && string(auth.ExtraDb) != `null` {
+			err := json.Unmarshal(auth.ExtraDb, &extra)
+			if err != nil {
+				return err
+			}
+		}
+
+		extra[key] = value
+		auth.ExtraDb, err = json.Marshal(extra)
+		return err
+
+	case config.VaultStore:
+		if auth.Extra == nil {
+			auth.Extra = make(map[string]interface{})
+		}
+
+		auth.Extra[key] = value
+
+		return nil
+
+	case config.SecretsManagerStore:
+		return ErrBadSecretStore
+
+	default:
+		return ErrBadSecretStore
+	}
+}
+
+func (auth *Authentication) SetPassword(pass string) error {
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
+		encrypted, err := util.Encrypt(pass)
+		if err != nil {
+			return err
+		}
+
+		auth.Password = &encrypted
+		return nil
+
+	case config.VaultStore:
+		auth.Password = &pass
+		return nil
+
+	case config.SecretsManagerStore:
+		return ErrBadSecretStore
+
+	default:
+		return ErrBadSecretStore
+	}
+}

--- a/routes.go
+++ b/routes.go
@@ -74,6 +74,9 @@ func setupRoutes(e *echo.Echo) {
 		// Authentications
 		r.GET("/authentications", AuthenticationList, tenancyWithListMiddleware...)
 		r.POST("/authentications", AuthenticationCreate, permissionMiddleware...)
+
+		// set up uuid validation on the vault store, otherwise the regular id
+		// validation will do.
 		if config.IsVaultOn() {
 			r.GET("/authentications/:uid", AuthenticationGet, append(tenancyMiddleware, middleware.UuidValidation)...)
 			r.PATCH("/authentications/:uid", AuthenticationEdit, append(permissionMiddleware, middleware.Notifier, middleware.UuidValidation)...)

--- a/secret_handlers.go
+++ b/secret_handlers.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
@@ -9,7 +8,6 @@ import (
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
-	"gorm.io/datatypes"
 )
 
 var getSecretDao func(c echo.Context) (dao.SecretDao, error)
@@ -45,20 +43,16 @@ func SecretCreate(c echo.Context) error {
 		return util.NewErrBadRequest(err)
 	}
 
-	var extraDb datatypes.JSON
-
-	extraDb, err = json.Marshal(createRequest.Extra)
-
-	if err != nil {
-		return util.NewErrBadRequest(`invalid JSON given in "extra" field`)
-	}
-
 	secret := &m.Authentication{
 		Name:     createRequest.Name,
 		AuthType: createRequest.AuthType,
 		Username: createRequest.Username,
 		Password: createRequest.Password,
-		ExtraDb:  extraDb,
+	}
+
+	err = secret.SetExtra(createRequest.Extra)
+	if err != nil {
+		return err
 	}
 
 	if createRequest.UserScoped && requestParams.UserID != nil {

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -299,8 +298,11 @@ func linkUpAuthentications(req m.BulkCreateRequest, current *m.BulkCreateOutput,
 		a.AuthType = auth.AuthType
 		a.Username = util.StringValueOrNil(auth.Username)
 		a.Password = auth.Password
-		// TODO: set based on vault or not.
-		a.ExtraDb, _ = json.Marshal(auth.Extra)
+		// pull extra properly per secret store
+		err := a.SetExtra(auth.Extra)
+		if err != nil {
+			return nil, err
+		}
 		a.Name = auth.Name
 		a.Tenant = *tenant
 		a.TenantID = tenant.Id

--- a/service/superkey.go
+++ b/service/superkey.go
@@ -44,12 +44,7 @@ func SendSuperKeyCreateRequest(application *m.Application, headers []kafka.Heade
 		return err
 	}
 
-	var superKeyId string
-	if config.IsVaultOn() {
-		superKeyId = superKey.ID
-	} else {
-		superKeyId = strconv.FormatInt(superKey.DbID, 10)
-	}
+	superKeyId := superKey.GetID()
 
 	req := superkey.CreateRequest{
 		TenantID:        application.Tenant.ExternalTenant,
@@ -103,12 +98,7 @@ func SendSuperKeyDeleteRequest(application *m.Application, headers []kafka.Heade
 		return nil
 	}
 
-	var superKeyId string
-	if config.IsVaultOn() {
-		superKeyId = superKey.ID
-	} else {
-		superKeyId = strconv.FormatInt(superKey.DbID, 10)
-	}
+	superKeyId := superKey.GetID()
 
 	req := superkey.DestroyRequest{
 		TenantID:       application.Tenant.ExternalTenant,


### PR DESCRIPTION
So this is the start of the AWS Secrets Manager integration work.

Now that we are going forward with yet-another-backend for authentications (but don't want to remove the ability a) the database and b) maybe change the vault backend someday), I wanted a way to abstract out the "custom" fields like extra vs password vs even the IDs.

This PR takes most of the `if config.IsVaultOn()` logic out of handlers/service functions and moves it to methods on the authentication object itself which switches on each secret store type.

The biggest changes are as follows:
- *do not* set extra directly (e.g. `auth.ExtraDb = json.Marshal(...)`, always just use `auth.SetExtra(map[string]interface{})`, that will use the appropriate logic.
- *do* use `auth.GetID()` when fetching the string ID for returning, it will fetch the right field based on secret-store
- *do not* write tests that do if/else on vault anymore, I want (in the future) to pull all the if/else tests and write tests for each secret store.
- *do* use `auth.GetPassword()` to fetch the password, same with `auth.SetPassword(string)`, it will do the right thing based on the secret-store.
---

Another change is that if there isn't a secret-store set, we're defaulting to db (like normal), but I removed the check for db or vault, it takes any string now. If one passes in a string that isn't supported (like secrets-manager right now) all of the `/authentications` and `/secrets` endpoints will just return 500s with an error like so:
```json
{
	"errors": [
		{
			"detail": "Internal Server Error: invalid secret-store: secrets-manager",
			"status": "500"
		}
	]
}
```