### PR TITLE
Remove bearer from unleash auth

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -168,7 +168,7 @@ func Get() *SourcesApiConfig {
 			if cfg.FeatureFlags.ClientAccessToken != nil {
 				clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
 			}
-                        options.SetDefault("FeatureFlagsAPIToken", clientAccessToken)
+			options.SetDefault("FeatureFlagsAPIToken", clientAccessToken)
 		}
 
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,6 @@ type SourcesApiConfig struct {
 	FeatureFlagsUrl         string
 	FeatureFlagsAPIToken    string
 	FeatureFlagsService     string
-	FeatureFlagsBearerToken string
 	CacheHost               string
 	CachePort               int
 	CachePassword           string
@@ -169,7 +168,7 @@ func Get() *SourcesApiConfig {
 			if cfg.FeatureFlags.ClientAccessToken != nil {
 				clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
 			}
-			options.SetDefault("FeatureFlagsBearerToken", clientAccessToken)
+                        options.SetDefault("FeatureFlagsAPIToken", clientAccessToken)
 		}
 
 	} else {
@@ -318,7 +317,6 @@ func Get() *SourcesApiConfig {
 		FeatureFlagsEnvironment: options.GetString("FeatureFlagsEnvironment"),
 		FeatureFlagsUrl:         options.GetString("FeatureFlagsUrl"),
 		FeatureFlagsAPIToken:    options.GetString("FeatureFlagsAPIToken"),
-		FeatureFlagsBearerToken: options.GetString("FeatureFlagsBearerToken"),
 		FeatureFlagsService:     options.GetString("FeatureFlagsService"),
 		CacheHost:               options.GetString("CacheHost"),
 		CachePort:               options.GetInt("CachePort"),

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/99designs/gqlgen v0.17.2
 	github.com/RedHatInsights/rbac-client-go v1.0.0
 	github.com/RedHatInsights/tenant-utils v0.0.0-20220322192943-150a1a665a5f
-	github.com/Unleash/unleash-client-go/v3 v3.3.1
+	github.com/Unleash/unleash-client-go/v4 v4.1.0
 	github.com/alicebob/miniredis/v2 v2.17.0
 	github.com/aws/aws-sdk-go v1.42.22
 	github.com/aws/aws-sdk-go-v2 v1.17.1
@@ -50,9 +50,13 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.1 // indirect
 	github.com/aws/smithy-go v1.13.4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/sarama v1.30.0/go.mod h1:zujlQQx1kzHsh4jfV1USnptCQrHAEZ2Hk8fTKCulPVs=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/Shopify/toxiproxy/v2 v2.1.6-0.20210914104332-15ea381dcdae/go.mod h1:/cvHQkZ1fst0EmZnA5dFtiQdWCNCFYzb+uE2vqVgvx0=
-github.com/Unleash/unleash-client-go/v3 v3.3.1 h1:Kf22zUOvSTueKjg6RHQ6IAY3/OaYc5vsDizeR9SpcMs=
-github.com/Unleash/unleash-client-go/v3 v3.3.1/go.mod h1:jAf7F2WWpfJbfn1n8bZ74p7hkAhijrqH4TpWoT7kWLc=
+github.com/Unleash/unleash-client-go/v4 v4.1.0 h1:+9ZMa4sb176nlPfZyWYlWHeY8bA3odhGdZa2V063nZA=
+github.com/Unleash/unleash-client-go/v4 v4.1.0/go.mod h1:jzGQjqMwJm2y+vaVLzq3IzZPvh5SRWco0MNIw2KK03I=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=

--- a/service/feature_flags.go
+++ b/service/feature_flags.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -60,11 +59,7 @@ func init() {
 		}
 
 		authorizationHeader := ""
-		if conf.FeatureFlagsBearerToken != "" {
-			authorizationHeader = fmt.Sprintf("Bearer %s", conf.FeatureFlagsBearerToken)
-		} else {
-			authorizationHeader = conf.FeatureFlagsAPIToken
-		}
+		authorizationHeader = conf.FeatureFlagsAPIToken
 
 		unleashConfig := []unleash.ConfigOption{unleash.WithAppName(appName),
 			unleash.WithListener(&FeatureFlagListener{}),

--- a/service/feature_flags.go
+++ b/service/feature_flags.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/RedHatInsights/sources-api-go/config"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
-	"github.com/Unleash/unleash-client-go/v3"
+	"github.com/Unleash/unleash-client-go/v4"
 )
 
 const appName = "sources-api"


### PR DESCRIPTION
- Removes legacy Unleash Authentication Header
- Bumps Unleash client to v4
- closes RHCLOUD-31422

