### PR TITLE
Add provisioning ephemeral service account

### DIFF
--- a/dao/seeds/app_metadata.yml
+++ b/dao/seeds/app_metadata.yml
@@ -11,12 +11,16 @@ ci:
     aws_wizard_account_number: "589173575009"
   "/insights/platform/cloud-meter":
     aws_wizard_account_number: "372779871274"
+  "/insights/platform/provisioning":
+    aws_wizard_account_number: "399777895069"
 qa:
   "/insights/platform/cost-management":
     gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com
     aws_wizard_account_number: "589173575009"
   "/insights/platform/cloud-meter":
     aws_wizard_account_number: "372779871274"
+  "/insights/platform/provisioning":
+    aws_wizard_account_number: "399777895069"
 stage:
   "/insights/platform/cost-management":
     gcp_service_account: billing-export@red-hat-cost-management-stage.iam.gserviceaccount.com


### PR DESCRIPTION
For ephemeral environments, Provisioning uses a different service account then stage, so we need to add it to seeds and make qa or ci environment set in ephemeral.