### PR TITLE
[RHCLOUD-33508] update github actions to use updated actions/checkout and actions/setup-go

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,8 +9,8 @@ jobs:
     name: go fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-go@v5.0.1
         with:
           go-version: "1.18"
       - uses: Jerome1337/gofmt-action@v1.0.4
@@ -19,8 +19,8 @@ jobs:
     name: go vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-go@v5.0.1
         with:
           go-version: "1.18"
       - run: |
@@ -30,8 +30,8 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-go@v5.0.1
         with:
           go-version: "1.18"
       - name: golangci-lint
@@ -46,8 +46,8 @@ jobs:
     name: go test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-go@v5.0.1
         with:
           go-version: "1.18"
       - run: |


### PR DESCRIPTION
[RHCLOUD-33508](https://issues.redhat.com/browse/RHCLOUD-33508)

solve github actions warnings https://github.com/RedHatInsights/sources-api-go/actions/runs/9659515998

[go fmt](https://github.com/RedHatInsights/sources-api-go/actions/runs/9659515998/job/26643078118)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-go@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.