### PR TITLE
RHCLOUD-36959 | fix: integration tests not passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Here lies the source code for the Sources API re-write, based on the [original R
     - `make lint` to run the same linters as the PR action, and print errors.
 - Tests are currently in the same package adjacent to the source file. ex: `source_handlers.go` -> `source_handlers_test.go`, just using the standard library testing library. May change in the future. 
 
+### Launch the integration tests
+
+In order to launch the integration tests just do the following:
+
+- Launch a test database with the following command: `podman run --rm --name sources_test -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=sources_api_test_go -p 5432:5432 --rm docker.io/postgres:13 postgres -c log_statement=all`
+- Launch the tests themselves: `DATABASE_HOST=localhost DATABASE_PORT=5432 DATABASE_USER=postgres DATABASE_PASSWORD=postgres make alltest`
+
 ## License
 
 This project is available as open source under the terms of the [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -593,7 +593,7 @@ func TestApplicationAuthenticationDelete(t *testing.T) {
 
 	// Check that application authentication doesn't exist
 	_, err = appAuthDao.GetById(&appAuth.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected Not found error, got %s", err)
 	}
 

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -1100,19 +1100,19 @@ func TestApplicationDelete(t *testing.T) {
 
 	// Check that application doesn't exist
 	_, err = applicationDao.GetById(&app.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'application not found', got %s", err)
 	}
 
 	// Check that authentication doesn't exist
 	_, err = authenticationDao.GetById(auth.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'authentication not found', got %s", err)
 	}
 
 	// Check that application authentication doesn't exist
 	_, err = appAuthDao.GetById(&appAuth.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'application authentication not found', got %s", err)
 	}
 
@@ -2185,19 +2185,19 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 
 		applicationDao := dao.GetApplicationDao(suiteData.GetRequestParamsUserA())
 		_, err = applicationDao.GetById(&suiteData.ApplicationUserA().ID)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'application not found', got %s", err)
 		}
 
 		authenticationDao := dao.GetAuthenticationDao(suiteData.GetRequestParamsUserA())
 		_, err = authenticationDao.GetById(suiteData.AuthenticationUserA().ID)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'authentication not found', got %s", err)
 		}
 
 		applicationAuthenticationDao := dao.GetApplicationAuthenticationDao(suiteData.GetRequestParamsUserA())
 		_, err = applicationAuthenticationDao.GetById(&suiteData.ApplicationAuthenticationUserA().ID)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'application authentication not found', got %s", err)
 		}
 
@@ -2232,19 +2232,19 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 
 		applicationDao = dao.GetApplicationDao(suiteData.GetRequestParamsUserA())
 		_, err = applicationDao.GetById(&suiteData.ApplicationNoUser().ID)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'application not found', got %s", err)
 		}
 
 		authenticationDao = dao.GetAuthenticationDao(suiteData.GetRequestParamsUserA())
 		_, err = authenticationDao.GetById(suiteData.AuthenticationNoUser().ID)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'authentication not found', got %s", err)
 		}
 
 		applicationAuthenticationDao = dao.GetApplicationAuthenticationDao(suiteData.GetRequestParamsUserA())
 		_, err = applicationAuthenticationDao.GetById(&suiteData.ApplicationAuthenticationNoUser().ID)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'application authentication not found', got %s", err)
 		}
 

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -736,7 +736,7 @@ func TestAuthenticationDelete(t *testing.T) {
 
 	// Check that the authentication is deleted
 	_, err = authenticationDao.GetById(uid)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'authentication not found', got %s", err)
 	}
 

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -46,8 +46,8 @@ func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
 	nonExistentId := int64(12345)
 	_, err := applicationAuthenticationDao.Delete(&nonExistentId)
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
 
 	DropSchema("delete")

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -125,8 +125,8 @@ func TestDeleteApplicationNotExists(t *testing.T) {
 	nonExistentId := int64(12345)
 	_, err := applicationDao.Delete(&nonExistentId)
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
 
 	DropSchema("delete")
@@ -953,7 +953,7 @@ func TestApplicationCreateBadRequest(t *testing.T) {
 
 	// Create the test application.
 	err := applicationDao.Create(&application)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("wanted Bad Request err, got '%s'", err)
 	}
 

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -120,7 +120,7 @@ func TestApplicationTypeGetByNameNotFound(t *testing.T) {
 		t.Error("got application type object, want nil")
 	}
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("want not found err, got '%v'", err)
 	}
 
@@ -138,7 +138,7 @@ func TestApplicationTypeGetByNameBadRequest(t *testing.T) {
 		t.Error("got application type object, want nil")
 	}
 
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("want bad request err, got '%v'", err)
 	}
 

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -224,8 +224,8 @@ func TestAuthenticationDbDelete(t *testing.T) {
 	}
 
 	_, err = dao.GetById(id)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema("authentications_db")
