### PR TITLE
refactor: move encryption initialization to "main"

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	l "github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/redis"
 	"github.com/RedHatInsights/sources-api-go/statuslistener"
+	"github.com/RedHatInsights/sources-api-go/util"
 	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	echoMetrics "github.com/labstack/echo-contrib/prometheus"
 	"github.com/labstack/echo/v4"
@@ -25,6 +26,15 @@ import (
 var conf = config.Get()
 
 func main() {
+	// Initialize the encryption manually.
+	//
+	// Previously, an "init" function was used for this in the "encryption.go" file. The problem with that is that the
+	// Superkey worker depends on Sources API Go, and the "InitializeEncryption" function makes a call to the
+	// "setDefaultEncryptionKey" function, which in turn makes a call load the Sources API Go configuration. When the
+	// Superkey runs in stage or production, the configuration that it has is obviously different to the one that the
+	// Sources API Go has, which causes panics when the "setDefaultEncryptionKey" attempts to load the configuration.
+	util.InitializeEncryption()
+
 	l.InitLogger(conf)
 
 	// Redis needs to be initialized first since the database uses a Redis lock to ensure that only one application at

--- a/util/encryption.go
+++ b/util/encryption.go
@@ -20,12 +20,6 @@ var (
 	keyPresent = false
 )
 
-// init for this file basically just decodes the ENCRYPTION_KEY env var to the
-// plain text equivalent
-func init() {
-	InitializeEncryption()
-}
-
 // InitializeEncryption allows reinitializing the encryption key by reading from the "ENCRYPTION_KEY" environment
 // variable again. Useful for testing purposes outside the "util" package.
 func InitializeEncryption() {


### PR DESCRIPTION
Superkey depends on Sources API Go, and when updating its dependencies, launching the application with the Clowder configuration enabled was causing panics. It turned out that it was due to how encryption is initialized, which pulls the Sources API Go config and attempts to read it.

Obviously, when this happened in the Superkey application, it caused panics because the configuration for the Superkey worker and the Sources API Go application is different.