### PR TITLE
[RHCLOUD-33508] bump golangci-lint-actions to the latest version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,11 +35,10 @@ jobs:
         with:
           go-version: "1.18"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           only-new-issues: true
-          skip-go-installation: true
           args: --enable gci,bodyclose,forcetypeassert,misspell --timeout=5m
 
   gotest:


### PR DESCRIPTION
[RHCLOUD-33508](https://issues.redhat.com/browse/RHCLOUD-33508)

update the golangci-lint-actions from github actions and solve deprecation warning:

[golangci-lint](https://github.com/RedHatInsights/sources-api-go/actions/runs/9761067899/job/26941282318)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: golangci/golangci-lint-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

https://github.com/golangci/golangci-lint-action 