### PR TITLE
[RHCLOUD-33508] bump gofmt-action to the latest version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-go@v5.0.1
         with:
           go-version: "1.18"
-      - uses: Jerome1337/gofmt-action@v1.0.4
+      - uses: Jerome1337/gofmt-action@v1.0.5
 
   govet:
     name: go vet


### PR DESCRIPTION
[RHCLOUD-33508](https://issues.redhat.com/browse/RHCLOUD-33508)

the latest version v1.0.5 contains fix for `set-output` deprecation

 
<img width="1340" alt="image" src="https://github.com/RedHatInsights/sources-api-go/assets/89980168/6fc1dec2-b339-4d4b-9fad-1ef8eddd7d95">


https://github.com/Jerome1337/gofmt-action/releases/tag/v1.0.5