### PR TITLE
Handle tenant-refresh flow on the users table

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,7 @@ type SourcesApiConfig struct {
 	SecretStore             string
 	TenantTranslatorUrl     string
 	Env                     string
+	HandleTenantRefresh     bool
 
 	SecretsManagerAccessKey string
 	SecretsManagerSecretKey string
@@ -97,6 +98,7 @@ func (s SourcesApiConfig) String() string {
 	fmt.Fprintf(&b, "%s=%v ", "SecretStore", parsedConfig.SecretStore)
 	fmt.Fprintf(&b, "%s=%v ", "TenantTranslatorUrl", parsedConfig.TenantTranslatorUrl)
 	fmt.Fprintf(&b, "%s=%v ", "Env", parsedConfig.Env)
+	fmt.Fprintf(&b, "%s=%v ", "HandleTenantRefresh", parsedConfig.HandleTenantRefresh)
 	fmt.Fprintf(&b, "%s=%v ", "SecretsManagerPrefix", parsedConfig.SecretsManagerPrefix)
 	fmt.Fprintf(&b, "%s=%v ", "LocalStackURL", parsedConfig.LocalStackURL)
 	return b.String()
@@ -217,6 +219,9 @@ func Get() *SourcesApiConfig {
 
 	options.SetDefault("Env", os.Getenv("SOURCES_ENV"))
 
+	handleTenantRefresh, _ := strconv.ParseBool(os.Getenv("HANDLE_TENANT_REFRESH"))
+	options.SetDefault("HandleTenantRefresh", handleTenantRefresh)
+
 	options.SetDefault("FeatureFlagsService", os.Getenv("FEATURE_FLAGS_SERVICE"))
 
 	if os.Getenv("SOURCES_ENV") == "prod" {
@@ -327,6 +332,7 @@ func Get() *SourcesApiConfig {
 		SecretStore:             options.GetString("SecretStore"),
 		TenantTranslatorUrl:     options.GetString("TenantTranslatorUrl"),
 		Env:                     options.GetString("Env"),
+		HandleTenantRefresh:     options.GetBool("HandleTenantRefresh"),
 		SecretsManagerAccessKey: options.GetString("SecretsManagerAccessKey"),
 		SecretsManagerSecretKey: options.GetString("SecretsManagerSecretKey"),
 		SecretsManagerPrefix:    options.GetString("SecretsManagerPrefix"),

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -261,6 +261,8 @@ objects:
               name: sources-secrets-manager
               key: localstack_url
               optional: true
+        - name: HANDLE_TENANT_REFRESH
+          value: ${HANDLE_TENANT_REFRESH}
         readinessProbe:
           tcpSocket:
             port: 8000
@@ -451,3 +453,6 @@ parameters:
 - description: Which secret-store should sources use for authentications
   name: SECRET_STORE
   value: "database"
+- description: Whether to handle conflicts on user_ids during a tenant refresh
+  name: HANDLE_TENANT_REFRESH
+  value: "false"


### PR DESCRIPTION
Problem: when tenant-refresh occurs in stage we have to go through and manually update the database for all users that had their org_ids changed.

Solution: we just tack on an `on conflict update` on the create statement which updates the tenant_id to the new one. We'll probably end up with some orphan tenants this way but that is kind of expected since the refresh = everyone got a new identity anyway. As a followup we could probably now look for tenants that don't have users associated with them anymore and clean those records up. 