### PR TITLE
Remove endpoint object from azure and google section

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -125,14 +125,6 @@ google:
         - component: text-field
           name: authentication.username
           label: Project ID
-    endpoint:
-      hidden: true
-      fields:
-      - component: text-field
-        name: endpoint.role
-        hideField: true
-        initializeOnMount: true
-        initialValue: google
 azure:
   product_name: Microsoft Azure
   category: Cloud
@@ -198,14 +190,6 @@ azure:
         name: authentication.password
         label: Client Secret
         type: password
-    endpoint:
-      hidden: true
-      fields:
-      - component: text-field
-        name: endpoint.role
-        hideField: true
-        initializeOnMount: true
-        initialValue: azure
 bitbucket:
   product_name: Bitbucket
   category: Developer sources


### PR DESCRIPTION
Remove the sections of endpoint, so Provisioning Source is created as application not an Endpoint.

I've replicated what we've done in #526 as we are facing the same issue for Azure (Source creating Endpoint resource instead of App resource).