### PR TITLE
Reorganize various Authentication DAOs

### DIFF
--- a/dao/amazon/secrets_manager_client.go
+++ b/dao/amazon/secrets_manager_client.go
@@ -1,0 +1,1 @@
+package amazon

--- a/dao/authentication_dao_common.go
+++ b/dao/authentication_dao_common.go
@@ -1,0 +1,37 @@
+package dao
+
+import "github.com/RedHatInsights/sources-api-go/config"
+
+/*
+	Common DAO code for the 1..n authentication DAOs we support.
+	Currently, that list is:
+	1. DB Dao, using postgres and an encrypted column as a backend
+	2. Hashicorp vault, as the name implies storing authentication things in the vault
+	3. Amazon Secrets Manager, a WIP that uses Amazon Secrets Manager to store authentication things
+*/
+
+// init sets the default DAO implementation so that other packages can request it easily.
+func init() {
+	GetAuthenticationDao = getDefaultAuthenticationDao
+}
+
+// GetAuthenticationDao is a function definition that can be replaced in runtime in case some other DAO provider is
+// needed.
+var GetAuthenticationDao func(daoParams *RequestParams) AuthenticationDao
+
+// getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
+func getDefaultAuthenticationDao(daoParams *RequestParams) AuthenticationDao {
+	switch config.Get().SecretStore {
+	case config.DatabaseStore:
+		return &authenticationDaoDbImpl{RequestParams: daoParams}
+	case config.VaultStore:
+		return &authenticationDaoVaultImpl{RequestParams: daoParams}
+	case config.SecretsManagerStore:
+		return &authenticationSecretsManagerDaoImpl{
+			RequestParams:           daoParams,
+			authenticationDaoDbImpl: authenticationDaoDbImpl{RequestParams: daoParams},
+		}
+	default:
+		return &noSecretStoreAuthenticationDao{}
+	}
+}

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -223,7 +223,7 @@ func TestFindKeysByResourceTypeAndId(t *testing.T) {
 	}
 
 	// We use a RAW impl without the "GetAuthenticationDao" function since we want to access the unexported function.
-	implDao := authenticationDaoImpl{&RequestParams{TenantID: &fixtures.TestTenantData[0].Id}}
+	implDao := authenticationDaoVaultImpl{&RequestParams{TenantID: &fixtures.TestTenantData[0].Id}}
 	for _, tt := range testData {
 		// Call the function under test.
 		foundKeys, err := implDao.findKeysByResourceTypeAndId(tt.Keys, tt.ResourceType, tt.ResourceIds)

--- a/dao/authentication_secrets_manager_dao.go
+++ b/dao/authentication_secrets_manager_dao.go
@@ -1,0 +1,40 @@
+package dao
+
+import (
+	m "github.com/RedHatInsights/sources-api-go/model"
+)
+
+type authenticationSecretsManagerDaoImpl struct {
+	// tenant ID + User ID + context information
+	*RequestParams
+
+	// embedded isntance of the db - since we use it for all fields except the
+	// password. the only glaring difference is that we will store an
+	// unencrypted ARN as the password field, so we can just fetch it directly
+	// from amazon when we need to decrypt it.
+	//
+	// we also will continue to use all list/info methods as passthrough - only
+	// overriding when necessary.
+	authenticationDaoDbImpl
+}
+
+func (a *authenticationSecretsManagerDaoImpl) Create(src *m.Authentication) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *authenticationSecretsManagerDaoImpl) BulkCreate(src *m.Authentication) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *authenticationSecretsManagerDaoImpl) Update(src *m.Authentication) error {
+	panic("not implemented") // TODO: Implement
+}
+
+func (a *authenticationSecretsManagerDaoImpl) Delete(id string) (*m.Authentication, error) {
+	panic("not implemented") // TODO: Implement
+}
+
+// BulkDelete deletes all the authentications given as a list, and returns the ones that were deleted.
+func (a *authenticationSecretsManagerDaoImpl) BulkDelete(authentications []m.Authentication) ([]m.Authentication, error) {
+	panic("not implemented") // TODO: Implement
+}

--- a/dao/authentication_vault_dao.go
+++ b/dao/authentication_vault_dao.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/RedHatInsights/sources-api-go/config"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -23,30 +22,7 @@ import (
 // secret/data/<tenant_id>/<resourceType>_<resourceId>_<resourceUuid>
 const vaultSecretPathFormat = "secret/data/%d/%s_%d_%s"
 
