### PR TITLE
RHCLOUD-37724 | fix: a 500 response returned when app of same type created

### DIFF
--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -10,7 +10,7 @@ import (
 	"github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
-	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"


### PR DESCRIPTION
When an application that had the same type as an already existing application was attempted to be created, a "500" response was being returned to the caller instead of an expected "400" response.

## Jira ticket
[[RHCLOUD-37724]](https://issues.redhat.com/browse/RHCLOUD-37724)