### PR TITLE
[RHCLOUD-21516] Update SourceDao#List function to pass sources table in case of sorting based on other tables

### DIFF
--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -105,7 +105,7 @@ func (s *sourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 
 func (s *sourceDaoImpl) List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error) {
 	sources := make([]m.Source, 0, limit)
-	query := s.getDbWithModel()
+	query := s.getDbWithTable(DB.Debug(), "sources").Model(&m.Source{})
 
 	query, err := applyFilters(query, filters)
 	if err != nil {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-21516

bad query in question:
```graphql
{
	sources(
		limit: 50
		offset: 0
		sort_by: { name: "created_at", direction: desc }
		filter: [
			{
				name: "applications.application_type_id"
				operation: "eq"
				value: ["11"]
			}
			{ name: "source_type.category", operation: "eq", value: "Cloud" }
		]
	) {
		id
		created_at
		source_type_id
		name
		imported
		availability_status
		source_ref
		last_checked_at
		updated_at
		last_available_at
		app_creation_workflow
		paused_at
		authentications {
			authtype
			username
			availability_status_error
			availability_status
		}
		applications {
			application_type_id
			id
			availability_status_error
			availability_status
			paused_at
			authentications {
				id
				resource_type
			}
		}
		endpoints {
			id
			scheme
			host
			port
			path
			receptor_node
			role
			certificate_authority
			verify_ssl
			availability_status_error
			availability_status
			authentications {
				authtype
				availability_status
				availability_status_error
			}
		}
	}
	meta {
		count
	}
}
```