### PR TITLE
Add post deploy tests config file to Sources api

### DIFF
--- a/deploy/stage-post-deployment-tests.yaml
+++ b/deploy/stage-post-deployment-tests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: sources-api-post-deployment-tests
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdJobInvocation
+  metadata:
+    name: sources-api-tests-${UID}
+  spec:
+    appName: sources-api
+    testing:
+      iqe:
+        debug: false
+        dynaconfEnvName: stage_post_deploy
+        filter: ''
+        marker: 'sources_smoke and (not ui)'
+parameters:
+- name: IMAGE_TAG
+  value: ''
+  required: true
+- name: UID
+  description: "Unique CJI name suffix"
+  generate: expression
+  from: "[a-z0-9]{6}"


### PR DESCRIPTION
Part of RHCLOUD-37775 
Adds the yaml config file needed to run the tests from the post-deploy pipeline