### PR TITLE
Add external_id to cloud-meter-arn

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -87,6 +87,10 @@ amazon:
           pattern: "^arnaws:.*"
         - type: min-length
           threshold: 10
+      - name: authentication.extra.external_id
+        component: text-field
+        hideField: true
+        initializeOnMount: true       
     - type: provisioning-arn
       name: Provisioning's ARN
       fields:


### PR DESCRIPTION
Part of [RHCLOUD-32014](https://issues.redhat.com/browse/RHCLOUD-32014)

Added external_id field to cloud-meter-arn