### PR TITLE
RHCLOUD-39380 | fix: include branch name without the remote in the if condition

### DIFF
--- a/scripts/sonarqube.bash
+++ b/scripts/sonarqube.bash
@@ -39,7 +39,7 @@ readonly project_key
 # the runner has SELinux activated, and that we need to relabel the directory
 # to have permission to read it. More information here: https://www.reddit.com/r/podman/comments/fww87v/permission_denied_within_mounted_volume_inside/
 #
-if [ -n "${GIT_BRANCH:-}" ] && [ "${GIT_BRANCH}" == "origin/main" ]; then
+if [ -n "${GIT_BRANCH:-}" ] && { [ "${GIT_BRANCH}" == "main" ] || [ "${GIT_BRANCH}" == "origin/main" ]; }; then
   podman run \
     --env COMMIT_SHORT="${commit_short}" \
     --env GIT_BRANCH="${GIT_BRANCH}" \


### PR DESCRIPTION
The "scan_code" script matches the branch name that has been passed either with or without the remote just to be safe, so the main "scancode" script's code should also have that condition.

## Jira ticket
[[RHCLOUD-39380]](https://issues.redhat.com/browse/RHCLOUD-39380)