### PR TITLE
Cost Management - Add `bucket_region` for AWS sources

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -37,6 +37,12 @@ amazon:
         - type: required
         - type: pattern
           pattern: "^[A-Za-z0-9]+[A-Za-z0-9_-]*$"
+      - component: text-field
+        name: application.extra.bucket_region
+        label: S3 bucket region
+        validate:
+        - type: pattern
+          pattern: "^[a-z]+[a-z0-9-]*$"
       - name: authentication.username
         stepKey: arn
         component: text-field


### PR DESCRIPTION
A new optional field specifying the bucket region is available for AWS sources in Cost Management. This field needs to be available during creation and editing of AWS sources.