@@ -240,8 +240,8 @@ func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 
 	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 	_, err := dao.Delete("12345")
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema("authentications_db")
@@ -340,8 +340,8 @@ func TestListForSourceNotFound(t *testing.T) {
 		t.Errorf(`want error, got nil`)
 	}
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema("authentications_db")
@@ -439,8 +439,8 @@ func TestListForApplicationNotFound(t *testing.T) {
 		t.Errorf(`want error, got nil`)
 	}
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema("authentications_db")
@@ -546,8 +546,8 @@ func TestListForApplicationAuthenticationNotFound(t *testing.T) {
 		t.Errorf(`want error, got nil`)
 	}
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema("authentications_db")
@@ -643,8 +643,8 @@ func TestListForEndpointNotFound(t *testing.T) {
 		t.Errorf(`want error, got nil`)
 	}
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema("authentications_db")

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -68,8 +68,8 @@ func TestDeleteEndpointNotExists(t *testing.T) {
 	nonExistentId := int64(12345)
 	_, err := endpointDao.Delete(&nonExistentId)
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
 
 	DropSchema("delete")

--- a/dao/rhc_connection_dao_test.go
+++ b/dao/rhc_connection_dao_test.go
@@ -199,8 +199,8 @@ func TestRhcConnectionCreateSourceNotExists(t *testing.T) {
 		t.Errorf("want non nil error, got nil error")
 	}
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`want "%s" type, got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`want "%s" type, got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema(RhcConnectionSchema)
@@ -273,8 +273,8 @@ func TestRhcConnectionDeleteNotFound(t *testing.T) {
 		t.Errorf(`want error, got nil`)
 	}
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`want "%s" type, got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`want "%s" type, got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema(RhcConnectionSchema)
@@ -424,8 +424,8 @@ func TestDeleteRhcConnectionNotExists(t *testing.T) {
 	nonExistentId := int64(12345)
 	_, err := RhcConnectionDao.Delete(&nonExistentId)
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
 
 	DropSchema("delete")

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -377,8 +377,8 @@ func TestDeleteSourceNotExists(t *testing.T) {
 	nonExistentId := int64(12345)
 	_, err := sourceDao.Delete(&nonExistentId)
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFoundEmpty, reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
 
 	DropSchema("delete")
@@ -492,7 +492,7 @@ func TestDeleteCascade(t *testing.T) {
 		}
 		id := deletedApplicationAuthentications[0].ID
 		_, err = applicationAuthenticationDao.GetById(&id)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
 		}
 	}
@@ -504,7 +504,7 @@ func TestDeleteCascade(t *testing.T) {
 		}
 		id := deletedApplications[0].ID
 		_, err = applicationsDao.GetById(&id)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
 		}
 	}
@@ -516,7 +516,7 @@ func TestDeleteCascade(t *testing.T) {
 		}
 		id := deletedEndpoints[0].ID
 		_, err = endpointDao.GetById(&id)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
 		}
 	}
@@ -528,7 +528,7 @@ func TestDeleteCascade(t *testing.T) {
 		}
 		id := deletedRhcConnections[0].ID
 		_, err = rhcConnectionsDao.GetById(&id)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
 		}
 	}
@@ -537,7 +537,7 @@ func TestDeleteCascade(t *testing.T) {
 	{
 		id := deletedSource.ID
 		_, err = sourceDao.GetById(&id)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
 		}
 	}
@@ -569,7 +569,7 @@ func TestDeleteCascade(t *testing.T) {
 
 	// Check that the authentication is deleted
 	_, err = authenticationDao.GetById(id)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("Expected not found error, got %s", err)
 	}
 

--- a/dao/source_type_dao_test.go
+++ b/dao/source_type_dao_test.go
@@ -74,7 +74,7 @@ func TestSourceTypeGetByNameNotFound(t *testing.T) {
 		t.Error("got source type object, want nil")
 	}
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("want not found err, got '%v'", err)
 	}
 
@@ -92,7 +92,7 @@ func TestSourceTypeGetByNameBadRequest(t *testing.T) {
 		t.Error("got source type object, want nil")
 	}
 
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("want bad request err, got '%v'", err)
 	}
 

