### PR TITLE
Rename Provisioning public facing name

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -65,7 +65,7 @@
     satellite:
     - receptor_node
 "/insights/platform/provisioning":
-  display_name: Provisioning
+  display_name: Launch images
   dependent_applications: []
   supported_source_types:
     - amazon


### PR DESCRIPTION
Provisioning is called Launch for now.