### PR TITLE
RHCLOUD-35160  | feature: support "external ID" field for Cloud Meter roles

### DIFF
--- a/dao/seeds/superkey_metadata.yml
+++ b/dao/seeds/superkey_metadata.yml
@@ -131,12 +131,17 @@
               "AWS": "arn:aws:iam::ACCOUNT:root"
             },
             "Action": "sts:AssumeRole",
-            "Condition": {}
+            "Condition": {
+              "StringEquals": {
+                "sts:ExternalID": "EXTERNAL_ID"
+              }
+            }
           }
         ]
       }
     substitutions:
       ACCOUNT: get_account
+      EXTERNAL_ID: generate_external_id
   - step: 3
     name: bind_role
     payload: {}


### PR DESCRIPTION
Cloud Meter is adopting the "external ID" field in their roles to make use of the suggested feature from AWS to restrict the access to third parties to AWS accounts.

Therefore, we need to update the Superkey metadata for the application so that the new roles are created with that new field.

## Jira ticket
[[RHCLOUD-35160]](https://issues.redhat.com/browse/RHCLOUD-35160)