### PR TITLE
Pass through requestParams to RHC DAO and omit all associations when updating various models

### DIFF
--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -171,7 +171,7 @@ func (a *applicationDaoImpl) Create(app *m.Application) error {
 }
 
 func (a *applicationDaoImpl) Update(app *m.Application) error {
-	result := a.getDb().Updates(app)
+	result := a.getDb().Omit(clause.Associations).Updates(app)
 	return result.Error
 }
 

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -8,6 +8,7 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type authenticationDaoDbImpl struct {
@@ -316,6 +317,7 @@ func (add *authenticationDaoDbImpl) BulkCreate(auth *m.Authentication) error {
 
 func (add *authenticationDaoDbImpl) Update(authentication *m.Authentication) error {
 	return add.getDb().
+		Omit(clause.Associations).
 		Updates(authentication).
 		Error
 }

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -120,7 +120,7 @@ func (a *endpointDaoImpl) Create(app *m.Endpoint) error {
 }
 
 func (a *endpointDaoImpl) Update(app *m.Endpoint) error {
-	result := DB.Updates(app)
+	result := DB.Omit(clause.Associations).Updates(app)
 	return result.Error
 }
 

--- a/dao/rhc_connection_dao_test.go
+++ b/dao/rhc_connection_dao_test.go
@@ -419,7 +419,7 @@ func TestDeleteRhcConnectionNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
 
-	RhcConnectionDao := GetRhcConnectionDao(&fixtures.TestSourceData[0].TenantID)
+	RhcConnectionDao := GetRhcConnectionDao(&RequestParams{TenantID: &fixtures.TestSourceData[0].TenantID})
 
 	nonExistentId := int64(12345)
 	_, err := RhcConnectionDao.Delete(&nonExistentId)

--- a/dao/secret_db_dao.go
+++ b/dao/secret_db_dao.go
@@ -6,6 +6,7 @@ import (
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type secretDaoDbImpl struct {
@@ -119,6 +120,7 @@ func (secret *secretDaoDbImpl) List(limit, offset int, filters []util.Filter) ([
 
 func (secret *secretDaoDbImpl) Update(authentication *m.Authentication) error {
 	return secret.getDb().
+		Omit(clause.Associations).
 		Updates(authentication).
 		Error
 }

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -192,7 +192,7 @@ func (s *sourceDaoImpl) Create(src *m.Source) error {
 }
 
 func (s *sourceDaoImpl) Update(src *m.Source) error {
-	result := s.getDb().Updates(src)
+	result := s.getDb().Omit(clause.Associations).Updates(src)
 	return result.Error
 }
 

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -416,7 +416,7 @@ func TestDeleteCascade(t *testing.T) {
 	applicationsDao := GetApplicationDao(&daoParams)
 	authenticationDao := GetAuthenticationDao(&daoParams)
 	endpointDao := GetEndpointDao(&fixtures.TestTenantData[0].Id)
-	rhcConnectionsDao := GetRhcConnectionDao(&fixtures.TestTenantData[0].Id)
+	rhcConnectionsDao := GetRhcConnectionDao(&daoParams)
 
 	// Create all the subresources.
 	// Create the related application.
@@ -1102,7 +1102,7 @@ func TestSourceSubcollectionWithUserOwnership(t *testing.T) {
 			t.Errorf("Expected source IDs %v are not same with obtained IDs: %v", suiteData.SourceIDsUserA(), subCollectionSourcesIDs)
 		}
 
-		rhcDAO := GetRhcConnectionDao(suiteData.TenantID())
+		rhcDAO := GetRhcConnectionDao(requestParams)
 		rhcSourceUserA, errRhc := rhcDAO.Create(&m.RhcConnection{Sources: suiteData.resourcesUserA.Sources})
 		if errRhc != nil {
 			t.Errorf(`unexpected error after calling Create for rhc connection: %v`, errRhc)

--- a/rhc_connection_handlers.go
+++ b/rhc_connection_handlers.go
@@ -9,20 +9,18 @@ import (
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"
-	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
 
 var getRhcConnectionDao func(c echo.Context) (dao.RhcConnectionDao, error)
 
 func getDefaultRhcConnectionDao(c echo.Context) (dao.RhcConnectionDao, error) {
-	tenantId, err := echoUtils.GetTenantFromEchoContext(c)
-
+	requestParams, err := dao.NewRequestParamsFromContext(c)
 	if err != nil {
 		return nil, err
 	}
 
-	return dao.GetRhcConnectionDao(&tenantId), nil
+	return dao.GetRhcConnectionDao(requestParams), nil
 }
 
 func RhcConnectionList(c echo.Context) error {

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -321,13 +321,19 @@ func (acr availabilityCheckRequester) updateRhcStatus(source *m.Source, status s
 		rhcConnection.AvailabilityStatusError = errstr
 	}
 
-	err := dao.GetSourceDao(&dao.RequestParams{TenantID: &source.TenantID}).Update(source)
+	requestParams, err := dao.NewRequestParamsFromContext(acr.c)
+	if err != nil {
+		acr.Logger().Warnf("failed to fetch request params from context: %v", err)
+		return
+	}
+
+	err = dao.GetSourceDao(requestParams).Update(source)
 	if err != nil {
 		acr.Logger().Warnf("failed to update source availability status: %v", err)
 		return
 	}
 
-	err = dao.GetRhcConnectionDao(&source.TenantID).Update(rhcConnection)
+	err = dao.GetRhcConnectionDao(requestParams).Update(rhcConnection)
 	if err != nil {
 		acr.Logger().Warnf("failed to update RHC Connection availability status: %v", err)
 		return

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1538,7 +1538,7 @@ func TestSourceDelete(t *testing.T) {
 	auths = append(auths, auth)
 
 	// Create a rhc connection
-	rhcConnectionDao := dao.GetRhcConnectionDao(&tenantID)
+	rhcConnectionDao := dao.GetRhcConnectionDao(&requestParams)
 
 	rhc := &m.RhcConnection{
 		RhcId:   "123e4567-e89b-12d3-a456-426614174000",


### PR DESCRIPTION
Pods are getting oomkilled on prod seemingly randomly - but it's always during an availability check. 

I'm wondering if it's something weird with GORM's association handling in the RHC availability check code - but need more logging to see which source it is exactly (I can see which tenant, but there are hundreds of sources underneath it).