### PR TITLE
[RHCLOUD-22806] Fix RHC Connection results for last checked/updated at

### DIFF
--- a/dao/mappers/rhcConnection_row_mapper.go
+++ b/dao/mappers/rhcConnection_row_mapper.go
@@ -43,45 +43,26 @@ func MapRowToRhcConnection(row map[string]interface{}) (*model.RhcConnection, er
 	}
 
 	if value, ok := row["last_checked_at"]; ok {
-		if lastCheckedAtStr, ok := value.(string); ok {
-			lastCheckedAt, err := time.Parse(time.RFC3339, lastCheckedAtStr)
-			if err != nil {
-				return nil, err
-			}
-
-			rhcConnection.LastCheckedAt = &lastCheckedAt
+		if t, ok := value.(time.Time); ok {
+			rhcConnection.LastCheckedAt = &t
 		}
 	}
 
 	if value, ok := row["last_available_at"]; ok {
-		if lastAvailableAtStr, ok := value.(string); ok {
-			lastAvailableAt, err := time.Parse(time.RFC3339, lastAvailableAtStr)
-			if err != nil {
-				return nil, err
-			}
-
-			rhcConnection.LastAvailableAt = &lastAvailableAt
+		if t, ok := value.(time.Time); ok {
+			rhcConnection.LastAvailableAt = &t
 		}
 	}
 
 	if value, ok := row["created_at"]; ok {
-		if createdAtStr, ok := value.(string); ok {
-			createdAt, err := time.Parse(time.RFC3339, createdAtStr)
-			if err != nil {
-				return nil, err
-			}
-
-			rhcConnection.CreatedAt = createdAt
+		if t, ok := value.(time.Time); ok {
+			rhcConnection.CreatedAt = t
 		}
 	}
 
 	if value, ok := row["updated_at"]; ok {
-		if updatedAtStr, ok := value.(string); ok {
-			updatedAt, err := time.Parse(time.RFC3339, updatedAtStr)
-			if err != nil {
-				return nil, err
-			}
-			rhcConnection.UpdatedAt = updatedAt
+		if t, ok := value.(time.Time); ok {
+			rhcConnection.UpdatedAt = t
 		}
 	}
 

--- a/dao/mappers/rhcConnection_row_mapper_test.go
+++ b/dao/mappers/rhcConnection_row_mapper_test.go
@@ -12,16 +12,22 @@ import (
 // validNumberOfSourceIds stores the total amount of source ids that the list has.
 const validNumberOfSourceIds = 5
 
-const validId = int64(1)
-const validRhcId = "rhcIdUuid"
-const validExtra = `{"hello": "world"}`
-const validAvailabilityStatus = "available"
-const validAvailabilityStatusError = ""
-const validLastCheckedAt = "2000-01-01T00:00:00Z"
-const validLastAvailableAt = "2001-01-01T00:00:00Z"
-const validCreatedAt = "1998-01-01T00:00:00Z"
-const validUpdatedAt = "1999-01-01T00:00:00Z"
-const validSourceIdList = "1, 2, 3, 4, 5"
+const (
+	validId                      = int64(1)
+	validRhcId                   = "rhcIdUuid"
+	validExtra                   = `{"hello": "world"}`
+	validAvailabilityStatus      = "available"
+	validAvailabilityStatusError = ""
+	validSourceIdList            = "1, 2, 3, 4, 5"
+)
+
+var (
+	now                  = time.Now()
+	validLastCheckedAt   = now
+	validLastAvailableAt = now
+	validCreatedAt       = now
+	validUpdatedAt       = now
+)
 
 // setUpValidDatabaseRow sets up a valid database row the way the functions expect it.
 func setUpValidDatabaseRow() map[string]interface{} {
@@ -89,50 +95,30 @@ func TestMapRowToRhcConnection(t *testing.T) {
 	}
 
 	{
-		want, err := time.Parse(time.RFC3339, validLastCheckedAt)
-		if err != nil {
-			t.Errorf("error parsing time: %s", err)
-		}
-
 		got := *result.LastCheckedAt
-		if want != got {
-			t.Errorf(`Unexpected different last cheked at times found. Want "%s", got "%s"`, want, got)
+		if now != got {
+			t.Errorf(`Unexpected different last cheked at times found. Want "%s", got "%s"`, now, got)
 		}
 	}
 
 	{
-		want, err := time.Parse(time.RFC3339, validLastAvailableAt)
-		if err != nil {
-			t.Errorf("error parsing time: %s", err)
-		}
-
 		got := *result.LastAvailableAt
-		if want != got {
-			t.Errorf(`Unexpected different last available times found. Want "%s", got "%s"`, want, got)
+		if now != got {
+			t.Errorf(`Unexpected different last available times found. Want "%s", got "%s"`, now, got)
 		}
 	}
 
 	{
-		want, err := time.Parse(time.RFC3339, validCreatedAt)
-		if err != nil {
-			t.Errorf("error parsing time: %s", err)
-		}
-
 		got := result.CreatedAt
-		if want != got {
-			t.Errorf(`Unexpected different create times found. Want "%s", got "%s"`, want, got)
+		if now != got {
+			t.Errorf(`Unexpected different create times found. Want "%s", got "%s"`, now, got)
 		}
 	}
 
 	{
-		want, err := time.Parse(time.RFC3339, validUpdatedAt)
-		if err != nil {
-			t.Errorf("error parsing time: %s", err)
-		}
-
 		got := result.UpdatedAt
-		if want != got {
-			t.Errorf(`Unexpected different update times found. Want "%s", got "%s"`, want, got)
+		if now != got {
+			t.Errorf(`Unexpected different update times found. Want "%s", got "%s"`, now, got)
 		}
 	}
 }

--- a/dao/rhc_connection_dao.go
+++ b/dao/rhc_connection_dao.go
@@ -212,6 +212,7 @@ func (s *rhcConnectionDaoImpl) Update(rhcConnection *m.RhcConnection) error {
 		// We need to use the "Omit" clause since otherwise Gorm tries to create the associate source for the
 		// connection as well.
 		Omit(clause.Associations).
+		Select("*").
 		Updates(rhcConnection).
 		Error
 	return err

--- a/model/rhc_connection.go
+++ b/model/rhc_connection.go
@@ -55,6 +55,8 @@ func (r *RhcConnection) ToResponse() *RhcConnectionResponse {
 		Extra:                   r.Extra,
 		AvailabilityStatus:      r.AvailabilityStatus,
 		AvailabilityStatusError: r.AvailabilityStatusError,
+		LastCheckedAt:           r.LastCheckedAt,
+		LastAvailableAt:         r.LastAvailableAt,
 		SourceIds:               r.SourceIDs(),
 	}
 }

--- a/model/rhc_connection_http.go
+++ b/model/rhc_connection_http.go
@@ -24,8 +24,8 @@ type RhcConnectionResponse struct {
 	RhcId                   *string        `json:"rhc_id"`
 	Extra                   datatypes.JSON `json:"extra,omitempty"`
 	AvailabilityStatus      string         `json:"availability_status,omitempty"`
-	LastCheckedAt           time.Time      `json:"last_checked_at,omitempty"`
-	LastAvailableAt         time.Time      `json:"last_available_at,omitempty"`
+	LastCheckedAt           *time.Time     `json:"last_checked_at,omitempty"`
+	LastAvailableAt         *time.Time     `json:"last_available_at,omitempty"`
 	AvailabilityStatusError string         `json:"availability_status_error,omitempty"`
 	SourceIds               []string       `json:"source_ids,omitempty"`
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-22806

Just wanted to fix the API results for rhc conns - since its always the zero value even when there is a setting. Turns out there was just an issue in the mapper where it was thought strings were returned but it was actually `time.Time` structs. 

This also updates the `Update` function to `Select("*")` so we update everything to zero values when needed (e.g. availability_status_error = "").

Before:
```json
{
	"data": [
		{
			"id": "29",
			"rhc_id": "913f784f-74ac-4e08-a6e8-4e3f3b0f8f0b",
			"availability_status": "available",
			"last_checked_at": "0001-01-01T00:00:00Z",
			"last_available_at": "0001-01-01T00:00:00Z",
			"availability_status_error": "cloud-connector returned 'disconnected'",
			"source_ids": [
				"176518"
			]
		},
		{
			"id": "33",
			"rhc_id": "745d0294-133f-425b-ac90-b4f709e2235e",
			"availability_status": "available",
			"last_checked_at": "0001-01-01T00:00:00Z",
			"last_available_at": "0001-01-01T00:00:00Z",
			"availability_status_error": "cloud-connector returned 'disconnected'",
			"source_ids": [
				"207172"
			]
		},
		{
			"id": "35",
			"rhc_id": "5eb6a758-c603-4747-acca-f20d5f8583aa",
			"availability_status": "unavailable",
			"last_checked_at": "0001-01-01T00:00:00Z",
			"last_available_at": "0001-01-01T00:00:00Z",
			"availability_status_error": "cloud-connector returned 'disconnected'",
			"source_ids": [
				"270491"
			]
		}
	],
	"meta": {
		"count": 3,
		"limit": 100,
		"offset": 0
	},
	"links": {
		"first": "/api/sources/v3.1/rhc_connections?limit=100&offset=0",
		"last": "/api/sources/v3.1/rhc_connections?limit=100&offset=100"
	}
}
```

After:
```json
{
	"data": [
		{
			"id": "29",
			"rhc_id": "913f784f-74ac-4e08-a6e8-4e3f3b0f8f0b",
			"availability_status": "available",
			"last_checked_at": "2022-07-05T17:45:07.87932Z",
			"availability_status_error": "cloud-connector returned 'disconnected'",
			"source_ids": [
				"176518"
			]
		},
		{
			"id": "33",
			"rhc_id": "745d0294-133f-425b-ac90-b4f709e2235e",
			"availability_status": "available",
			"last_checked_at": "2022-10-08T23:45:04.294972Z",
			"last_available_at": "2022-10-08T23:45:04.294972Z",
			"availability_status_error": "cloud-connector returned 'disconnected'",
			"source_ids": [
				"207172"
			]
		},
		{
			"id": "35",
			"rhc_id": "5eb6a758-c603-4747-acca-f20d5f8583aa",
			"availability_status": "unavailable",
			"last_checked_at": "2022-11-02T11:59:03.934318Z",
			"last_available_at": "2022-11-02T11:59:03.934318Z",
			"availability_status_error": "yeet",
			"source_ids": [
				"270491"
			]
		}
	],
	"meta": {
		"count": 3,
		"limit": 100,
		"offset": 0
	},
	"links": {
		"first": "/api/sources/v3.1/rhc_connections?limit=100&offset=0",
		"last": "/api/sources/v3.1/rhc_connections?limit=100&offset=100"
	}
}
```