### PR TITLE
fix: RDS CA is exported to a non-existing path

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	KafkaGroupId  = "sources-api-go"
-	RdsCaLocation = "/app/rdsca.cert"
+	RdsCaLocation = "rdsca.cert"
 
 	DatabaseStore       = "database"
 	VaultStore          = "vault"


### PR DESCRIPTION
When upgrading the dependencies, I modified the path the application gets built to in the Dockerfile, because there was no reason to shove everything into an "app" directory and give it so many permissions. However, when changing that behavior, I did not see that there was one RDS certificate being written to that "app" directory.