### PR TITLE
Pass through x-rh-id when sending an http availability check request

### DIFF
--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -114,9 +114,16 @@ func (acr availabilityCheckRequester) httpAvailabilityRequest(source *m.Source, 
 		return
 	}
 
+	// yoink the xrhid from the parent request
+	xrhid, ok := acr.c.Get(h.XRHID).(string)
+	if !ok {
+		acr.Logger().Warnf("couldn't pull xrhid from request")
+		return
+	}
+
+	req.Header.Add(h.XRHID, xrhid)
 	req.Header.Add(h.OrgID, source.Tenant.OrgID)
 	req.Header.Add(h.AccountNumber, source.Tenant.ExternalTenant)
-	req.Header.Add(h.XRHID, util.GeneratedXRhIdentity(source.Tenant.ExternalTenant, source.Tenant.OrgID))
 	req.Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/util/identity_header.go
+++ b/util/identity_header.go
@@ -9,9 +9,13 @@ import (
 
 // GeneratedXRhIdentity returns a base64 encoded header to use as x-rh-identity when one is not provided
 func GeneratedXRhIdentity(account, orgId string) string {
-	id := identity.XRHID{Identity: identity.Identity{
-		AccountNumber: account,
-		OrgID:         orgId},
+	id := identity.XRHID{
+		Identity: identity.Identity{
+			AccountNumber: account,
+			OrgID:         orgId,
+			// setting the type to system since this was most likely an internal-to-cluster request
+			Type: "System",
+		},
 	}
 	bytes, err := json.Marshal(id)
 	if err != nil {


### PR DESCRIPTION
Per: https://redhat-internal.slack.com/archives/C0246P60U8H/p1673944289746899

Seems we should include the `Type` field since platform-go-middleware actively checks against it. I set it to `System` since this codepath only gets ran if its a PSK request (e.g. in-cluster)

I also changed the availability check operation to pass through the xrhid rather than generating one, since that seems to be "the right way" to do it. 
