### PR TITLE
fix condition in application_type_handler

### DIFF
--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -21,7 +21,7 @@ func getApplicationTypeDaoWithTenant(c echo.Context) (dao.ApplicationTypeDao, er
 		return nil, err
 	}
 
-	if tenantId == 0 && err == nil {
+	if tenantId == 0 {
 		return dao.GetApplicationTypeDao(nil), nil
 	} else {
 		return dao.GetApplicationTypeDao(&tenantId), nil


### PR DESCRIPTION
fix condition in the function `getApplicationTypeDaoWithTenant()` in `application_type_handlers.go`

before the change the function looks like this:
```
func getApplicationTypeDaoWithTenant(c echo.Context) (dao.ApplicationTypeDao, error) {
	tenantId, err := echoUtils.GetTenantFromEchoContext(c)

	if err != nil {
		return nil, err
	}

	if tenantId == 0 && err == nil {
		return dao.GetApplicationTypeDao(nil), nil
	} else {
		return dao.GetApplicationTypeDao(&tenantId), nil
	}
}
```

in case the `err` is not `nil` then we return it here
```
	if err != nil {
		return nil, err
	}
```

so there is no need to test that `err == nil` because we KNOW that `err == nil`