### PR TITLE
[RHCLOUD-22788] Populate sources field on RHC conn during update so message contains source_ids

### DIFF
--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -328,7 +328,8 @@ func (acr availabilityCheckRequester) updateRhcStatus(source *m.Source, status s
 	}
 
 	l.Log.Debugf(`[source_id: %d][rhc_connection_id: %d] RHC Connection's status updated to "%s"`, source.ID, rhcConnection.ID, status)
-
+	// we have to populate the Sources field in order to pass along the source_ids on the message.
+	rhcConnection.Sources = []m.Source{*source}
 	err = RaiseEvent("RhcConnection.update", rhcConnection, headers)
 	if err != nil {
 		acr.Logger().Warnf("error raising RhcConnection.update event: %v", err)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-22788

It was found that on stage/prod there were messages going out on the event-stream when an `RhcConnection.update` message was going out where source_id's would be `[]`, which theoretically shouldn't be possible.

After digging through the code (and failing) to reproduce this on the POST/PATCH/DELETE endpoints - I was looking where we process availability check requests and found we weren't populating the array of sources - and thus when we called `RhcConnection#SourceIDs` it was returning `[]` rather than `[int64]`. 

---

This PR just adds a line to set that field to the current source - so we'll always have it set.

Notes: this was only on availability status update events, not on regular create/update/delete messages, so the sync process shouldn't have been effected by this. 