### PR TITLE
Prevent a 500 when passed a 'bad' filter

### DIFF
--- a/middleware/filtering.go
+++ b/middleware/filtering.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -11,7 +12,11 @@ var BadQueryParams = []string{"limit", "offset", "sort_by"}
 
 func SortAndFilter(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		filters := parseFilter(c)
+		filters, err := parseFilter(c)
+		if err != nil {
+			return util.NewErrBadRequest(err)
+		}
+
 		if sort := parseSorting(c); sort != nil {
 			filters = append(filters, *sort)
 		}
@@ -21,12 +26,15 @@ func SortAndFilter(next echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
-func parseFilter(c echo.Context) []util.Filter {
+func parseFilter(c echo.Context) ([]util.Filter, error) {
 	f := make([]util.Filter, 0)
 	for key, values := range c.QueryParams() {
 		if strings.HasPrefix(key, "filter") {
 			matches := util.FilterRegex.FindAllStringSubmatch(key, -1)
 			filter := util.Filter{}
+			if len(matches) < 2 {
+				return nil, fmt.Errorf("filter")
+			}
 
 			// matching filter[subresource][field][operation]
 			// we only support filtering on source type/application type
@@ -66,7 +74,7 @@ func parseFilter(c echo.Context) []util.Filter {
 		}
 	}
 
-	return f
+	return f, nil
 }
 
 func parseSorting(c echo.Context) *util.Filter {

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -16,7 +16,7 @@ func TestParseFilterWithOperation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[name][eq]=test", nil)
 	c := e.NewContext(req, nil)
 
-	filters := parseFilter(c)
+	filters, _ := parseFilter(c)
 
 	if len(filters) != 1 {
 		t.Error("wrong number of filters")
@@ -41,7 +41,7 @@ func TestParseFilterWithoutOperation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[name]=test", nil)
 	c := e.NewContext(req, nil)
 
-	filters := parseFilter(c)
+	filters, _ := parseFilter(c)
 
 	if len(filters) != 1 {
 		t.Error("wrong number of filters")
@@ -112,7 +112,7 @@ func TestParseSubresourceFilterWithOperation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[source_type][name][eq]=test", nil)
 	c := e.NewContext(req, nil)
 
-	filters := parseFilter(c)
+	filters, _ := parseFilter(c)
 
 	if len(filters) != 1 {
 		t.Error("wrong number of filters")
@@ -141,7 +141,7 @@ func TestParseSubresourceFilterWithoutOperation(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[source_type][name]=test", nil)
 	c := e.NewContext(req, nil)
 
-	filters := parseFilter(c)
+	filters, _ := parseFilter(c)
 
 	if len(filters) != 1 {
 		t.Error("wrong number of filters")
@@ -170,7 +170,7 @@ func TestParseFilteringWithoutFilterArg(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?name=test", nil)
 	c := e.NewContext(req, nil)
 
-	filters := parseFilter(c)
+	filters, _ := parseFilter(c)
 	f := filters[0]
 
 	if f.Name != "name" {
@@ -186,7 +186,7 @@ func TestParseFilteringWithoutFilterArgWithLimit(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?name=test&limit=100", nil)
 	c := e.NewContext(req, nil)
 
-	filters := parseFilter(c)
+	filters, _ := parseFilter(c)
 	f := filters[0]
 
 	if f.Name != "name" {
@@ -199,5 +199,20 @@ func TestParseFilteringWithoutFilterArgWithLimit(t *testing.T) {
 
 	if len(filters) != 1 {
 		t.Errorf("too many filters were parsed - should have been one")
+	}
+}
+
+func TestParseFilteringBadFilter(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter=filter[name][eq]=test", nil)
+	c := e.NewContext(req, nil)
+
+	filters, err := parseFilter(c)
+
+	if err == nil {
+		t.Error("got no error when there should have been one")
+	}
+
+	if len(filters) != 0 {
+		t.Error("got a filter when there should not have been one")
 	}
 }


### PR DESCRIPTION
https://redhat-internal.slack.com/archives/C0246P60U8H/p1679677836774999

Found here. Probably needed to do this a while ago but this is a great excuse for it!