### PR TITLE
[RHCLOUD-33508] update 'Capitalize()' function to use golang.org/x/text/cases instead of deprecated strings.Title

### DIFF
--- a/util/string_utils.go
+++ b/util/string_utils.go
@@ -1,9 +1,13 @@
 package util
 
-import "strings"
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
 
 func Capitalize(str string) string {
-	return strings.Title(strings.ToLower(str))
+	caser := cases.Title(language.English)
+	return caser.String(str)
 }
 
 func StringRef(str string) *string {


### PR DESCRIPTION
[RHCLOUD-33508](https://issues.redhat.com/browse/RHCLOUD-33508)

this will solve error found by `golangci-lint` https://github.com/RedHatInsights/sources-api-go/actions/runs/9659515998

[golangci-lint: util/string_utils.go#L6](https://github.com/RedHatInsights/sources-api-go/commit/9c9789b2e4d3c82bc9ee1af81f5991bf87804f5d#annotation_23177283262)
SA1019: strings.Title has been deprecated since Go 1.18 and an alternative has been available since Go 1.0: The rule Title uses for word boundaries does not handle Unicode punctuation properly. Use golang.org/x/text/cases instead.  (staticcheck)