--- a/dao/tenant_dao_test.go
+++ b/dao/tenant_dao_test.go
@@ -223,8 +223,8 @@ func TestTenantByIdentityNotFound(t *testing.T) {
 		AccountNumber: "invalid",
 	})
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	// Call the function under test by providing it an invalid orgId.
@@ -232,8 +232,8 @@ func TestTenantByIdentityNotFound(t *testing.T) {
 		OrgID: "invalid",
 	})
 
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
-		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFoundEmpty), reflect.TypeOf(err))
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema("tenant_tests")

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -1020,13 +1020,13 @@ func TestEndpointDelete(t *testing.T) {
 
 	// Check that endpoint doesn't exist
 	_, err = endpointDao.GetById(&endpoint.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'endpoint not found', got %s", err)
 	}
 
 	// Check that authentication doesn't exist
 	_, err = authenticationDao.GetById(auth.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'authentication not found', got %s", err)
 	}
 

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -940,7 +940,7 @@ func TestSecretDelete(t *testing.T) {
 
 		secretDao := dao.GetSecretDao(&dao.RequestParams{TenantID: &tenantIDForSecret, UserID: userID})
 		_, err = secretDao.GetById(&secret.DbID)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Error("'secret not found' expected")
 		}
 	}

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -267,7 +267,7 @@ func TestParseSourcesBadRequestInvalidSourceTypeId(t *testing.T) {
 	// Parse the sources and check the results
 	var err error
 	sources, err := parseSources(reqSources, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("expected bad request error, got <%s>", err)
 	}
 
@@ -299,7 +299,7 @@ func TestParseSourcesNotFoundInvalidSourceTypeId(t *testing.T) {
 	// Parse the sources and check the results
 	var err error
 	sources, err := parseSources(reqSources, &tenant, &userResource)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected not found error, got <%s>", err)
 	}
 
@@ -331,7 +331,7 @@ func TestParseSourcesBadRequestInvalidSourceTypeName(t *testing.T) {
 	// Parse the sources and check the results
 	var err error
 	sources, err := parseSources(reqSources, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("expected bad request error, got <%s>", err)
 	}
 
@@ -361,7 +361,7 @@ func TestParseSourcesBadRequestMissingSourceType(t *testing.T) {
 	// Parse the sources and check the results
 	var err error
 	sources, err := parseSources(reqSources, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("expected bad request error, got <%s>", err)
 	}
 
@@ -392,7 +392,7 @@ func TestParseSourcesBadRequestValidationFails(t *testing.T) {
 	// Parse the sources and check the results
 	var err error
 	sources, err := parseSources(reqSources, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("expected bad request error, got <%s>", err)
 	}
 
@@ -550,7 +550,7 @@ func TestParseApplicationsBadRequestApplicationNotLinked(t *testing.T) {
 
 	// Parse the applications
 	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
 	}
 
@@ -583,7 +583,7 @@ func TestParseApplicationsBadRequestWithoutAppType(t *testing.T) {
 
 	// Parse the applications
 	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
 	}
 
@@ -620,7 +620,7 @@ func TestParseApplicationsBadRequestInvalidAppTypeId(t *testing.T) {
 
 	// Parse the applications
 	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
 	}
 
@@ -657,7 +657,7 @@ func TestParseApplicationsAppTypeIdNotFound(t *testing.T) {
 
 	// Parse the applications
 	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
 	}
 
@@ -692,7 +692,7 @@ func TestParseApplicationsBadRequestInvalidAppTypeName(t *testing.T) {
 
 	// Parse the applications
 	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
 	}
 
@@ -727,7 +727,7 @@ func TestParseApplicationsBadRequestNotCompatible(t *testing.T) {
 
 	// Parse the applications
 	apps, err := parseApplications(reqApplications, &bulkCreateOutput, &tenant, &userResource)
-	if !errors.Is(err, util.ErrBadRequestEmpty) {
+	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf(`unexpected error when parsing the applications from bulk create: %s`, err)
 	}
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -1577,31 +1577,31 @@ func TestSourceDelete(t *testing.T) {
 
 	// Check that source doesn't exist
 	_, err = sourceDao.GetById(&src.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'source not found', got %s", err)
 	}
 
 	// Check that application doesn't exist
 	_, err = applicationDao.GetById(&app.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'application not found', got %s", err)
 	}
 
 	// Check that application authentication doesn't exist
 	_, err = appAuthDao.GetById(&appAuth.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'application authentication not found', got %s", err)
 	}
 
 	// Check that endpoint doesn't exist
 	_, err = endpointDao.GetById(&endpoint.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'endpoint not found', got %s", err)
 	}
 
 	// Check that rhc connection doesn't exist
 	_, err = rhcConnectionDao.GetById(&rhc.ID)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected 'rhc connection not found', got %s", err)
 	}
 
@@ -1617,7 +1617,7 @@ func TestSourceDelete(t *testing.T) {
 	// Check that all authentications don't exist
 	for _, a := range auths {
 		_, err = authenticationDao.GetById(a.ID)
-		if !errors.Is(err, util.ErrNotFoundEmpty) {
+		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'authentication not found', got %s", err)
 		}
 	}
@@ -2773,7 +2773,7 @@ func TestSuperKeyDestroyWithOwnershipWhenUserIsNotAllowedToDelete(t *testing.T) 
 
 	superKeyDestroySource := middleware.SuperKeyDestroySource(SourceDelete)
 	err = superKeyDestroySource(c)
-	if !errors.Is(err, util.ErrNotFoundEmpty) {
+	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("improper error occurred for super key destroy source operation %v", err)
 	}
 

--- a/util/error_document.go
+++ b/util/error_document.go
@@ -5,9 +5,6 @@ import (
 	"reflect"
 )
 
-var ErrNotFoundEmpty = NewErrNotFound("")
-var ErrBadRequestEmpty = NewErrBadRequest("")
-
 type Error struct {
 	Detail    string `json:"detail"`
 	Status    string `json:"status"`


### PR DESCRIPTION
When reducing the noise in the logs by the commit
03488aa83e4479f5fce9bb7bd3e5e7f1140caa16, I forgot to fix the integration tests for Sources.

This new commit fixes those, and leverages the use of "errors.As" instead of having to compare that to a custom created object for the tests.

## Jira ticket
[[RHCLOUD-36959]](https://issues.redhat.com/browse/RHCLOUD-36959)