-// GetAuthenticationDao is a function definition that can be replaced in runtime in case some other DAO provider is
-// needed.
-var GetAuthenticationDao func(daoParams *RequestParams) AuthenticationDao
-
-// getDefaultAuthenticationDao gets the default DAO implementation which will have the given tenant ID.
-func getDefaultAuthenticationDao(daoParams *RequestParams) AuthenticationDao {
-	switch config.Get().SecretStore {
-	case config.DatabaseStore:
-		return &authenticationDaoDbImpl{RequestParams: daoParams}
-	case config.VaultStore:
-		return &authenticationDaoImpl{RequestParams: daoParams}
-	case config.SecretsManagerStore:
-		return &noSecretStoreAuthenticationDao{}
-	default:
-		return &noSecretStoreAuthenticationDao{}
-	}
-}
-
-// init sets the default DAO implementation so that other packages can request it easily.
-func init() {
-	GetAuthenticationDao = getDefaultAuthenticationDao
-}
-
-type authenticationDaoImpl struct {
+type authenticationDaoVaultImpl struct {
 	*RequestParams
 }
 
@@ -59,7 +35,7 @@ so we could potentially fetch multiple at once.
 TODO: Maybe parallelize fetching multiple records with goroutines +
 waitgroup
 */
-func (a *authenticationDaoImpl) List(limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+func (a *authenticationDaoVaultImpl) List(limit int, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
 	keys, err := a.listKeys()
 	if err != nil {
 		return nil, 0, err
@@ -91,7 +67,7 @@ func (a *authenticationDaoImpl) List(limit int, offset int, filters []util.Filte
 	return out, count, nil
 }
 
-func (a *authenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
+func (a *authenticationDaoVaultImpl) ListForSource(sourceID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	// Check if sourceID exists
 	_, err := GetSourceDao(&RequestParams{TenantID: a.TenantID}).GetById(&sourceID)
 	if err != nil {
@@ -119,7 +95,7 @@ func (a *authenticationDaoImpl) ListForSource(sourceID int64, _, _ int, _ []util
 	return out, int64(len(out)), nil
 }
 
-func (a *authenticationDaoImpl) ListForApplication(applicationID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
+func (a *authenticationDaoVaultImpl) ListForApplication(applicationID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	// checking if application exists first
 	_, err := GetApplicationDao(&RequestParams{TenantID: a.TenantID, UserID: a.UserID}).GetById(&applicationID)
 	if err != nil {
@@ -147,7 +123,7 @@ func (a *authenticationDaoImpl) ListForApplication(applicationID int64, _, _ int
 	return auths, int64(len(auths)), nil
 }
 
-func (a *authenticationDaoImpl) ListForApplicationAuthentication(appauthID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
+func (a *authenticationDaoVaultImpl) ListForApplicationAuthentication(appauthID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	appauth := m.ApplicationAuthentication{ID: appauthID}
 	result := DB.
 		Where("tenant_id = ?", *a.TenantID).
@@ -165,7 +141,7 @@ func (a *authenticationDaoImpl) ListForApplicationAuthentication(appauthID int64
 	return auths, int64(len(auths)), nil
 }
 
-func (a *authenticationDaoImpl) ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
+func (a *authenticationDaoVaultImpl) ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
 	_, err := GetEndpointDao(a.TenantID).GetById(&endpointID)
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("endpoint")
@@ -192,7 +168,7 @@ func (a *authenticationDaoImpl) ListForEndpoint(endpointID int64, limit, offset 
 	return auths, int64(len(auths)), nil
 }
 
-func (a *authenticationDaoImpl) getAuthsForAppAuth(appAuths []m.ApplicationAuthentication) ([]m.Authentication, error) {
+func (a *authenticationDaoVaultImpl) getAuthsForAppAuth(appAuths []m.ApplicationAuthentication) ([]m.Authentication, error) {
 	out := make([]m.Authentication, len(appAuths))
 	for i, appAuth := range appAuths {
 		auth, err := a.getKey(appAuth.VaultPath)
@@ -212,7 +188,7 @@ the one with the right suffix before fetching it. So every "show" request
 will always incur 2 reqs to vault. It may be slower but that is a casualty
 of not having an RDMS.
 */
-func (a *authenticationDaoImpl) GetById(uid string) (*m.Authentication, error) {
+func (a *authenticationDaoVaultImpl) GetById(uid string) (*m.Authentication, error) {
 	keys, err := a.listKeys()
 	if err != nil {
 		return nil, err
@@ -233,7 +209,7 @@ func (a *authenticationDaoImpl) GetById(uid string) (*m.Authentication, error) {
 	return a.getKey(fullKey)
 }
 
-func (a *authenticationDaoImpl) Create(auth *m.Authentication) error {
+func (a *authenticationDaoVaultImpl) Create(auth *m.Authentication) error {
 	query := DB.Select("source_id").Where("tenant_id = ?", *a.TenantID)
 
 	switch strings.ToLower(auth.ResourceType) {
@@ -285,7 +261,7 @@ func (a *authenticationDaoImpl) Create(auth *m.Authentication) error {
 // Create method _without_ checking if the resource exists. Basically since this
 // is the bulk-create method the resource doesn't exist yet and we know the
 // source ID is set beforehand.
-func (a *authenticationDaoImpl) BulkCreate(auth *m.Authentication) error {
+func (a *authenticationDaoVaultImpl) BulkCreate(auth *m.Authentication) error {
 	auth.ID = uuid.New().String()
 	auth.CreatedAt = time.Now()
 	path := fmt.Sprintf("secret/data/%d/%s_%v_%s", *a.TenantID, auth.ResourceType, auth.ResourceID, auth.ID)
@@ -308,7 +284,7 @@ func (a *authenticationDaoImpl) BulkCreate(auth *m.Authentication) error {
 	return nil
 }
 
-func (a *authenticationDaoImpl) Update(auth *m.Authentication) error {
+func (a *authenticationDaoVaultImpl) Update(auth *m.Authentication) error {
 	path := fmt.Sprintf("secret/data/%d/%s_%v_%s", *a.TenantID, auth.ResourceType, auth.ResourceID, auth.ID)
 
 	data, err := auth.ToVaultMap()
@@ -329,7 +305,7 @@ func (a *authenticationDaoImpl) Update(auth *m.Authentication) error {
 	return nil
 }
 
-func (a *authenticationDaoImpl) Delete(uid string) (*m.Authentication, error) {
+func (a *authenticationDaoVaultImpl) Delete(uid string) (*m.Authentication, error) {
 	keys, err := a.listKeys()
 	if err != nil {
 		return nil, err
@@ -347,7 +323,7 @@ func (a *authenticationDaoImpl) Delete(uid string) (*m.Authentication, error) {
 	return nil, util.NewErrNotFound("authentication")
 }
 
-func (a *authenticationDaoImpl) Tenant() *int64 {
+func (a *authenticationDaoVaultImpl) Tenant() *int64 {
 	return a.TenantID
 }
 
@@ -356,7 +332,7 @@ This method lists all keys for a certain tenant - this is necessary because
 of the fact that we can't search for a key based on name, type etc much like
 a k/v store. (almost like the `vault kv get` and `vault kv put`)
 */
-func (a *authenticationDaoImpl) listKeys() ([]string, error) {
+func (a *authenticationDaoVaultImpl) listKeys() ([]string, error) {
 	// List all the keys
 	path := fmt.Sprintf("secret/metadata/%d/", *a.TenantID)
 	list, err := Vault.List(path)
@@ -385,7 +361,7 @@ func (a *authenticationDaoImpl) listKeys() ([]string, error) {
 /*
 Fetch a key from Vault (full path, type and id included)
 */
-func (a *authenticationDaoImpl) getKey(path string) (*m.Authentication, error) {
+func (a *authenticationDaoVaultImpl) getKey(path string) (*m.Authentication, error) {
 	secret, err := Vault.Read(fmt.Sprintf("secret/data/%d/%s", *a.TenantID, path))
 	if err != nil || secret == nil {
 		return nil, fmt.Errorf("authentication not found")
@@ -541,7 +517,7 @@ func authFromVault(secret *api.Secret) *m.Authentication {
 	return auth
 }
 
-func (a *authenticationDaoImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
+func (a *authenticationDaoVaultImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
 	a.TenantID = &resource.TenantID
 	authentication, err := a.GetById(resource.ResourceUID)
 	if err != nil {
@@ -551,7 +527,7 @@ func (a *authenticationDaoImpl) BulkMessage(resource util.Resource) (map[string]
 	return BulkMessageFromSource(&authentication.Source, authentication)
 }
 
-func (a *authenticationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) (interface{}, error) {
+func (a *authenticationDaoVaultImpl) FetchAndUpdateBy(resource util.Resource, updateAttributes map[string]interface{}) (interface{}, error) {
 	authentication, err := a.GetById(resource.ResourceUID)
 	if err != nil {
 		return nil, err
@@ -576,7 +552,7 @@ func (a *authenticationDaoImpl) FetchAndUpdateBy(resource util.Resource, updateA
 	return authentication, nil
 }
 
-func (a *authenticationDaoImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
+func (a *authenticationDaoVaultImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
 	a.TenantID = &resource.TenantID
 	auth, err := a.GetById(resource.ResourceUID)
 	if err != nil {
@@ -594,7 +570,7 @@ func (a *authenticationDaoImpl) ToEventJSON(resource util.Resource) ([]byte, err
 	return data, nil
 }
 
-func (a *authenticationDaoImpl) AuthenticationsByResource(authentication *m.Authentication) ([]m.Authentication, error) {
+func (a *authenticationDaoVaultImpl) AuthenticationsByResource(authentication *m.Authentication) ([]m.Authentication, error) {
 	var err error
 	var resourceAuthentications []m.Authentication
 
@@ -616,7 +592,7 @@ func (a *authenticationDaoImpl) AuthenticationsByResource(authentication *m.Auth
 	return resourceAuthentications, nil
 }
 
-func (a *authenticationDaoImpl) ListIdsForResource(resourceType string, resourceIds []int64) ([]m.Authentication, error) {
+func (a *authenticationDaoVaultImpl) ListIdsForResource(resourceType string, resourceIds []int64) ([]m.Authentication, error) {
 	keys, err := a.listKeys()
 	if err != nil {
 		return nil, err
@@ -641,7 +617,7 @@ func (a *authenticationDaoImpl) ListIdsForResource(resourceType string, resource
 	return authentications, nil
 }
 
-func (a *authenticationDaoImpl) BulkDelete(authentications []m.Authentication) ([]m.Authentication, error) {
+func (a *authenticationDaoVaultImpl) BulkDelete(authentications []m.Authentication) ([]m.Authentication, error) {
 	var deletedAuthentications []m.Authentication
 	for _, auth := range authentications {
 		path := fmt.Sprintf("%s_%d_%s", auth.ResourceType, auth.ResourceID, auth.ID)
@@ -660,7 +636,7 @@ func (a *authenticationDaoImpl) BulkDelete(authentications []m.Authentication) (
 
 // findKeysByResourceTypeAndId returns the list of keys that matched the given resource type and resource ids. An error
 // is returned when the regexp used can't be compiled.
-func (a *authenticationDaoImpl) findKeysByResourceTypeAndId(keys []string, resourceType string, resourceIds []int64) ([]string, error) {
+func (a *authenticationDaoVaultImpl) findKeysByResourceTypeAndId(keys []string, resourceType string, resourceIds []int64) ([]string, error) {
 	var foundKeys []string
 
 	for _, id := range resourceIds {

--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -3,7 +3,6 @@ package dao
 import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
-	"github.com/hashicorp/vault/api"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
@@ -155,13 +154,6 @@ type SourceTypeDao interface {
 	Update(src *m.SourceType) error
 	Delete(id *int64) error
 	GetByName(name string) (*m.SourceType, error)
-}
-
-type VaultClient interface {
-	Read(path string) (*api.Secret, error)
-	List(path string) (*api.Secret, error)
-	Write(path string, data map[string]interface{}) (*api.Secret, error)
-	Delete(path string) (*api.Secret, error)
 }
 
 type RhcConnectionDao interface {

--- a/dao/vault/vault_client.go
+++ b/dao/vault/vault_client.go
@@ -1,0 +1,33 @@
+package vault
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/vault/api"
+)
+
+type VaultClient interface {
+	Read(path string) (*api.Secret, error)
+	List(path string) (*api.Secret, error)
+	Write(path string, data map[string]interface{}) (*api.Secret, error)
+	Delete(path string) (*api.Secret, error)
+}
+
+func NewClient() VaultClient {
+	// Open up the conn to Vault
+	cfg := api.DefaultConfig()
+	if cfg == nil {
+		panic("Failed to parse Vault Config")
+	}
+	err := cfg.ReadEnvironment()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to read Vault Environment: %v", err))
+	}
+
+	vaultClient, err := api.NewClient(cfg)
+	if err != nil {
+		panic(fmt.Sprintf("Failed to Create Vault Client: %v", err))
+	}
+
+	return vaultClient.Logical()
+}


### PR DESCRIPTION
Based on #607, so that one will need to go first. 

This PR does a few things:
1. Renames `authenticationDaoImpl` -> `authenticationDaoVaultImpl` since that is what it is
2. Moves `VaultClient` itnerface (and creation) to `dao/vault` since it is a separate package
3. Creates `dao/amazon` for the secrets manager client
4. Initial empty secrets manager authentication dao impl