### PR TITLE
Capitalize util function panics on empty string

### DIFF
--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -3,7 +3,7 @@ package util
 import "strings"
 
 func Capitalize(str string) string {
-	return strings.ToUpper(string(str[0])) + str[1:]
+	return strings.Title(strings.ToLower(str))
 }
 
 func StringRef(str string) *string {

--- a/util/string_utils_test.go
+++ b/util/string_utils_test.go
@@ -10,3 +10,21 @@ func TestCapitalize(t *testing.T) {
 		t.Errorf("Capitalize not working correctly - got %v instead of %v", capped, "Thing")
 	}
 }
+
+func TestAllCapsCapitalize(t *testing.T) {
+	str := "THING"
+	capped := Capitalize(str)
+
+	if capped != "Thing" {
+		t.Errorf("Capitalize not working correctly - got %v instead of %v", capped, "Thing")
+	}
+}
+
+func TestEmptyCapitalize(t *testing.T) {
+	str := ""
+	capped := Capitalize(str)
+
+	if capped != "" {
+		t.Errorf("Capitalize not working correctly - got %v instead of %v", capped, "")
+	}
+}


### PR DESCRIPTION
Receiving a message with source availability check response with empty resource_type payload leads to:

```
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 51 [running]:
testing.tRunner.func1.2({0x961820, 0xc0000241b0})
	/home/lzap/sdk/go1.18/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/home/lzap/sdk/go1.18/src/testing/testing.go:1392 +0x39f
panic({0x961820, 0xc0000241b0})
	/home/lzap/sdk/go1.18/src/runtime/panic.go:838 +0x207
github.com/RedHatInsights/sources-api-go/util.Capitalize(...)
	/home/lzap/work/sources-api-go/util/string_utils.go:6
github.com/RedHatInsights/sources-api-go/util.TestEmptyCapitalize(0xc000236000?)
	/home/lzap/work/sources-api-go/util/string_utils_test.go:16 +0x18
testing.tRunner(0xc000236340, 0x9d4e98)
	/home/lzap/sdk/go1.18/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/home/lzap/sdk/go1.18/src/testing/testing.go:1486 +0x35f
FAIL	github.com/RedHatInsights/sources-api-go/util	0.028s
ok  	github.com/RedHatInsights/sources-api-go/util/echo	0.013s
FAIL
```

This patch fixes it and adds a test.