### PR TITLE
RHCLOUD-39709 | refactor: RBAC base path creation and RBAC client creation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ type SourcesApiConfig struct {
 	CachePort               int
 	CachePassword           string
 	SlowSQLThreshold        int
-	Psks                    []string
+	AuthorizedPsks          []string
 	BypassRbac              bool
 	StatusListener          bool
 	BackgroundWorker        bool
@@ -300,7 +300,7 @@ func Get() *SourcesApiConfig {
 	options.SetDefault("AppName", "source-api-go")
 
 	// psks for .... psk authentication
-	options.SetDefault("psks", strings.Split(os.Getenv("SOURCES_PSKS"), ","))
+	options.SetDefault("AuthorizedPsks", strings.Split(os.Getenv("SOURCES_PSKS"), ","))
 
 	// Grab the Kafka Sasl Settings.
 	var brokerConfig []clowder.BrokerConfig
@@ -338,7 +338,7 @@ func Get() *SourcesApiConfig {
 		CacheHost:               options.GetString("CacheHost"),
 		CachePort:               options.GetInt("CachePort"),
 		CachePassword:           options.GetString("CachePassword"),
-		Psks:                    options.GetStringSlice("psks"),
+		AuthorizedPsks:          options.GetStringSlice("AuthorizedPsks"),
 		BypassRbac:              options.GetBool("BypassRbac"),
 		StatusListener:          options.GetBool("StatusListener"),
 		BackgroundWorker:        options.GetBool("BackgroundWorker"),

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/parser"
+	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
+)
+
+func TestMain(t *testing.M) {
+	// We need to parse the flags as otherwise we face the "flag provided but not defined: -integration" error.
+	_ = parser.ParseFlags()
+
+	t.Run()
+}
+
+// TestFindDependentApplication tests that the function under test reports an error when the specified application is
+// not found in Clowder's configuration, and that the endpoint is returned when it is.
+func TestFindDependentApplication(t *testing.T) {
+	// Declare the test endpoints as if we had read them from Clowder.
+	testEndpoints := []clowder.DependencyEndpoint{
+		{
+			App: "authorization",
+		},
+		{
+			App: "cache",
+		},
+		{
+			App: "message-bus",
+		},
+	}
+
+	// Define a slice of test cases.
+	testCases := []struct {
+		ApplicationName string
+		ExpectError     bool
+	}{
+		{
+			ApplicationName: "made-up-application",
+			ExpectError:     true,
+		},
+		{
+			ApplicationName: "auth",
+			ExpectError:     true,
+		},
+		{
+			ApplicationName: "AuTh",
+			ExpectError:     true,
+		},
+		{
+			ApplicationName: "authorization",
+			ExpectError:     false,
+		},
+		{
+			ApplicationName: "cache",
+			ExpectError:     false,
+		},
+		{
+			ApplicationName: "message-bus",
+			ExpectError:     false,
+		},
+		{
+			ApplicationName: "AUTHORIZATION",
+			ExpectError:     false,
+		},
+		{
+			ApplicationName: "authoriZation",
+			ExpectError:     false,
+		},
+		{
+			ApplicationName: "AuThOrIzaTiOn",
+			ExpectError:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		endpoint, err := findDependentApplication(tc.ApplicationName, testEndpoints)
+
+		if tc.ExpectError {
+			if err == nil {
+				t.Errorf(`the function under test should have returned an error, none was returned for application "%s"`, tc.ApplicationName)
+				continue
+			}
+
+			wantErrorMsg := fmt.Sprintf(`unable to find application "%s" in the endpoints section of the cdappconfig.json file`, tc.ApplicationName)
+			if err.Error() != wantErrorMsg {
+				t.Errorf(`the function under test returned an unexpected error. Want "%s", got "%s"`, wantErrorMsg, err.Error())
+				continue
+			}
+		} else {
+			if err != nil {
+				t.Errorf(`the function under test should have not returned an error when testing it with the application "%s", but the following one was returned: %s`, tc.ApplicationName, err)
+				continue
+			}
+
+			if !strings.EqualFold(endpoint.App, tc.ApplicationName) {
+				t.Errorf(`unexpected application was found by the function under test. Want "%s", got "%s"`, tc.ApplicationName, endpoint.App)
+				continue
+			}
+		}
+	}
+}

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -204,8 +204,8 @@ objects:
               name: sources-api-secrets
               key: psks
               optional: true
-        - name: RBAC_URL
-          value: ${RBAC_SCHEME}://${RBAC_HOST}:${RBAC_PORT}${RBAC_PATH}
+        - name: RBAC_HOST
+          value: ${RBAC_HOST}
         - name: SOURCES_PSKS
           valueFrom:
             secretKeyRef:
@@ -375,25 +375,11 @@ parameters:
   displayName: Postgres SSL mode
   name: PGSSLMODE
   value: prefer
-- description: Host to use for the RBAC service URL.
-  displayName: Rbac Service Host
+- description: The host and port for the RBAC service Sources depends on. Used only in development environments.
+  displayName: RBAC service's host.
   name: RBAC_HOST
-  value: rbac-service
-- description: Port to use for the RBAC service URL.
-  displayName: Rbac Service Port
-  name: RBAC_PORT
-  required: true
-  value: '8000'
-- description: Scheme to use for the RBAC service URL. Can be either http or https
-  displayName: Rbac Service Scheme
-  name: RBAC_SCHEME
-  required: true
-  value: http
-- description: Path to rbac
-  displayName: Rbac path
-  name: RBAC_PATH
-  required: true
-  value: /api/rbac/v1
+  value: 'http://localhost:8080'
+  required: false
 - description: Skip the RBAC service entirely. If "BYPASS_RBAC=true" all the identified requests will be assumed to be valid.
   displayName: Bypass RBAC option enabled
   name: BYPASS_RBAC

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -24,7 +24,7 @@ import (
 //     operation on a subset of paths.
 //   - The request is a regularly authenticated one, so we will call RBAC to verify that the principal that comes in
 //     the header has the authorization to perform the operation in Sources.
-func PermissionCheck(bypassRbac bool, rbacPsks []string, rbacClient rbac.Client) echo.MiddlewareFunc {
+func PermissionCheck(bypassRbac bool, authorizedPsks []string, rbacClient rbac.Client) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			switch {
@@ -36,7 +36,7 @@ func PermissionCheck(bypassRbac bool, rbacPsks []string, rbacClient rbac.Client)
 					return fmt.Errorf("error casting psk to string: %v", c.Get(h.PSK))
 				}
 
-				if !pskMatches(rbacPsks, psk) {
+				if !pskMatches(authorizedPsks, psk) {
 					return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Unauthorized Action: Incorrect PSK", "401"))
 				}
 
@@ -109,6 +109,6 @@ func certDeleteAllowed(c echo.Context) bool {
 }
 
 // pskMatches returns true if the given PSK is in the list of allowed PSKs.
-func pskMatches(allowedPsks []string, psk string) bool {
-	return util.SliceContainsString(allowedPsks, psk)
+func pskMatches(authorizedPsks []string, psk string) bool {
+	return util.SliceContainsString(authorizedPsks, psk)
 }

--- a/middleware/authorization.go
+++ b/middleware/authorization.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/RedHatInsights/sources-api-go/config"
 	h "github.com/RedHatInsights/sources-api-go/middleware/headers"
 	"github.com/RedHatInsights/sources-api-go/rbac"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -13,105 +12,103 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-var (
-	psks       = config.Get().Psks
-	bypassRbac = config.Get().BypassRbac
-	rbacClient = rbac.NewRbacClient(config.Get().RbacHost)
-)
-
-/*
-Takes the information stored in the context and returns a 401 if we do not
-have authorization to perform "write" things such as POST/PATCH/DELETE.
-
- 1. Checks for PSK (if present) and if it is there and matches any of the
-    PSKs we approve, lets it through.
-
- 2. Sends the x-rh-identity header off to rbac to get an ACL list, and
-    returns whether or not it contains the correct `sources:*:*` permission.
-*/
-func PermissionCheck(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		switch {
-		case bypassRbac:
-			c.Logger().Debugf("Skipping authorization check -- disabled in ENV")
-		case c.Get(h.PSK) != nil:
-			psk, ok := c.Get(h.PSK).(string)
-			if !ok {
-				return fmt.Errorf("error casting psk to string: %v", c.Get(h.PSK))
-			}
-
-			if !pskMatches(psk) {
-				return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Unauthorized Action: Incorrect PSK", "401"))
-			}
-
-		case c.Get(h.XRHID) != nil:
-			// first check the identity (already parsed) to see if it contains
-			// the system key and if it does do some extra checks to authorize
-			// based on some internal rules (operator + satellite)
-			id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
-			if !ok {
-				return fmt.Errorf("error casting identity to struct: %+v", c.Get(h.ParsedIdentity))
-			}
-
-			// checking to see if we're going to change the results since
-			// system-auth is treated completely differently than
-			// org_admin/rbac/psk
-			if id.Identity.System != (identity.System{}) {
-				// system-auth only allows GET and POST requests.
-				method := c.Request().Method
-				if method != http.MethodGet && method != http.MethodPost && method != http.MethodDelete {
-					c.Response().Header().Set("Allow", "GET, POST, DELETE")
-					return c.JSON(http.StatusMethodNotAllowed, util.NewErrorDoc("Method not allowed", "405"))
-				}
-				// Secondary check for delete - we could move this to middleware
-				if method == http.MethodDelete && !certDeleteAllowed(c) {
-					c.Response().Header().Set("Allow", "GET, POST")
-					return c.JSON(http.StatusMethodNotAllowed, util.NewErrorDoc("Method not allowed", "405"))
+// PermissionCheck takes the authentication information stored in the context and returns a "401 — Unauthorized" if the
+// given request is not authorized to perform "write" operations such as "POST, PATCH and DELETE".
+//
+//   - When "bypassRbac" is "true", all the requests are authenticated and authorized.
+//   - When using a "psk" in the request, the latter gets authorized if the PSK is in our list of authorized PSKs that
+//     can send requests to Sources.
+//   - Lastly, the requests that come with an "x-rh-identity" header must fulfill one of the following two conditions:
+//   - The request has been authenticated with a certificate, and it's been sent with an allowed "GET", "POST" or
+//     "DELETE" http verb. In the case that it's a "DELETE" request, it will only be authorized to perform that
+//     operation on a subset of paths.
+//   - The request is a regularly authenticated one, so we will call RBAC to verify that the principal that comes in
+//     the header has the authorization to perform the operation in Sources.
+func PermissionCheck(bypassRbac bool, rbacPsks []string, rbacClient rbac.Client) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			switch {
+			case bypassRbac:
+				c.Logger().Debugf("Skipping authorization check -- disabled in ENV")
+			case c.Get(h.PSK) != nil:
+				psk, ok := c.Get(h.PSK).(string)
+				if !ok {
+					return fmt.Errorf("error casting psk to string: %v", c.Get(h.PSK))
 				}
 
-				// basically we're checking whether cn or cluster_id is set in
-				// the system section of the header, if it is then this request
-				// can go through (but only if it's a POST)
-				//
-				// we're returning early because this is easier than a goto.
-				if id.Identity.System.ClusterId != "" || id.Identity.System.CommonName != "" {
-					return next(c)
-				} else {
-					return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Unauthorized Action: system authorization only supports cn/cluster_id authorization", "401"))
+				if !pskMatches(rbacPsks, psk) {
+					return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Unauthorized Action: Incorrect PSK", "401"))
 				}
+
+			case c.Get(h.XRHID) != nil:
+				// first check the identity (already parsed) to see if it contains
+				// the system key and if it does do some extra checks to authorize
+				// based on some internal rules (operator + satellite)
+				id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
+				if !ok {
+					return fmt.Errorf("error casting identity to struct: %+v", c.Get(h.ParsedIdentity))
+				}
+
+				// checking to see if we're going to change the results since
+				// system-auth is treated completely differently than
+				// org_admin/rbac/psk
+				if id.Identity.System != (identity.System{}) {
+					// system-auth only allows GET and POST requests.
+					method := c.Request().Method
+					if method != http.MethodGet && method != http.MethodPost && method != http.MethodDelete {
+						c.Response().Header().Set("Allow", "GET, POST, DELETE")
+						return c.JSON(http.StatusMethodNotAllowed, util.NewErrorDoc("Method not allowed", "405"))
+					}
+					// Secondary check for delete - we could move this to middleware
+					if method == http.MethodDelete && !certDeleteAllowed(c) {
+						c.Response().Header().Set("Allow", "GET, POST")
+						return c.JSON(http.StatusMethodNotAllowed, util.NewErrorDoc("Method not allowed", "405"))
+					}
+
+					// basically we're checking whether cn or cluster_id is set in
+					// the system section of the header, if it is then this request
+					// can go through (but only if it's a POST)
+					//
+					// we're returning early because this is easier than a goto.
+					if id.Identity.System.ClusterId != "" || id.Identity.System.CommonName != "" {
+						return next(c)
+					} else {
+						return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Unauthorized Action: system authorization only supports cn/cluster_id authorization", "401"))
+					}
+				}
+
+				// otherwise, ship the xrhid off to rbac and check access rights.
+				rhid, ok := c.Get(h.XRHID).(string)
+				if !ok {
+					return fmt.Errorf("error casting x-rh-identity to string: %v", c.Get(h.XRHID))
+				}
+
+				allowed, err := rbacClient.Allowed(rhid)
+				if err != nil {
+					return fmt.Errorf("error hitting rbac: %v", err)
+				}
+
+				if !allowed {
+					return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Unauthorized Action: Missing RBAC permissions", "401"))
+				}
+
+			default:
+				return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Authentication required by either [x-rh-identity] or [x-rh-sources-psk]", "401"))
 			}
 
-			// otherwise, ship the xrhid off to rbac and check access rights.
-			rhid, ok := c.Get(h.XRHID).(string)
-			if !ok {
-				return fmt.Errorf("error casting x-rh-identity to string: %v", c.Get(h.XRHID))
-			}
-
-			allowed, err := rbacClient.Allowed(rhid)
-			if err != nil {
-				return fmt.Errorf("error hitting rbac: %v", err)
-			}
-
-			if !allowed {
-				return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Unauthorized Action: Missing RBAC permissions", "401"))
-			}
-
-		default:
-			return c.JSON(http.StatusUnauthorized, util.NewErrorDoc("Authentication required by either [x-rh-identity] or [x-rh-sources-psk]", "401"))
+			return next(c)
 		}
-
-		return next(c)
 	}
 }
 
+// certDeleteAllowed returns true when the given "DELETE" request authenticated by a certificate has been sent to the
+// paths which we allow those request to be sent for.
 func certDeleteAllowed(c echo.Context) bool {
-
-	//Limit to "sources" endpoint - further filtering done by source handler
-	m := regexp.MustCompile(`/sources/\d+$`)
-	allowed := m.MatchString(c.Request().URL.Path)
-	return allowed
+	//Limit to "sources" endpoint - further filtering done by source handler.
+	return regexp.MustCompile(`/sources/\d+$`).MatchString(c.Request().URL.Path)
 }
 
-func pskMatches(psk string) bool {
-	return util.SliceContainsString(psks, psk)
+// pskMatches returns true if the given PSK is in the list of allowed PSKs.
+func pskMatches(allowedPsks []string, psk string) bool {
+	return util.SliceContainsString(allowedPsks, psk)
 }

--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -11,13 +11,38 @@ import (
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
-var permCheckOrElse204 = PermissionCheck(func(c echo.Context) error {
-	return c.NoContent(http.StatusNoContent)
-})
+// mockedRbacResponse defines the response that we will get from the RBAC client.
+type mockedRbacResponse struct {
+	AllowedResponse bool
+	ErrorResponse   error
+}
+
+// mockRbacClient helps us mock RBAC responses.
+type mockRbacClient struct {
+	mockedRbacResponse
+}
+
+func (m *mockRbacClient) Allowed(string) (bool, error) {
+	if m.mockedRbacResponse.ErrorResponse != nil {
+		return false, m.mockedRbacResponse.ErrorResponse
+	}
+
+	return m.AllowedResponse, nil
+}
+
+// setUpMiddleware sets up a "PermissionCheck" middleware with the given arguments. It also sets the middleware up so
+// that if no errors occur, a "204 — No content" response is returned.
+func setUpMiddleware(bypassRbac bool, allowedPsks []string, rbacResponse mockedRbacResponse) echo.HandlerFunc {
+	mockedRbacClient := mockRbacClient{mockedRbacResponse: rbacResponse}
+
+	middleware := PermissionCheck(bypassRbac, allowedPsks, &mockedRbacClient)
+
+	return middleware(func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+}
 
 func TestRbacDisabled(t *testing.T) {
-	bypassRbac = true
-
 	c, rec := request.CreateTestContext(
 		http.MethodPost,
 		"/",
@@ -25,31 +50,31 @@ func TestRbacDisabled(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(true, []string{}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 204 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusNoContent)
 	}
-
-	bypassRbac = false
 }
 
 func TestPSKMatches(t *testing.T) {
-	psks = []string{"1234"}
-	if pskMatches("1234") != true {
+	allowedPsks := []string{"1234"}
+
+	if pskMatches(allowedPsks, "1234") != true {
 		t.Errorf("psk didn't match when it should have")
 	}
 
-	if pskMatches("12345") == true {
+	if pskMatches(allowedPsks, "12345") == true {
 		t.Errorf("psk matched when it should not have")
 	}
 }
 
 func TestGoodPSK(t *testing.T) {
-	psks = []string{"1234"}
 	c, rec := request.CreateTestContext(
 		http.MethodPost,
 		"/",
@@ -57,18 +82,19 @@ func TestGoodPSK(t *testing.T) {
 		map[string]interface{}{h.PSK: "1234"},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(true, []string{"1234"}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 204 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusNoContent)
 	}
 }
 
 func TestBadPSK(t *testing.T) {
-	psks = []string{"abcdef"}
 	c, rec := request.CreateTestContext(
 		http.MethodPost,
 		"/",
@@ -76,18 +102,19 @@ func TestBadPSK(t *testing.T) {
 		map[string]interface{}{h.PSK: "1234"},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{"abcdef"}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 401 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 401)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusUnauthorized)
 	}
 }
 
 func TestNoPSK(t *testing.T) {
-	psks = []string{"abcdef"}
 	c, rec := request.CreateTestContext(
 		"POST",
 		"/",
@@ -95,13 +122,15 @@ func TestNoPSK(t *testing.T) {
 		map[string]interface{}{},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{"abcdef"}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 401 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 401)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusUnauthorized)
 	}
 }
 
@@ -122,13 +151,15 @@ func TestSystemClusterID(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(true, []string{}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 204 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusNoContent)
 	}
 }
 
@@ -149,13 +180,15 @@ func TestSystemCN(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(true, []string{}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 204 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusNoContent)
 	}
 }
 
@@ -176,13 +209,15 @@ func TestSystemPatch(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 405 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 405)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusMethodNotAllowed)
 	}
 }
 
@@ -203,13 +238,15 @@ func TestSystemDelete(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 405 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 405)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusMethodNotAllowed)
 	}
 }
 
@@ -230,13 +267,15 @@ func TestSystemDeleteSource(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 204 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusNoContent)
 	}
 }
 
@@ -257,33 +296,19 @@ func TestSystemDeleteSourceVersioned(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 204 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusNoContent)
 	}
-}
-
-// yay dummy structs!
-type dummyRbac struct {
-	access bool
-	blowup bool
-}
-
-func (d dummyRbac) Allowed(_ string) (bool, error) {
-	if d.blowup {
-		return false, errors.New("kablooey!")
-	}
-
-	return d.access, nil
 }
 
 func TestRbacWithAccess(t *testing.T) {
-	rbacClient = dummyRbac{access: true}
-
 	c, rec := request.CreateTestContext(
 		"POST",
 		"/",
@@ -294,19 +319,19 @@ func TestRbacWithAccess(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{AllowedResponse: true})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 204 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 204)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusNoContent)
 	}
 }
 
 func TestRbacWithoutAccess(t *testing.T) {
-	rbacClient = dummyRbac{access: false}
-
 	c, rec := request.CreateTestContext(
 		"POST",
 		"/",
@@ -317,19 +342,19 @@ func TestRbacWithoutAccess(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{AllowedResponse: false})
+
+	err := middleware(c)
 	if err != nil {
 		t.Errorf("caught an error when there should not have been one")
 	}
 
-	if rec.Code != 401 {
-		t.Errorf("%v was returned instead of %v", rec.Code, 401)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusUnauthorized)
 	}
 }
 
 func TestRbacNoConnection(t *testing.T) {
-	rbacClient = dummyRbac{access: false, blowup: true}
-
 	c, _ := request.CreateTestContext(
 		"POST",
 		"/",
@@ -340,8 +365,9 @@ func TestRbacNoConnection(t *testing.T) {
 		},
 	)
 
-	err := permCheckOrElse204(c)
+	middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{ErrorResponse: fmt.Errorf("unable to connect to rbac")})
 
