### PR TITLE
[RHCLOUD-29389] removed kafka topic for satellite operations

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -289,9 +289,6 @@ objects:
     - topicName: platform.sources.superkey-requests
       partitions: 3
       replicas: 3
-    - topicName: platform.topological-inventory.operations-satellite
-      partitions: 3
-      replicas: 3
     - topicName: platform.notifications.ingress
       partitions: 3
       replicas: 3


### PR DESCRIPTION
the sources-satellite removed from app-interface here: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/87993 and now we need to remove related kafka topic