### PR TITLE
Wait for RHC Connection availability checks to complete before canceling context

### DIFF
--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -211,7 +211,7 @@ type rhcConnectionStatusResponse struct {
 // status for each RHC id is connected or disconnected
 func (acr availabilityCheckRequester) RhcConnectionAvailabilityCheck(source *m.Source, headers []kafka.Header) {
 	for i := range source.SourceRhcConnections {
-		go acr.pingRHC(source, &source.SourceRhcConnections[i].RhcConnection, headers)
+		acr.pingRHC(source, &source.SourceRhcConnections[i].RhcConnection, headers)
 	}
 }
 

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -343,7 +343,7 @@ func SourceCheckAvailability(c echo.Context) error {
 	var ctx context.Context
 	var cancel context.CancelFunc
 	ctx = context.WithValue(context.Background(), logger.EchoLogger{}, c.Get("logger"))
-	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 20*time.Second)
 	c.Set("override_context", ctx)
 
 	sourceDao, err := getSourceDao(c)


### PR DESCRIPTION
found by this beautiful message: https://kibana.apps.crcs02ue1.urby.p1.openshiftapps.com/app/kibana#/discover/doc/c863ed00-1859-11eb-aa0b-65271eaaec07/cwl-sources-stage-2023.04.24?id=37517679887939716683936446146127543388836283873578319891

basically just making it run inline like the rest of the checks. not sure why i made it async, but oh well. 