+	err := middleware(c)
 	if err == nil {
 		t.Errorf("no error was returned when we were expecting one!")
 	}

--- a/rbac/rbac.go
+++ b/rbac/rbac.go
@@ -1,0 +1,56 @@
+package rbac
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/RedHatInsights/rbac-client-go"
+)
+
+// Client represents an RBAC client with which we can communicate with that service.
+type Client interface {
+	// Allowed checks whether the given principal in the "x-rh-identity" header has the "sources:*:*" permission or
+	// not.
+	Allowed(string) (bool, error)
+}
+
+// rbacClientImpl is the internal implementation of the RBAC client.
+type rbacClientImpl struct {
+	// baseURL is the base URL of the RBAC service without the
+	baseURL string
+	// legacyClient is the client that comes from the "rbac-client-go" dependency. There are two problems with that
+	// legacy client:
+	//
+	// 1) The base URL needs to be specified with the version.
+	// 2) It only supports the v1's "access" endpoint, but nothing else.
+	//
+	// We could probably replace it with an ad-hoc call from Sources, but we would need to implement the model and the
+	// logic, and since the client already does it for us, it seems like a good idea to just keep it around for now.
+	legacyClient rbac.Client
+}
+
+// NewRbacClient creates an RBAC client ready to be used by the callers.
+func NewRbacClient(rbacHostname string) Client {
+	// First set up the base URL for the client...
+	client := rbacClientImpl{
+		baseURL: fmt.Sprintf("%s/api/rbac", rbacHostname),
+	}
+
+	// ... and then create the legacy client with that base URL.
+	client.legacyClient = rbac.NewClient(fmt.Sprintf("%s/v1", client.baseURL), "sources")
+
+	return &client
+}
+
+func (r *rbacClientImpl) Allowed(xrhid string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	acl, err := r.legacyClient.GetAccess(ctx, xrhid, "")
+	if err != nil {
+		return false, err
+	}
+
+	return acl.IsAllowed("sources", "*", "*"), nil
+}

