### PR TITLE
[RHCLOUD-28264] Sources needs to add RHEL metering to Azure Cost Management Source

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -226,6 +226,17 @@ azure:
         name: authentication.password
         label: Client Secret
         type: password
+      - component: select
+        name: application.extra.metered
+        label: Metered Product
+        simpleValue: true
+        options: 
+          - label: None
+            value: ""
+          - label: Red Hat Enterprise Linux
+            value: rhel
+        isRequired: false
+        hideField: false
 bitbucket:
   product_name: Bitbucket
   category: Developer sources


### PR DESCRIPTION
- Adding backend azure source_types update for the application.extra.metered value
Related: https://issues.redhat.com/browse/RHCLOUD-28264