### PR TITLE
[RHCLOUD-26237] Sources needs to add RHEL metering to AWS Cost Management Source

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -58,6 +58,11 @@ amazon:
           pattern: "^arnaws:.*"
         - type: min-length
           threshold: 10
+      - component: text-field
+        name: application.extra.metered
+        label: Metered Product
+        isRequired: false
+        hideField: true
     - type: cloud-meter-arn
       name: Subscription Watch ARN
       fields:


### PR DESCRIPTION
* Adding backend source_types update for the application.extra.metered value

Related: https://issues.redhat.com/browse/RHCLOUD-26237