### PR TITLE
RHCLOUD-38735 | feature: skip Cost Management applications in availability checks

### DIFF
--- a/dao/interfaces.go
+++ b/dao/interfaces.go
@@ -10,7 +10,12 @@ type SourceDao interface {
 	// List lists all the sources from a given tenant, which should be specified in the request.
 	List(limit, offset int, filters []util.Filter) ([]m.Source, int64, error)
 	// ListInternal lists all the existing sources.
-	ListInternal(limit, offset int, filters []util.Filter) ([]m.Source, int64, error)
+	//
+	// The "skipEmptySources" parameter is a useful parameter for when the Sources monitor requests all the Sources in
+	// order to perform availability checks for them. By specifying that parameter, we can only return a list of
+	// Sources which contain associated applications or RHC Connections with them. Cost Management applications do not
+	// count as a Source having associated applications, due to https://issues.redhat.com/browse/RHCLOUD-38735.
+	ListInternal(limit, offset int, filters []util.Filter, skipEmptySources bool) ([]m.Source, int64, error)
 	SubCollectionList(primaryCollection interface{}, limit, offset int, filters []util.Filter) ([]m.Source, int64, error)
 	GetById(id *int64) (*m.Source, error)
 	Create(src *m.Source) error

--- a/internal/testutils/mocks/mock_dao_source.go
+++ b/internal/testutils/mocks/mock_dao_source.go
@@ -67,7 +67,7 @@ func (mockSourceDao *MockSourceDao) List(_, _ int, _ []util.Filter) ([]m.Source,
 	return mockSourceDao.Sources, count, nil
 }
 
-func (mockSourceDao *MockSourceDao) ListInternal(_, _ int, _ []util.Filter) ([]m.Source, int64, error) {
+func (mockSourceDao *MockSourceDao) ListInternal(_, _ int, _ []util.Filter, _ bool) ([]m.Source, int64, error) {
 	count := int64(len(mockSourceDao.Sources))
 	return mockSourceDao.Sources, count, nil
 }

--- a/internal/testutils/request/request.go
+++ b/internal/testutils/request/request.go
@@ -19,6 +19,18 @@ func CreateTestContext(method string, path string, body io.Reader, context map[s
 	recorder := httptest.NewRecorder()
 	echoContext := echoInstance.NewContext(request, recorder)
 
+	// Passing the headers in the context instead of in a new variable is very unorthodox, but this avoids having to
+	// refactor all the functions that depend on this, which would clutter any PR that needs to modify it.
+	if headersMap, ok := context["headers"]; ok {
+		if headers, typeOk := headersMap.(map[string]string); typeOk {
+			for key, value := range headers {
+				request.Header.Add(key, value)
+			}
+		}
+
+		delete(context, "headers")
+	}
+
 	for k, v := range context {
 		echoContext.Set(k, v)
 	}

--- a/internal_handlers.go
+++ b/internal_handlers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"net/http"
+	"strings"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -48,7 +49,7 @@ func InternalSourceList(c echo.Context) error {
 	// here: https://issues.redhat.com/browse/RHCLOUD-38735.
 	var skipEmptySources = false
 	if skip := c.Request().Header.Get(headers.SkipEmptySources); skip != "" {
-		skipEmptySources = skip == "true"
+		skipEmptySources = strings.ToLower(skip) == "true"
 	}
 
 	// The DAO doesn't need a tenant set, since the queries won't be filtered by that tenant

--- a/internal_handlers.go
+++ b/internal_handlers.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"net/http"
 	"strings"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
+	"github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/util"
 	"github.com/labstack/echo/v4"
 )

--- a/internal_handlers_test.go
+++ b/internal_handlers_test.go
@@ -100,6 +100,120 @@ func TestSourceListInternal(t *testing.T) {
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
+// TestSourceListInternalSkipEmptySources tests that when the "skip empty sources" header is sent, the empty sources
+// and the ones that just have Cost Management applications are skipped.
+func TestSourceListInternalSkipEmptySources(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+
+	requestTester := func(sourceIDWithoutApplications int64, expectedNumberElements int, shouldFindSourceWithoutApplications bool) {
+		// Create the fake request.
+		context, recorder := request.CreateTestContext(http.MethodGet, "/internal/v2.0/sources", nil, map[string]interface{}{
+			"limit":   100,
+			"offset":  0,
+			"filters": []util.Filter{},
+			"headers": map[string]string{h.SkipEmptySources: "true"},
+		})
+
+		// Call the handler.
+		err := InternalSourceList(context)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Make sure we get an OK response.
+		if recorder.Code != http.StatusOK {
+			t.Error("Did not return 200")
+		}
+
+		var out util.Collection
+		err = json.Unmarshal(recorder.Body.Bytes(), &out)
+		if err != nil {
+			t.Error("Failed unmarshalling output")
+		}
+
+		// Assert that an expected number of elements was returned.
+		if len(out.Data) != expectedNumberElements {
+			t.Errorf(`unexpected number of sources returned, want "%d", got "%d"`, expectedNumberElements, len(out.Data))
+		}
+
+		// Assert that the source with the Cost Management applications is or isn't present in the results.
+		var found = false
+		for _, src := range out.Data {
+			s, ok := src.(map[string]interface{})
+			if !ok {
+				t.Error("model did not deserialize as a source")
+			}
+
+			// Parse the source
+			responseSourceId, err := util.InterfaceToInt64(s["id"])
+			if err != nil {
+				t.Errorf("could not parse id from response: %s", err)
+			}
+
+			if responseSourceId == sourceIDWithoutApplications {
+				if shouldFindSourceWithoutApplications {
+					found = true
+					break
+				} else {
+					t.Errorf("the source with just a Cost Management application is in the response, when it shouldn't")
+				}
+			}
+		}
+
+		if shouldFindSourceWithoutApplications && !found {
+			t.Errorf("the source with just a Cost Management application should have been returned, because now it has an associated RHC Connection with it")
+		}
+	}
+
+	// Create a "Cost Management" application for the source without applications, which should not be returned in the
+	// response.
+	sourceWithoutApplications := fixtures.TestSourceData[4] // Source without applications.
+	application := &m.Application{
+		ApplicationTypeID:  fixtures.TestApplicationTypeData[5].Id, // "Cost Management" application type.
+		AvailabilityStatus: "available",
+		SourceID:           sourceWithoutApplications.ID,
+		TenantID:           1,
+	}
+
+	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+	if err := applicationDao.Create(application); err != nil {
+		t.Errorf("unable to create Cost Management application: %s", err)
+	}
+
+	// Clean up the created application.
+	defer func() {
+		_, err := applicationDao.Delete(&application.ID)
+		if err != nil {
+			t.Errorf("unable to clean up the created application. Expect many other tests to fail: %s", err)
+		}
+	}()
+
+	requestTester(sourceWithoutApplications.ID, 3, false)
+
+	// Associate an RHC Connection with the "applicationless source".
+	rhcConnection := &m.RhcConnection{
+		ID:                 12345,
+		RhcId:              "abcde",
+		Sources:            []m.Source{sourceWithoutApplications},
+		AvailabilityStatus: "available",
+	}
+
+	rhcConnectionDao := dao.GetRhcConnectionDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+	if _, err := rhcConnectionDao.Create(rhcConnection); err != nil {
+		t.Errorf("unable to create the RHC Connection: %s", err)
+	}
+
+	// Clean up the created RHC Connection.
+	defer func() {
+		_, err := rhcConnectionDao.Delete(&rhcConnection.ID)
+		if err != nil {
+			t.Errorf("unable to clean up the created RHC Connection. Expect many other tests to fail: %s", err)
+		}
+	}()
+
+	requestTester(sourceWithoutApplications.ID, 4, true)
+}
+
 func TestSourceListInternalBadRequestInvalidFilter(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 

--- a/middleware/headers/headers.go
+++ b/middleware/headers/headers.go
@@ -4,6 +4,7 @@ const (
 	PSK               = "x-rh-sources-psk"
 	AccountNumber     = "x-rh-sources-account-number"
 	OrgID             = "x-rh-sources-org-id"
+	SkipEmptySources  = "x-rh-sources-skip-empty-sources"
 	PSKUserID         = "x-rh-sources-user-id"
 	XRHID             = "x-rh-identity"
 	InsightsRequestID = "x-rh-insights-request-id"

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -76,7 +76,7 @@ func (acr availabilityCheckRequester) ApplicationAvailabilityCheck(source *m.Sou
 	for _, app := range source.Applications {
 		// We do not want to send availability check requests for Cost Management applications, as detailed in
 		// https://issues.redhat.com/browse/RHCLOUD-38735.
-		if skipEmptySources && app.ApplicationType.Name == "/insights/platform/cost-management" {
+		if skipEmptySources && isCostManagementApplication(app) {
 			continue
 		}
 
@@ -277,4 +277,9 @@ func (acr availabilityCheckRequester) updateRhcStatus(source *m.Source, status s
 
 func (acr availabilityCheckRequester) Logger() echo.Logger {
 	return acr.c.Logger()
+}
+
+// isCostManagementApplication returns true when the given application is a Cost Management application.
+func isCostManagementApplication(application m.Application) bool {
+	return application.ApplicationType.Name == "/insights/platform/cost-management"
 }

--- a/service/availability_check.go
+++ b/service/availability_check.go
@@ -31,7 +31,7 @@ type availabilityCheckRequester struct {
 
 type availabilityChecker interface {
 	// public methods
-	ApplicationAvailabilityCheck(source *m.Source)
+	ApplicationAvailabilityCheck(source *m.Source, skipEmptySources bool)
 	RhcConnectionAvailabilityCheck(source *m.Source, headers []kafka.Header)
 
 	// private methods
@@ -52,12 +52,12 @@ var (
 )
 
 // requests both types of availability checks for a source
-func RequestAvailabilityCheck(c echo.Context, source *m.Source, headers []kafka.Header) {
+func RequestAvailabilityCheck(c echo.Context, source *m.Source, headers []kafka.Header, skipEmptySources bool) {
 	var ac availabilityChecker = &availabilityCheckRequester{c: c}
 	ac.Logger().Infof("[source_id: %d] Requesting availability check for source", source.ID)
 
 	if len(source.Applications) != 0 {
-		ac.ApplicationAvailabilityCheck(source)
+		ac.ApplicationAvailabilityCheck(source, skipEmptySources)
 	}
 
 	// we only want to send endpoint requests if we _do not_ have any endpoints
@@ -72,8 +72,14 @@ func RequestAvailabilityCheck(c echo.Context, source *m.Source, headers []kafka.
 
 // sends off an availability check http request for each of the source's
 // applications
-func (acr availabilityCheckRequester) ApplicationAvailabilityCheck(source *m.Source) {
+func (acr availabilityCheckRequester) ApplicationAvailabilityCheck(source *m.Source, skipEmptySources bool) {
 	for _, app := range source.Applications {
+		// We do not want to send availability check requests for Cost Management applications, as detailed in
+		// https://issues.redhat.com/browse/RHCLOUD-38735.
+		if skipEmptySources && app.ApplicationType.Name == "/insights/platform/cost-management" {
+			continue
+		}
+
 		uri := app.ApplicationType.AvailabilityCheckURL()
 		if uri == nil {
 			acr.Logger().Errorf("[source_id: %d][application_id: %d][application_type: %s] Failed to fetch availability check url - continuing", source.ID, app.ID, app.ApplicationType.Name)

--- a/service/availability_check_test.go
+++ b/service/availability_check_test.go
@@ -92,3 +92,27 @@ func TestAllAvailability(t *testing.T) {
 		t.Errorf("availability check not called for all rhc connections, got %v expected %v", acr.RhcConnectionCounter, 1)
 	}
 }
+
+// TestIsCostManagementApp tests that the helper function which determines if an application is a "Cost Management"
+// application works as expected.
+func TestIsCostManagementApp(t *testing.T) {
+	if isCostManagementApplication(m.Application{}) {
+		t.Errorf("empty application identified as a Cost Management application")
+	}
+
+	nonCostManagementApplication := m.Application{
+		ApplicationType: m.ApplicationType{Name: "/insights/platform/some-other-app"},
+	}
+
+	if isCostManagementApplication(nonCostManagementApplication) {
+		t.Errorf("non-Cost Management application was identified as such")
+	}
+
+	costManagementApplication := m.Application{
+		ApplicationType: m.ApplicationType{Name: "/insights/platform/cost-management"},
+	}
+
+	if !isCostManagementApplication(costManagementApplication) {
+		t.Errorf("a Cost Management application was not identified as such")
+	}
+}

--- a/service/availability_check_test.go
+++ b/service/availability_check_test.go
@@ -24,7 +24,7 @@ func (c dummyChecker) Logger() echo.Logger {
 }
 
 // send out a http response per application
-func (c *dummyChecker) ApplicationAvailabilityCheck(source *m.Source) {
+func (c *dummyChecker) ApplicationAvailabilityCheck(source *m.Source, skipCostManagementApplications bool) {
 	for i := 0; i < len(source.Applications); i++ {
 		c.httpAvailabilityRequest(source, &source.Applications[i], &url.URL{})
 	}
@@ -52,7 +52,7 @@ func TestApplicationAvailability(t *testing.T) {
 	acr.ApplicationAvailabilityCheck(&m.Source{
 		// 2 applications on this source.
 		Applications: []m.Application{{}, {}},
-	})
+	}, false)
 
 	if acr.ApplicationCounter != 2 {
 		t.Errorf("availability check not called for both applications, got %v expected %v", acr.ApplicationCounter, 2)
@@ -81,7 +81,7 @@ func TestAllAvailability(t *testing.T) {
 		// ...and 1 rhc connection
 		SourceRhcConnections: []m.SourceRhcConnection{{RhcConnection: m.RhcConnection{RhcId: "asdf"}}},
 	}
-	acr.ApplicationAvailabilityCheck(src)
+	acr.ApplicationAvailabilityCheck(src, false)
 	acr.RhcConnectionAvailabilityCheck(src, []kafka.Header{})
 
 	if acr.ApplicationCounter != 3 {

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"net/http"
 	"strconv"
 	"time"
@@ -11,6 +10,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/logger"
 	"github.com/RedHatInsights/sources-api-go/marketplace"
+	"github.com/RedHatInsights/sources-api-go/middleware/headers"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/service"
 	"github.com/RedHatInsights/sources-api-go/util"

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gorm.io/datatypes"
 	"io"
 	"net/http"
 	"os"
@@ -32,6 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/labstack/echo/v4"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"gorm.io/datatypes"
 )
 
 func TestSourceListAuthentications(t *testing.T) {

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"gorm.io/datatypes"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -1707,6 +1709,74 @@ func TestAvailabilityStatusCheck(t *testing.T) {
 
 	c.SetParamNames("source_id")
 	c.SetParamValues("1")
+
+	err := SourceCheckAvailability(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if rec.Code != 202 {
+		t.Errorf("Wrong code, got %v, expected %v", rec.Code, 202)
+	}
+}
+
+// TestAvailabilityStatusCheckSkipEmptySources tests that when the "skip empty sources" header is passed, then the
+// empty sources are skipped when performing the availability status check. Since the availability checker does not
+// return an error, the test will always pass.
+func TestAvailabilityStatusCheckSkipEmptySources(t *testing.T) {
+	c, rec := request.CreateTestContext(
+		http.MethodPost,
+		"/api/sources/v3.1/sources/12345/check_availability",
+		nil,
+		map[string]interface{}{
+			"tenantID": int64(12345),
+			"headers":  map[string]string{h.SkipEmptySources: "true"},
+		},
+	)
+
+	// Set the environment variables so that the URL to which we need to send the request gets properly built.
+	if err := os.Setenv("COST_MANAGEMENT_AVAILABILITY_CHECK_URL", "invalidurl"); err != nil {
+		t.Errorf("unable to set the URL for the Cost Management application: %err", err)
+	}
+	defer func() {
+		if err := os.Unsetenv("COST_MANAGEMENT_AVAILABILITY_CHECK_URL"); err != nil {
+			t.Errorf("unable to unset the URL for the Cost Management application: %err", err)
+		}
+	}()
+
+	// Create a fixture that we will use with a custom "mock source dao". That ensures that we will not mess up the
+	// rest of the tests.
+	fixtureSourceId := int64(12345)
+	fixtureSourceUuid := "cae13d9c-00bf-11f0-ac7d-083a885cd988"
+	customSourceFixtures := append(fixtures.TestSourceData, m.Source{
+		ID:                 fixtureSourceId,
+		Name:               "Source with a Cost Management application",
+		SourceTypeID:       fixtures.TestSourceTypeData[0].Id, // an AWS source type.
+		AvailabilityStatus: "available",
+		Uid:                &fixtureSourceUuid,
+		TenantID:           fixtures.TestTenantData[0].Id,
+		Applications: []m.Application{
+			{
+				ID:                6,
+				Extra:             datatypes.JSON("{\"extra\": false}"),
+				ApplicationTypeID: fixtures.TestApplicationTypeData[5].Id, // the Cost Management application type.
+				SourceID:          fixtureSourceId,                        // the parent source to this application.
+				TenantID:          fixtures.TestTenantData[0].Id,
+				ApplicationType:   fixtures.TestApplicationTypeData[5], // the Cost Management application type.
+			},
+		},
+	})
+
+	// Override the "mock source" so that we return the new mock with the source we just added above. Then, we need to
+	// make sure to revert it for the rest of the tests.
+	previousMockSourceDao := mockSourceDao
+	defer func() {
+		mockSourceDao = previousMockSourceDao
+	}()
+	mockSourceDao = &mocks.MockSourceDao{Sources: customSourceFixtures, RelatedSources: fixtures.TestSourceData}
+
+	c.SetParamNames("source_id")
+	c.SetParamValues("12345")
 
 	err := SourceCheckAvailability(c)
 	if err != nil {


### PR DESCRIPTION
Enables being able to request sources from the Sources Monitor which are not empty —a source with just Cost Management applications is considered empty too— and skipping the availability status checks for Cost Management applications, to avoid doing the same work twice. More details in the Jira ticket.

## Jira ticket
[[RHCLOUD-38735]](https://issues.redhat.com/browse/RHCLOUD-38735)