### PR TITLE
[RHCLOUD-22515] App parse bulk create - return bad request err for not compatible app type and source type

### DIFF
--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -217,9 +217,9 @@ func parseApplications(reqApplications []m.BulkCreateApplication, current *m.Bul
 			}
 
 			// check compatibility with the source type
-			err := dao.GetApplicationTypeDao(&tenant.Id).ApplicationTypeCompatibleWithSourceType(a.ApplicationType.Id, src.SourceType.Id)
+			err = dao.GetApplicationTypeDao(&tenant.Id).ApplicationTypeCompatibleWithSourceType(a.ApplicationType.Id, src.SourceType.Id)
 			if err != nil {
-				return nil, err
+				return nil, util.NewErrBadRequest("the application type is not compatible with the source type")
 			}
 
 			// fill out whats left of the application (spoiler: not much)

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -701,3 +701,38 @@ func TestParseApplicationsBadRequestInvalidAppTypeName(t *testing.T) {
 		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
 	}
 }
+
+// TestParseApplicationsBadRequestNotCompatible tests that bad request is returned
+// for not compatible app type with source type
+func TestParseApplicationsBadRequestNotCompatible(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	// Prepare test data
+	source := fixtures.TestSourceData[0]
+	appType := fixtures.TestApplicationTypeData[1]
+
+	tenant := fixtures.TestTenantData[0]
+	userResource := model.UserResource{}
+
+	bulkCreateOutput := model.BulkCreateOutput{
+		Sources: []model.Source{source},
+	}
+
+	reqApplications := []model.BulkCreateApplication{
+		{
+			ApplicationTypeName: appType.Name,
+			SourceName:          source.Name,
+		},
+	}
+
+	// Parse the applications
+	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
+	if !errors.Is(err, util.ErrBadRequestEmpty) {
+		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
+	}
+
+	// Check the results
+	if apps != nil {
+		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
+	}
+}

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -567,13 +567,12 @@ func TestParseApplicationsBadRequestWithoutAppType(t *testing.T) {
 
 	// Prepare test data
 	source := fixtures.TestSourceData[0]
-	anotherSource := fixtures.TestSourceData[1]
 
 	tenant := fixtures.TestTenantData[0]
 	userResource := model.UserResource{}
 
 	bulkCreateOutput := model.BulkCreateOutput{
-		Sources: []model.Source{anotherSource},
+		Sources: []model.Source{source},
 	}
 
 	reqApplications := []model.BulkCreateApplication{
@@ -601,14 +600,13 @@ func TestParseApplicationsBadRequestInvalidAppTypeId(t *testing.T) {
 
 	// Prepare test data
 	source := fixtures.TestSourceData[0]
-	anotherSource := fixtures.TestSourceData[1]
 	appTypeIdRaw := "amazon"
 
 	tenant := fixtures.TestTenantData[0]
 	userResource := model.UserResource{}
 
 	bulkCreateOutput := model.BulkCreateOutput{
-		Sources: []model.Source{anotherSource},
+		Sources: []model.Source{source},
 	}
 
 	reqApplications := []model.BulkCreateApplication{
@@ -639,14 +637,13 @@ func TestParseApplicationsAppTypeIdNotFound(t *testing.T) {
 
 	// Prepare test data
 	source := fixtures.TestSourceData[0]
-	anotherSource := fixtures.TestSourceData[1]
 	appTypeIdRaw := "1000"
 
 	tenant := fixtures.TestTenantData[0]
 	userResource := model.UserResource{}
 
 	bulkCreateOutput := model.BulkCreateOutput{
-		Sources: []model.Source{anotherSource},
+		Sources: []model.Source{source},
 	}
 
 	reqApplications := []model.BulkCreateApplication{
@@ -677,14 +674,13 @@ func TestParseApplicationsBadRequestInvalidAppTypeName(t *testing.T) {
 
 	// Prepare test data
 	source := fixtures.TestSourceData[0]
-	anotherSource := fixtures.TestSourceData[1]
 	appTypeName := "not existing app type name"
 
 	tenant := fixtures.TestTenantData[0]
 	userResource := model.UserResource{}
 
 	bulkCreateOutput := model.BulkCreateOutput{
-		Sources: []model.Source{anotherSource},
+		Sources: []model.Source{source},
 	}
 
 	reqApplications := []model.BulkCreateApplication{


### PR DESCRIPTION
bulk create + not compatible application type and source type
response before:
```
{
    "errors": [
        {
            "detail": "Internal Server Error: record not found",
            "status": "500"
        }
    ]
}
```

response now:
```
{
    "errors": [
        {
            "detail": "bad request: application type is not compatible with the source type",
            "status": "400"
        }
    ]
}
```

**JIRA:** [RHCLOUD-22515](https://issues.redhat.com/browse/RHCLOUD-22515)