### PR TITLE
RHCLOUD-36959 | Feature: improve Sources' logging

### DIFF
--- a/dao/common.go
+++ b/dao/common.go
@@ -19,7 +19,7 @@ func GetFromResourceType(resourceType string, tenantID int64) (m.EventModelDao, 
 	case "source":
 		resource = GetSourceDao(&RequestParams{TenantID: &tenantID})
 	case "endpoint":
-		resource = GetEndpointDao(nil)
+		resource = GetEndpointDao(&tenantID)
 	case "application":
 		resource = GetApplicationDao(&RequestParams{TenantID: &tenantID})
 	case "authentication":

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -50,6 +50,8 @@ func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenan
 
 	// If the error isn't a "Not Found" one, something went wrong.
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		logger.Log.WithFields(logrus.Fields{"org_id": identity.OrgID, "account_number": identity.AccountNumber}).Errorf("Unable to find tenant by its org ID: %s", err)
+
 		return nil, fmt.Errorf("unexpected error when fetching a tenant by its OrgId: %w", err)
 	}
 
@@ -68,6 +70,8 @@ func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenan
 
 		// Again, if the error isn't a "Not Found" one, something went wrong.
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			logger.Log.WithFields(logrus.Fields{"org_id": identity.OrgID, "account_number": identity.AccountNumber}).Errorf("Unable to find tenant by its account number: %s", err)
+
 			return nil, fmt.Errorf("unexpected error when fetching a tenant by its EBS account number: %w", err)
 		}
 	}
@@ -83,6 +87,8 @@ func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenan
 			Error
 
 		if err != nil {
+			logger.Log.WithFields(logrus.Fields{"org_id": identity.OrgID, "account_number": identity.AccountNumber}).Errorf("Unable to create tenant: %s", err)
+
 			return nil, fmt.Errorf("unable to create the tenant: %w", err)
 		}
 

--- a/dao/user_dao.go
+++ b/dao/user_dao.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 
 	"github.com/RedHatInsights/sources-api-go/config"
+	"github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
+	"github.com/sirupsen/logrus"
 	"gorm.io/gorm/clause"
 )
 
@@ -55,9 +57,13 @@ func (u *userDaoImpl) FindOrCreate(userID string) (*m.User, error) {
 
 		err = stmt.Create(&user).Error
 		if err != nil {
+			logger.Log.WithFields(logrus.Fields{"tenant_id": *u.TenantID, "user_id": user.UserID}).Errorf("Unable to create user: %s", err)
+
 			return nil, err
 		}
 	}
+
+	logger.Log.WithFields(logrus.Fields{"tenant_id": *u.TenantID, "user_id": user.UserID, "user_sources_id": user.Id}).Info("User created")
 
 	return &user, nil
 }

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -8,6 +8,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/kafka"
 	logging "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/model"
+	"github.com/sirupsen/logrus"
 )
 
 // DeleteCascade removes the resource type and all its dependants, raising an event for every deleted resource. Returns
@@ -52,6 +53,8 @@ func DeleteCascade(tenantId *int64, userId *int64, resourceType string, resource
 		go func() {
 			// Raise an event for the deleted application authentications.
 			for _, appAuth := range applicationAuthentications {
+				logging.Log.WithFields(logrus.Fields{"tenant_id": *tenantId, "application_authentication_id": appAuth.ID}).Info("Application authentication deleted")
+
 				err = RaiseEvent("ApplicationAuthentication.destroy", &appAuth, headers)
 				if err != nil {
 					logging.Log.Errorf(`Event "ApplicationAuthentication.destroy" could not be raised for application authentication %v: %s`, appAuth.ToEvent(), err)


### PR DESCRIPTION
These changes make sure that we are informed about useful events while
Sorces is running, especially those ones that modify our database.

By having these logs, we might be able to increase the default logging
level to "INFO" and reduce the noise in our logs, while maintaining a
good level of debuggability.

## Dependency
- https://github.com/RedHatInsights/sources-api-go/pull/734

## Jira ticket
[[RHCLOUD-36959]](https://issues.redhat.com/browse/RHCLOUD-36959)