### PR TITLE
 RHCLOUD-39467 | refactor: remove Oracle Cloud Infrastructure code

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -28,7 +28,6 @@
   - amazon
   - azure
   - google
-  - oracle-cloud-infrastructure
   - openshift
   - ibm
   supported_authentication_types:
@@ -40,8 +39,6 @@
     - project_id_service_account_json
     openshift:
     - token
-    oracle-cloud-infrastructure:
-    - ocid
     ibm:
     - api_token_account_id
 "/insights/platform/cloud-meter":

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -321,44 +321,6 @@ gitlab:
           - component: text-field
             name: authentication.password
             label: Personal Acces Token for the GitLab account
-oracle-cloud-infrastructure:
-  category: Cloud
-  product_name: Oracle Cloud Infrastructure
-  vendor: Oracle
-  icon_url: "/apps/frontend-assets/partners-icons/oracle-short.svg"
-  schema:
-    authentication:
-      - type: ocid
-        name: Oracle Cloud ID (OCID)
-        fields:
-          - component: text-field
-            hideField: true
-            initializeOnMount: true
-            initialValue: ocid
-            name: authentication.authtype
-          - component: text-field
-            hideField: true
-            initializeOnMount: true
-            initialValue: ocid.uuid
-            name: authentication.username
-          - component: text-field
-            name: application.extra.bucket
-            label: Bucket Name
-            isRequired: true
-            validate:
-              - type: required
-          - component: text-field
-            name: application.extra.bucket_namespace
-            label: Bucket Namespace
-            isRequired: true
-            validate:
-              - type: required
-          - component: text-field
-            name: application.extra.bucket_region
-            label: Bucket Region
-            isRequired: true
-            validate:
-              - type: required
 openshift:
   product_name: Red Hat OpenShift Container Platform
   category: Red Hat

--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -37,6 +37,6 @@ var TestApplicationTypeData = []m.ApplicationType{
 		Id:                   4,
 		DisplayName:          "Cost Management",
 		Name:                 "/insights/platform/cost-management",
-		SupportedSourceTypes: []byte(`["amazon", "azure", "google", "oracle-cloud-infrastructure", "openshift", "ibm"]`),
+		SupportedSourceTypes: []byte(`["amazon", "azure", "google", "openshift", "ibm"]`),
 	},
 }

--- a/public/openapi-3-v3.1.json
+++ b/public/openapi-3-v3.1.json
@@ -3953,7 +3953,6 @@
                     "google",
                     "github",
                     "gitlab",
-                    "oracle-cloud-infrastructure",
                     "openshift",
                     "quay",
                     "rh-marketplace",


### PR DESCRIPTION
Cost Management is dropping support for Oracle Cloud Infrastructure, so
it does not make sense to keep it around our code.

## Jira ticket
[[RHCLOUD-39467]](https://issues.redhat.com/browse/RHCLOUD-39467)