### PR TITLE
[RHCLOUD-18027] ci/qa leftovers removal from seeding files

### DIFF
--- a/dao/seeding.go
+++ b/dao/seeding.go
@@ -292,11 +292,11 @@ func seedAppMetadata(appTypes map[string]*m.ApplicationType) error {
 		return err
 	}
 
-	// defaulting to "ci" if no var is set.
+	// defaulting to "eph" if no var is set.
 	env, ok := os.LookupEnv("SOURCES_ENV")
 	if !ok {
-		l.Log.Infof("Defaulting SOURCES_ENV to ci")
-		env = "ci"
+		l.Log.Infof("Defaulting SOURCES_ENV to stage")
+		env = "eph"
 	}
 
 	for name, values := range seeds[env] {

--- a/dao/seeding_test.go
+++ b/dao/seeding_test.go
@@ -149,13 +149,15 @@ func TestSeedingApplicationMetadata(t *testing.T) {
 	appmdata := make([]m.MetaData, 0)
 	result := DB.Model(&m.MetaData{}).
 		Where("type = ?", m.AppMetaData).
-		Distinct("name").
 		Scan(&appmdata)
 	if result.Error != nil {
 		t.Fatalf("failed to list appmetadata: %v", result.Error)
 	}
 
-	count := len(seeds["ci"])
+	count := 0
+	for _, v := range seeds["eph"] {
+		count += len(v)
+	}
 
 	if len(appmdata) != count {
 		t.Errorf("Seeding did not match values, got %v expected %v", len(appmdata), count)

--- a/dao/seeds/app_metadata.yml
+++ b/dao/seeds/app_metadata.yml
@@ -5,18 +5,6 @@
 # string is valid json. So plain key/value works fine.
 #####
 
-ci:
-  "/insights/platform/cost-management":
-    gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com
-    aws_wizard_account_number: "589173575009"
-  "/insights/platform/cloud-meter":
-    aws_wizard_account_number: "372779871274"
-qa:
-  "/insights/platform/cost-management":
-    gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com
-    aws_wizard_account_number: "589173575009"
-  "/insights/platform/cloud-meter":
-    aws_wizard_account_number: "372779871274"
 eph:
   "/insights/platform/cost-management":
     gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com


### PR DESCRIPTION
[RHCLOUD-18027](https://issues.redhat.com/browse/RHCLOUD-18027) Remove CI and QA configurations for infra services

I had to update the `TestSeedingApplicationMetadata` to compare all metadata from `dao/seeds/app_metadata.yml` for `stage` (=7) and compare it from not unique records from DB (=7) because before we compared count of keys like `"/insights/platform/cost-management"` in `ci` env (=2) with count of unique metadata keys like `gcp_service_account` (=2) and that was accidentally 2 in both cases