### PR TITLE
recognize X-Rh-Edge-Request-Id

### DIFF
--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -43,6 +43,10 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 			c.Set(h.PSKUserID, c.Request().Header.Get(h.PSKUserID))
 		}
 
+		if c.Request().Header.Get(h.EdgeRequestID) != "" {
+			c.Set(h.EdgeRequestID, c.Request().Header.Get(h.EdgeRequestID))
+		}
+
 		if c.Request().Header.Get(h.InsightsRequestID) != "" {
 			c.Set(h.InsightsRequestID, c.Request().Header.Get(h.InsightsRequestID))
 		}

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -7,6 +7,7 @@ const (
 	PSKUserID         = "x-rh-sources-user-id"
 	XRHID             = "x-rh-identity"
 	InsightsRequestID = "x-rh-insights-request-id"
+	EdgeRequestID     = "x-rh-edge-request-id"
 	ParsedIdentity    = "identity"
 	TenantID          = "tenantID"
 	UserID            = "userID"

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -17,6 +17,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 		acct := c.Get(h.AccountNumber)
 		orgid := c.Get(h.OrgID)
 		uuid := c.Get(h.InsightsRequestID)
+		edgeId := c.Get(h.EdgeRequestID)
 
 		baseFields := logrus.Fields{
 			"uri":            uri,
@@ -25,6 +26,7 @@ func LoggerFields(next echo.HandlerFunc) echo.HandlerFunc {
 			"org_id":         orgid,
 			"user_agent":     agent,
 			"request_id":     uuid,
+			"edge_id":        edgeId,
 		}
 
 		baseLoggerEntry := l.Log.WithFields(baseFields)


### PR DESCRIPTION
Sources currently recognizes `X-Rh-Insights-Request-Id`, however, there is also `X-Rh-Edge-Request-Id` which was recently recommended to us as the primary correlation id. This patch makes this HTTP header recognized and then stores it in the Echo context under the InsightsRequestID constant.

Reason: We proxy this header when calling sources so we can correlate log entries in ELK with our logs for each Insights Platform HTTP request.