### PR TITLE
[RHCLOUD-20975] Update openAPI schema for rhc_connection endpoints

### DIFF
--- a/public/openapi-3-v3.1.json
+++ b/public/openapi-3-v3.1.json
@@ -1134,10 +1134,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RhcConnectionRead"
-                  }
+                  "$ref": "#/components/schemas/RhcConnectionCollection"
                 }
               }
             }
@@ -1308,10 +1305,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/SourcesCollection"
-                  }
+                  "$ref": "#/components/schemas/SourcesCollection"
                 }
               }
             }
@@ -1356,10 +1350,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/RhcConnectionCollection"
-                  }
+                  "$ref": "#/components/schemas/RhcConnectionCollection"
                 }
               }
             }


### PR DESCRIPTION
Yet another openAPI spec udpate. RhcConnection endpoint schemas should use RhcConnectionCollection instead of array type so the client can deserialize the response