### PR TITLE
[RHCLOUD-33926] upgrade go version into 1.19

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-go@v5.0.1
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: Jerome1337/gofmt-action@v1.0.5
 
   govet:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-go@v5.0.1
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - run: |
           go vet ./...
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-go@v5.0.1
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
@@ -48,6 +48,6 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-go@v5.0.1
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - run: |
           go test ./...

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   sources-api-db-setup:
-    image: golang:1.18
+    image: golang:1.19
     entrypoint: "bash"
     command:
       - -c

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RedHatInsights/sources-api-go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/99designs/gqlgen v0.17.49
@@ -127,7 +127,7 @@ require (
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sys v0.21.0 // indirect
-	golang.org/x/text v0.16.0 // indirect
+	golang.org/x/text v0.16.0
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
 	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -55,7 +55,7 @@ export DATABASE_NAME=sources_api_test_go
 
 echo "Running tests...here we go"
 
-export GOROOT="/opt/go/1.18.1"
+export GOROOT="/opt/go/1.19.11"
 export PATH="${GOROOT}/bin:${PATH}"
 make alltest
 


### PR DESCRIPTION
to solve vulnerability from [RHCLOUD-33926](https://issues.redhat.com/browse/RHCLOUD-33926) we need to upgrade go from 1.18 into 1.21 ... lets do it step by step