### PR TITLE
Tweaking GCP fields for filtered data support

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -116,11 +116,11 @@ google:
         stepKey: cost-management
         label: Cloud storage bucket name
         validate:
-          - type: required
-          - type: pattern
-            pattern: "^[a-z0-9_.-]+$"
-          - type: min-length
-              threshold: 3
+        - type: required
+        - type: pattern
+          pattern: "^[a-z0-9_.-]+$"
+        - type: min-length
+          threshold: 3
     - type: provisioning_project_id
       name: Provisioning — project ID
       fields:

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -111,9 +111,16 @@ google:
         name: application.extra.dataset
         stepKey: cost-management
         label: Dataset name
-        isRequired: true
+      - component: text-field
+        name: application.extra.bucket
+        stepKey: cost-management
+        label: Cloud storage bucket name
         validate:
-        - type: required
+          - type: required
+          - type: pattern
+            pattern: "^[a-z0-9_.-]+$"
+          - type: min-length
+              threshold: 3
     - type: provisioning_project_id
       name: Provisioning — project ID
       fields:


### PR DESCRIPTION
This pr kinda follows suit from this https://github.com/RedHatInsights/sources-api-go/pull/641

With the new GCP filtered customer data flow we need to swap between requiring a dataset to a storage bucket. This change hopefully changes dataset to optional and also adds the optional bucket field for when it comes to editing a source.