### PR TITLE
RHCLOUD-39416 | fix: forgotten "source" statement causes PR check to fail

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -70,7 +70,7 @@ curl -s "https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bo
 if ! source "${CICD_ROOT}/build.sh"; then
     exit 1
 fi
-source
+
 if ! source "${CICD_ROOT}/deploy_ephemeral_env.sh"; then
     exit 1
 fi


### PR DESCRIPTION
I forgot to remove one of the "source" lines which causes the PR check to fail.

## Jira ticket
[[RHCLOUD-39416]](https://issues.rehdat.com/browse/RHCLOUD-39416)