### PR TITLE
[RHCLOUD-22705] Only send Receptor based availability check if we don't have RHC Connnections

### DIFF
--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -68,12 +68,13 @@ func RequestAvailabilityCheck(c echo.Context, source *m.Source, headers []kafka.
 		ac.ApplicationAvailabilityCheck(source)
 	}
 
-	if len(source.Endpoints) != 0 {
-		ac.EndpointAvailabilityCheck(source)
-	}
-
+	// we only want to send endpoint requests if we _do not_ have any endpoints
+	// associated with this source. This way the satellite worker has no chance
+	// of overwriting the status set by the RHC check
 	if len(source.SourceRhcConnections) != 0 {
 		ac.RhcConnectionAvailabilityCheck(source, headers)
+	} else if len(source.Endpoints) != 0 {
+		ac.EndpointAvailabilityCheck(source)
 	}
 
 	ac.Logger().Infof("Finished Publishing Availability Messages for Source %v", source.ID)

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -294,8 +294,8 @@ func (acr availabilityCheckRequester) pingRHC(source *m.Source, rhcConnection *m
 		return
 	}
 
-	// only go through and update if there was a change.
-	if rhcConnection.AvailabilityStatus != sanitizedStatus {
+	// only go through and update if there was a change. to either the source or rhc connection
+	if rhcConnection.AvailabilityStatus != sanitizedStatus || source.AvailabilityStatus != sanitizedStatus {
 		acr.updateRhcStatus(source, sanitizedStatus, errstr, rhcConnection, headers)
 	}
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-22705

Running into an issue on prod where RHC connection based sources that _also_ have an endpoint aren't accurately getting checked - we're sending a request to the worker too which overwrites anything that comes back from RHC. 

So we get into a weird state:
- RHC Conn is available
- Source is unavailable
- on availability check, the rhc conn is available (the same status) so we don't update either the source or rhc conn availability status
- ...which would get overridden anyway by the satellite worker

This pr mitigates that by only sending a request to the receptor worker if and only if there isn't an RHC Connection attached to the source. I also check both RHC + the Source's availability status on update so hopefully they wouldn't get out of sync like this again. 