--- a/rbac/rbac.go
+++ b/rbac/rbac.go
@@ -17,7 +17,7 @@ type Client interface {
 
 // rbacClientImpl is the internal implementation of the RBAC client.
 type rbacClientImpl struct {
-	// baseURL is the base URL of the RBAC service without the
+	// baseURL is the base URL of the RBAC service without the version suffix.
 	baseURL string
 	// legacyClient is the client that comes from the "rbac-client-go" dependency. There are two problems with that
 	// legacy client:

--- a/routes.go
+++ b/routes.go
@@ -27,7 +27,7 @@ func setupRoutes(e *echo.Echo) {
 	rbacClient := rbac.NewRbacClient(config.Get().RbacHost)
 
 	// Set up the middlewares.
-	permissionCheckMiddleware := middleware.PermissionCheck(config.Get().BypassRbac, config.Get().Psks, rbacClient)
+	permissionCheckMiddleware := middleware.PermissionCheck(config.Get().BypassRbac, config.Get().AuthorizedPsks, rbacClient)
 
 	var listMiddleware = []echo.MiddlewareFunc{middleware.SortAndFilter, middleware.Pagination}
 	var tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.LoggerFields, middleware.UserCatcher}

--- a/routes.go
+++ b/routes.go
@@ -7,17 +7,10 @@ import (
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/middleware"
+	"github.com/RedHatInsights/sources-api-go/rbac"
 	echoUtils "github.com/RedHatInsights/sources-api-go/util/echo"
 	"github.com/labstack/echo/v4"
 )
-
-var listMiddleware = []echo.MiddlewareFunc{middleware.SortAndFilter, middleware.Pagination}
-var tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.LoggerFields, middleware.UserCatcher}
-
-var tenancyWithListMiddleware = append(tenancyMiddleware, listMiddleware...)
-var permissionMiddleware = append(permissionMiddlewareWithoutEvents, middleware.RaiseEvent)
-var permissionWithListMiddleware = append(listMiddleware, middleware.PermissionCheck)
-var permissionMiddlewareWithoutEvents = append(tenancyMiddleware, middleware.PermissionCheck)
 
 func setupRoutes(e *echo.Echo) {
 	e.GET("/health", func(c echo.Context) error {
@@ -29,6 +22,20 @@ func setupRoutes(e *echo.Echo) {
 	e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error { return next(&echoUtils.SourcesContext{Context: c}) }
 	})
+
+	// Set up the dependencies for the middlewares and the handlers.
+	rbacClient := rbac.NewRbacClient(config.Get().RbacHost)
+
+	// Set up the middlewares.
+	permissionCheckMiddleware := middleware.PermissionCheck(config.Get().BypassRbac, config.Get().Psks, rbacClient)
+
+	var listMiddleware = []echo.MiddlewareFunc{middleware.SortAndFilter, middleware.Pagination}
+	var tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.LoggerFields, middleware.UserCatcher}
+
+	var tenancyWithListMiddleware = append(tenancyMiddleware, listMiddleware...)
+	var permissionMiddlewareWithoutEvents = append(tenancyMiddleware, permissionCheckMiddleware)
+	var permissionMiddleware = append(permissionMiddlewareWithoutEvents, middleware.RaiseEvent)
+	var permissionWithListMiddleware = append(listMiddleware, permissionCheckMiddleware)
 
 	apiVersions := []string{"v1.0", "v2.0", "v3.0", "v3.1", "v1", "v2", "v3"}
 	for _, version := range apiVersions {


### PR DESCRIPTION
We get the RBAC service's URL from an environment variable but we should really get it from Clowder's configuration file, in case the service's hostname or port changes.

Also, since the legacy RBAC client requires the whole base path including the "/v1" suffix, and we might need to send requests to the "/v2" API soon, I refactored the way the RBAC client gets created so that we can easily extend or refactor it in the future.

## Jira ticket
[[RHCLOUD-39709]](https://issues.redhat.com/browse/RHCLOUD-39709)