### PR TITLE
RHCLOUD-40209 | feature: allow adjusting Sources' background worker's resources

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -97,11 +97,11 @@ objects:
               optional: true
         resources:
           limits:
-            cpu: ${AVAILABILITY_LISTENER_CPU_LIMIT}
-            memory: ${AVAILABILITY_LISTENER_MEMORY_LIMIT}
+            cpu: ${BACKGROUND_WORKER_CPU_LIMIT}
+            memory: ${BACKGROUND_WORKER_MEMORY_LIMIT}
           requests:
-            cpu: ${AVAILABILITY_LISTENER_CPU_REQUEST}
-            memory: ${AVAILABILITY_LISTENER_MEMORY_REQUEST}
+            cpu: ${BACKGROUND_WORKER_CPU_REQUEST}
+            memory: ${BACKGROUND_WORKER_MEMORY_REQUEST}
         readinessProbe:
           httpGet:
             path: /health
@@ -322,6 +322,10 @@ parameters:
   value: 200m
 - name: AVAILABILITY_LISTENER_CPU_REQUEST
   value: 50m
+- name: BACKGROUND_WORKER_CPU_LIMIT
+  value: 200m
+- name: BACKGROUND_WORKER_CPU_REQUEST
+  value: 50m
 - description: Clowder ENV
   name: ENV_NAME
   required: true
@@ -357,6 +361,10 @@ parameters:
 - name: AVAILABILITY_LISTENER_MEMORY_LIMIT
   value: 128Mi
 - name: AVAILABILITY_LISTENER_MEMORY_REQUEST
+  value: 32Mi
+- name: BACKGROUND_WORKER_MEMORY_LIMIT
+  value: 128Mi
+- name: BACKGROUND_WORKER_MEMORY_REQUEST
   value: 32Mi
 - description: Prometheus Metrics Port
   displayName: Metrics Port


### PR DESCRIPTION
By having these variables in the ClowdApp template we will be able to adjust each pod's resources independently.

## Jira ticket
[[RHCLOUD-40209]](https://issues.redhat.com/browse/RHCLOUD-40209)