### PR TITLE
[RHCLOUD-35770] Convert cloud-connector availability checks to use v2 interface

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -189,7 +189,9 @@ objects:
         - name: COST_MANAGEMENT_AVAILABILITY_CHECK_URL
           value: ${KOKU_SOURCES_API_SCHEME}://${KOKU_SOURCES_API_HOST}:${KOKU_SOURCES_API_PORT}${KOKU_SOURCES_API_APP_CHECK_PATH}
         - name: CLOUD_CONNECTOR_AVAILABILITY_CHECK_URL
-          value: ${CLOUD_CONNECTOR_SCHEME}://${CLOUD_CONNECTOR_HOST}:${CLOUD_CONNECTOR_PORT}${CLOUD_CONNECTOR_CHECK_PATH}
+          value: ${CLOUD_CONNECTOR_SCHEME}://${CLOUD_CONNECTOR_HOST}:${CLOUD_CONNECTOR_PORT}${CLOUD_CONNECTOR_BASE_PATH}
+        - name: CLOUD_CONNECTOR_STATUS_PATH
+          value: ${CLOUD_CONNECTOR_STATUS_PATH}
         - name: PROVISIONING_AVAILABILITY_CHECK_URL
           value: ${PROVISIONING_SCHEME}://${PROVISIONING_HOST}:${PROVISIONING_PORT}${PROVISIONING_CHECK_PATH}
         - name: SOURCES_ENV
@@ -426,9 +428,14 @@ parameters:
 - name: CLOUD_CONNECTOR_PORT
   required: true
   value: "9000"
-- name: CLOUD_CONNECTOR_CHECK_PATH
+- name: CLOUD_CONNECTOR_BASE_PATH
+  description: Partial path for performing connection operations
   required: true
-  value: "/connection_status"
+  value: "/connections"
+- name: CLOUD_CONNECTOR_STATUS_PATH
+  description: Partial path for checking connection status, used with CLOUD_CONNECTOR_BASE_PATH
+  required: true
+  value: "/status"
 - name: PROVISIONING_SCHEME
   required: true
   value: "http"


### PR DESCRIPTION
## Jira ticket

https://issues.redhat.com/browse/RHCLOUD-35570

## Description

Updates the `service/availability_check.pingRHC()` function to use the new V2 availability check API:

- Before: `PUT /v1/connection_status`
- After: `GET v2/connections/{client_id}/status`

Since the ID is now part of the URL, it needs to be assembled at runtime. This required some changes to the ClowdApp params/env vars:

- **Param** `CLOUD_CONNECTOR_CHECK_PATH` is now `CLOUD_CONNECTOR_BASE_PATH`, which defaults to `/connector`
- **Added new param** `CLOUD_CONNECTOR_STATUS_PATH` which defaults to `/status`. This is also an **env var**, and is used in the function to assemble the final URL

## Compatibility

ClowdApp parameters will need to be revised as described above

## Testing

Ran `make alltest` with no new failures (`dao/application_dao_test.TestApplicationCreateBadRequest()` currently fails on the main branch).