### PR TITLE
chore: fix linting errors

### DIFF
--- a/application_authentication_handlers.go
+++ b/application_authentication_handlers.go
@@ -44,6 +44,7 @@ func ApplicationAuthenticationList(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
 	c.Logger().Infof("tenant: %v", *appAuthDB.Tenant())
 
 	out := make([]interface{}, len(appAuths))
@@ -82,7 +83,9 @@ func ApplicationAuthenticationCreate(c echo.Context) error {
 	}
 
 	input := m.ApplicationAuthenticationCreateRequest{}
-	if err := c.Bind(&input); err != nil {
+
+	err = c.Bind(&input)
+	if err != nil {
 		return err
 	}
 
@@ -150,6 +153,7 @@ func ApplicationAuthenticationListAuthentications(c echo.Context) error {
 	}
 
 	tenantId := authDao.Tenant()
+
 	out := make([]interface{}, count)
 	for i := 0; i < int(count); i++ {
 		// Set the marketplace token —if the auth is of the marketplace type— for the authentication.

--- a/application_authentication_handlers_test.go
+++ b/application_authentication_handlers_test.go
@@ -44,6 +44,7 @@ func TestApplicationAuthenticationList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -58,6 +59,7 @@ func TestApplicationAuthenticationList(t *testing.T) {
 	}
 
 	var wantAppAuthCount int
+
 	for _, a := range fixtures.TestApplicationAuthenticationData {
 		if a.TenantID == tenantId {
 			wantAppAuthCount++
@@ -105,6 +107,7 @@ func TestApplicationAuthenticationList(t *testing.T) {
 // for not existing tenant
 func TestApplicationAuthenticationListTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
@@ -130,6 +133,7 @@ func TestApplicationAuthenticationListTenantNotExist(t *testing.T) {
 // for tenant without application authentication
 func TestApplicationAuthenticationListTenantWithoutAppAuths(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 	c, rec := request.CreateTestContext(
 		http.MethodGet,
@@ -169,6 +173,7 @@ func TestApplicationAuthenticationListBadRequestInvalidFilter(t *testing.T) {
 	)
 
 	badRequestApplicationAuthenticationList := ErrorHandlingContext(ApplicationAuthenticationList)
+
 	err := badRequestApplicationAuthenticationList(c)
 	if err != nil {
 		t.Error(err)
@@ -203,6 +208,7 @@ func TestApplicationAuthenticationGet(t *testing.T) {
 	}
 
 	var out m.ApplicationAuthenticationResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -238,6 +244,7 @@ func TestApplicationAuthenticationGet(t *testing.T) {
 // for existing app auth id but with invalid tenant
 func TestApplicationAuthenticationGetInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	appAuthId := int64(1)
 
@@ -254,6 +261,7 @@ func TestApplicationAuthenticationGetInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
 
 	notFoundApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationGet)
+
 	err := notFoundApplicationAuthenticationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -266,6 +274,7 @@ func TestApplicationAuthenticationGetInvalidTenant(t *testing.T) {
 // for not existing tenant
 func TestApplicationAuthenticationGetTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	appAuthId := int64(1)
 
@@ -282,6 +291,7 @@ func TestApplicationAuthenticationGetTenantNotExist(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
 
 	notFoundApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationGet)
+
 	err := notFoundApplicationAuthenticationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -304,6 +314,7 @@ func TestApplicationAuthenticationGetNotFound(t *testing.T) {
 	c.SetParamValues("13094830948")
 
 	notFoundApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationGet)
+
 	err := notFoundApplicationAuthenticationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -326,6 +337,7 @@ func TestApplicationAuthenticationGetBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationGet)
+
 	err := badRequestApplicationAuthenticationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -336,6 +348,7 @@ func TestApplicationAuthenticationGetBadRequest(t *testing.T) {
 
 func TestApplicationAuthenticationCreate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 
 	// Create own test data - source with application and authentication
@@ -414,6 +427,7 @@ func TestApplicationAuthenticationCreate(t *testing.T) {
 	}
 
 	var out m.ApplicationAuthenticationResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -423,7 +437,9 @@ func TestApplicationAuthenticationCreate(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	appAuthDao := dao.GetApplicationAuthenticationDao(&daoParams)
+
 	appAuthOut, err := appAuthDao.GetById(&appAuthID)
 	if err != nil {
 		t.Error(err)
@@ -433,9 +449,11 @@ func TestApplicationAuthenticationCreate(t *testing.T) {
 	if appAuthOut.TenantID != tenantId {
 		t.Errorf("application authentication with id %d should belong to tenant with id %d, but got %d", appAuthOut.ID, tenantId, appAuthOut.TenantID)
 	}
+
 	if app.TenantID != tenantId {
 		t.Errorf("application with id %d should belong to tenant with id %d, but got %d", app.ID, tenantId, app.TenantID)
 	}
+
 	if auth.TenantID != tenantId {
 		t.Errorf("authentication with id %d should belong to tenant with id %d, but got %d", auth.DbID, tenantId, auth.TenantID)
 	}
@@ -466,6 +484,7 @@ func TestApplicationAuthenticationCreateBadAppId(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json")
 
 	badRequestApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationCreate)
+
 	err := badRequestApplicationAuthenticationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -493,6 +512,7 @@ func TestApplicationAuthenticationCreateBadAuthId(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json")
 
 	badRequestApplicationAuthenticationGet := ErrorHandlingContext(ApplicationAuthenticationCreate)
+
 	err := badRequestApplicationAuthenticationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -503,6 +523,7 @@ func TestApplicationAuthenticationCreateBadAuthId(t *testing.T) {
 
 func TestApplicationAuthenticationDelete(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 
 	// Create own test data - to be independent on fixtures
@@ -560,6 +581,7 @@ func TestApplicationAuthenticationDelete(t *testing.T) {
 		ApplicationID:    app.ID,
 		AuthenticationID: auth.DbID,
 	}
+
 	err = appAuthDao.Create(&appAuth)
 	if err != nil {
 		t.Errorf("application authentication not created correctly: %s", err)
@@ -608,6 +630,7 @@ func TestApplicationAuthenticationDelete(t *testing.T) {
 // for tenant who doesn't own the app auth
 func TestApplicationAuthenticationDeleteInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	appAuthId := int64(1)
 
@@ -624,6 +647,7 @@ func TestApplicationAuthenticationDeleteInvalidTenant(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundApplicationAuthenticationDelete := ErrorHandlingContext(ApplicationAuthenticationDelete)
+
 	err := notFoundApplicationAuthenticationDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -645,6 +669,7 @@ func TestApplicationAuthenticationDeleteNotFound(t *testing.T) {
 	c.SetParamValues("1234523452542")
 
 	notFoundApplicationAuthenticationDelete := ErrorHandlingContext(ApplicationAuthenticationDelete)
+
 	err := notFoundApplicationAuthenticationDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -666,6 +691,7 @@ func TestApplicationAuthenticationDeleteBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestApplicationAuthenticationDelete := ErrorHandlingContext(ApplicationAuthenticationDelete)
+
 	err := badRequestApplicationAuthenticationDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -676,6 +702,7 @@ func TestApplicationAuthenticationDeleteBadRequest(t *testing.T) {
 
 func TestApplicationAuthenticationListAuthentications(t *testing.T) {
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	tenantId := int64(1)
 	appAuthId := int64(2)
 
@@ -704,6 +731,7 @@ func TestApplicationAuthenticationListAuthentications(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -755,6 +783,7 @@ func TestApplicationAuthenticationListAuthentications(t *testing.T) {
 // is returned for not existing tenant
 func TestApplicationAuthenticationListAuthenticationsTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	appAuthId := int64(2)
 
@@ -774,6 +803,7 @@ func TestApplicationAuthenticationListAuthenticationsTenantNotExist(t *testing.T
 	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
 
 	notFoundAppAuthListAuths := ErrorHandlingContext(ApplicationAuthenticationListAuthentications)
+
 	err := notFoundAppAuthListAuths(c)
 	if err != nil {
 		t.Error(err)
@@ -786,6 +816,7 @@ func TestApplicationAuthenticationListAuthenticationsTenantNotExist(t *testing.T
 // is returned for valid tenant who doesn't own the app auth
 func TestApplicationAuthenticationListAuthenticationsInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	appAuthId := int64(2)
 
@@ -805,6 +836,7 @@ func TestApplicationAuthenticationListAuthenticationsInvalidTenant(t *testing.T)
 	c.SetParamValues(fmt.Sprintf("%d", appAuthId))
 
 	notFoundAppAuthListAuths := ErrorHandlingContext(ApplicationAuthenticationListAuthentications)
+
 	err := notFoundAppAuthListAuths(c)
 	if err != nil {
 		t.Error(err)
@@ -832,6 +864,7 @@ func TestApplicationAuthenticationListAuthenticationsNotFound(t *testing.T) {
 	c.SetParamValues("78967899")
 
 	notFoundAppAuthListAuths := ErrorHandlingContext(ApplicationAuthenticationListAuthentications)
+
 	err := notFoundAppAuthListAuths(c)
 	if err != nil {
 		t.Error(err)
@@ -859,6 +892,7 @@ func TestApplicationAuthenticationListAuthenticationsBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestAppAuthListAuths := ErrorHandlingContext(ApplicationAuthenticationListAuthentications)
+
 	err := badRequestAppAuthListAuths(c)
 	if err != nil {
 		t.Error(err)
@@ -887,5 +921,6 @@ func checkAllApplicationAuthenticationsBelongToTenant(tenantId int64, appAuths [
 			}
 		}
 	}
+
 	return nil
 }

--- a/application_handlers.go
+++ b/application_handlers.go
@@ -75,7 +75,6 @@ func ApplicationGet(c echo.Context) error {
 	c.Logger().Infof("Getting Application ID %v", id)
 
 	app, err := applicationDB.GetById(&id)
-
 	if err != nil {
 		return err
 	}
@@ -95,7 +94,9 @@ func ApplicationCreate(c echo.Context) error {
 	}
 
 	input := &m.ApplicationCreateRequest{}
-	if err = c.Bind(input); err != nil {
+
+	err = c.Bind(input)
+	if err != nil {
 		return err
 	}
 
@@ -163,25 +164,33 @@ func ApplicationEdit(c echo.Context) error {
 
 	// Store the previous status before updating the application.
 	previousStatus := app.AvailabilityStatus
+
 	var statusFromRequest *string
 
 	if app.PausedAt != nil {
 		input := &m.ResourceEditPausedRequest{}
-		if err := c.Bind(input); err != nil {
+
+		err := c.Bind(input)
+		if err != nil {
 			return util.NewErrBadRequest(err)
 		}
+
 		statusFromRequest = input.AvailabilityStatus
-		err := app.UpdateFromRequestPaused(input)
+
+		err = app.UpdateFromRequestPaused(input)
 		if err != nil {
 			return util.NewErrBadRequest(err)
 		}
 	} else {
 		input := &m.ApplicationEditRequest{}
-		if err := c.Bind(input); err != nil {
+
+		err := c.Bind(input)
+		if err != nil {
 			return util.NewErrBadRequest(err)
 		}
 
-		if err := service.ValidateApplicationEditRequest(input); err != nil {
+		err = service.ValidateApplicationEditRequest(input)
+		if err != nil {
 			return util.NewErrBadRequest(fmt.Errorf(`invalid payload: %w`, err))
 		}
 
@@ -269,6 +278,7 @@ func ApplicationListAuthentications(c echo.Context) error {
 	}
 
 	tenantId := authDao.Tenant()
+
 	out := make([]interface{}, count)
 	for i := 0; i < int(count); i++ {
 		// Set the marketplace token —if the auth is of the marketplace type— for the authentication.

--- a/application_handlers_test.go
+++ b/application_handlers_test.go
@@ -62,6 +62,7 @@ func TestSourceApplicationSubcollectionList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -82,6 +83,7 @@ func TestSourceApplicationSubcollectionList(t *testing.T) {
 	SortByStringValueOnKey("id", out.Data)
 
 	var wantData []m.Application
+
 	for _, app := range fixtures.TestApplicationData {
 		if app.SourceID == sourceId {
 			wantData = append(wantData, app)
@@ -161,6 +163,7 @@ func TestSourceApplicationSubcollectionListNotFound(t *testing.T) {
 	c.SetParamValues("134793847")
 
 	notFoundSourceListApplications := ErrorHandlingContext(SourceListApplications)
+
 	err := notFoundSourceListApplications(c)
 	if err != nil {
 		t.Error(err)
@@ -189,6 +192,7 @@ func TestSourceApplicationSubcollectionListBadRequestInvalidSyntax(t *testing.T)
 		c.SetParamValues(p)
 
 		badRequestSourceListApplications := ErrorHandlingContext(SourceListApplications)
+
 		err := badRequestSourceListApplications(c)
 		if err != nil {
 			t.Error(err)
@@ -219,6 +223,7 @@ func TestSourceApplicationSubcollectionListBadRequestInvalidFilter(t *testing.T)
 	c.SetParamValues("1")
 
 	badRequestSourceListApplications := ErrorHandlingContext(SourceListApplications)
+
 	err := badRequestSourceListApplications(c)
 	if err != nil {
 		t.Error(err)
@@ -231,6 +236,7 @@ func TestSourceApplicationSubcollectionListBadRequestInvalidFilter(t *testing.T)
 // returned for not existing tenant
 func TestSourceApplicationSubcollectionListTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
@@ -250,6 +256,7 @@ func TestSourceApplicationSubcollectionListTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceListApplications := ErrorHandlingContext(SourceListApplications)
+
 	err := notFoundSourceListApplications(c)
 	if err != nil {
 		t.Error(err)
@@ -262,6 +269,7 @@ func TestSourceApplicationSubcollectionListTenantNotExists(t *testing.T) {
 // returned existing tenant who doesn't own the source
 func TestSourceApplicationSubcollectionListInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	sourceId := int64(1)
 
@@ -281,6 +289,7 @@ func TestSourceApplicationSubcollectionListInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceListApplications := ErrorHandlingContext(SourceListApplications)
+
 	err := notFoundSourceListApplications(c)
 	if err != nil {
 		t.Error(err)
@@ -313,6 +322,7 @@ func TestApplicationList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -382,7 +392,9 @@ func TestApplicationListBadRequestInvalidFilter(t *testing.T) {
 			"tenantID": int64(1),
 		},
 	)
+
 	badRequestApplicationList := ErrorHandlingContext(ApplicationList)
+
 	err := badRequestApplicationList(c)
 	if err != nil {
 		t.Error(err)
@@ -394,6 +406,7 @@ func TestApplicationListBadRequestInvalidFilter(t *testing.T) {
 // TestApplicationListTenantNotExists tests that empty list is returned for not existing tenant
 func TestApplicationListTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 
 	c, rec := request.CreateTestContext(
@@ -420,6 +433,7 @@ func TestApplicationListTenantNotExists(t *testing.T) {
 // without applications
 func TestApplicationListTenantWithoutApplications(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 
 	c, rec := request.CreateTestContext(
@@ -466,6 +480,7 @@ func TestApplicationGet(t *testing.T) {
 	}
 
 	var outApplication m.ApplicationResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &outApplication)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -487,6 +502,7 @@ func TestApplicationGet(t *testing.T) {
 			if app.TenantID != tenantId {
 				t.Errorf("wrong tenant id, expected %d, got %d", tenantId, app.TenantID)
 			}
+
 			break
 		}
 	}
@@ -496,6 +512,7 @@ func TestApplicationGet(t *testing.T) {
 // existing app id but the tenant doesn't own the app
 func TestApplicationGetInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 	appId := int64(1)
 
@@ -512,6 +529,7 @@ func TestApplicationGetInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationGet := ErrorHandlingContext(ApplicationGet)
+
 	err := notFoundApplicationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -524,6 +542,7 @@ func TestApplicationGetInvalidTenant(t *testing.T) {
 // not existing tenant
 func TestApplicationGetTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	appId := int64(1)
 
@@ -540,6 +559,7 @@ func TestApplicationGetTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationGet := ErrorHandlingContext(ApplicationGet)
+
 	err := notFoundApplicationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -562,6 +582,7 @@ func TestApplicationGetNotFound(t *testing.T) {
 	c.SetParamValues("9843762095")
 
 	notFoundApplicationGet := ErrorHandlingContext(ApplicationGet)
+
 	err := notFoundApplicationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -584,6 +605,7 @@ func TestApplicationGetBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestApplicationGet := ErrorHandlingContext(ApplicationGet)
+
 	err := badRequestApplicationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -594,6 +616,7 @@ func TestApplicationGetBadRequest(t *testing.T) {
 
 func TestApplicationCreateGood(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	service.AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
@@ -626,6 +649,7 @@ func TestApplicationCreateGood(t *testing.T) {
 
 	app := m.ApplicationResponse{}
 	raw, _ := io.ReadAll(rec.Body)
+
 	err = json.Unmarshal(raw, &app)
 	if err != nil {
 		t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -662,6 +686,7 @@ func TestApplicationCreateMissingSourceId(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestApplicationCreate := ErrorHandlingContext(ApplicationCreate)
+
 	err := badRequestApplicationCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -692,6 +717,7 @@ func TestApplicationCreateMissingApplicationTypeId(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestApplicationCreate := ErrorHandlingContext(ApplicationCreate)
+
 	err := badRequestApplicationCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -702,6 +728,7 @@ func TestApplicationCreateMissingApplicationTypeId(t *testing.T) {
 
 func TestApplicationCreateIncompatible(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	service.AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: false}
 
 	req := m.ApplicationCreateRequest{
@@ -724,6 +751,7 @@ func TestApplicationCreateIncompatible(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestApplicationCreate := ErrorHandlingContext(ApplicationCreate)
+
 	err := badRequestApplicationCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -736,6 +764,7 @@ func TestApplicationCreateIncompatible(t *testing.T) {
 // when source in request not belongs to the tenant
 func TestApplicationCreateInvalidSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 
 	req := m.ApplicationCreateRequest{
@@ -758,6 +787,7 @@ func TestApplicationCreateInvalidSource(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestApplicationCreate := ErrorHandlingContext(ApplicationCreate)
+
 	err := badRequestApplicationCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -837,6 +867,7 @@ func TestApplicationEdit(t *testing.T) {
 	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	appEditHandlerWithNotifier := middleware.Notifier(ApplicationEdit)
+
 	err = appEditHandlerWithNotifier(c)
 	if err != nil {
 		t.Error(err)
@@ -848,6 +879,7 @@ func TestApplicationEdit(t *testing.T) {
 
 	app := m.ApplicationResponse{}
 	raw, _ := io.ReadAll(rec.Body)
+
 	err = json.Unmarshal(raw, &app)
 	if err != nil {
 		t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -906,6 +938,7 @@ func TestApplicationEdit(t *testing.T) {
 // edit existing not owned application
 func TestApplicationEditInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	appId := int64(1)
 
@@ -931,6 +964,7 @@ func TestApplicationEditInvalidTenant(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundApplicationEdit := ErrorHandlingContext(ApplicationEdit)
+
 	err := notFoundApplicationEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -962,6 +996,7 @@ func TestApplicationEditNotFound(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundApplicationEdit := ErrorHandlingContext(ApplicationEdit)
+
 	err := notFoundApplicationEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -993,6 +1028,7 @@ func TestApplicationEditBadRequest(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestApplicationEdit := ErrorHandlingContext(ApplicationEdit)
+
 	err := badRequestApplicationEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -1127,6 +1163,7 @@ func TestApplicationDelete(t *testing.T) {
 // delete existing but not owned application
 func TestApplicationDeleteInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	appId := int64(1)
 
@@ -1143,6 +1180,7 @@ func TestApplicationDeleteInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationGet := ErrorHandlingContext(ApplicationDelete)
+
 	err := notFoundApplicationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -1165,6 +1203,7 @@ func TestApplicationDeleteNotFound(t *testing.T) {
 	c.SetParamValues("9843762095")
 
 	notFoundApplicationGet := ErrorHandlingContext(ApplicationDelete)
+
 	err := notFoundApplicationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -1187,6 +1226,7 @@ func TestApplicationDeleteBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestApplicationGet := ErrorHandlingContext(ApplicationDelete)
+
 	err := badRequestApplicationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -1224,6 +1264,7 @@ func TestApplicationListAuthentications(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -1238,6 +1279,7 @@ func TestApplicationListAuthentications(t *testing.T) {
 	}
 
 	var wantData []m.Authentication
+
 	for _, auth := range fixtures.TestAuthenticationData {
 		if auth.ResourceType == "Application" && auth.ResourceID == appId && auth.TenantID == tenantId {
 			wantData = append(wantData, auth)
@@ -1252,6 +1294,7 @@ func TestApplicationListAuthentications(t *testing.T) {
 	if !ok {
 		t.Error("model did not deserialize as a source")
 	}
+
 	if conf.SecretStore == "database" {
 		if auth["id"] != fmt.Sprintf("%d", wantData[0].DbID) {
 			t.Error("ghosts infected the return")
@@ -1312,6 +1355,7 @@ func TestApplicationListAuthenticationsEmptyList(t *testing.T) {
 // for not existing tenant
 func TestApplicationListAuthenticationsTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	appId := int64(1)
 
@@ -1331,6 +1375,7 @@ func TestApplicationListAuthenticationsTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationListAuthentications := ErrorHandlingContext(ApplicationListAuthentications)
+
 	err := notFoundApplicationListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1343,6 +1388,7 @@ func TestApplicationListAuthenticationsTenantNotExists(t *testing.T) {
 // for a tenant who doesn't own the application
 func TestApplicationListAuthenticationsInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	appId := int64(1)
 
@@ -1362,6 +1408,7 @@ func TestApplicationListAuthenticationsInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationListAuthentications := ErrorHandlingContext(ApplicationListAuthentications)
+
 	err := notFoundApplicationListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1389,6 +1436,7 @@ func TestApplicationListAuthenticationsNotFound(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationListAuthentications := ErrorHandlingContext(ApplicationListAuthentications)
+
 	err := notFoundApplicationListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1416,6 +1464,7 @@ func TestApplicationListAuthenticationsBadRequest(t *testing.T) {
 	c.SetParamValues(appId)
 
 	badRequestApplicationListAuthentications := ErrorHandlingContext(ApplicationListAuthentications)
+
 	err := badRequestApplicationListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1427,6 +1476,7 @@ func TestApplicationListAuthenticationsBadRequest(t *testing.T) {
 // TestPauseApplication tests that an application gets successfully paused.
 func TestPauseApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 	appId := int64(1)
 
@@ -1453,6 +1503,7 @@ func TestPauseApplication(t *testing.T) {
 
 	// Check that the application is paused
 	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
+
 	app, err := applicationDao.GetById(&appId)
 	if err != nil {
 		t.Error(err)
@@ -1486,6 +1537,7 @@ func TestPauseApplicationNotFound(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationPause := ErrorHandlingContext(ApplicationPause)
+
 	err := notFoundApplicationPause(c)
 	if err != nil {
 		t.Error(err)
@@ -1511,6 +1563,7 @@ func TestPauseApplicationBadRequest(t *testing.T) {
 	c.SetParamValues(appId)
 
 	badRequestApplicationPause := ErrorHandlingContext(ApplicationPause)
+
 	err := badRequestApplicationPause(c)
 	if err != nil {
 		t.Error(err)
@@ -1540,6 +1593,7 @@ func TestPauseApplicationInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationPause := ErrorHandlingContext(ApplicationPause)
+
 	err := notFoundApplicationPause(c)
 	if err != nil {
 		t.Error(err)
@@ -1552,6 +1606,7 @@ func TestPauseApplicationInvalidTenant(t *testing.T) {
 // for not existing tenant
 func TestPauseApplicationTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	appId := int64(1)
 
@@ -1568,6 +1623,7 @@ func TestPauseApplicationTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationPause := ErrorHandlingContext(ApplicationPause)
+
 	err := notFoundApplicationPause(c)
 	if err != nil {
 		t.Error(err)
@@ -1579,11 +1635,13 @@ func TestPauseApplicationTenantNotExists(t *testing.T) {
 // TestUnpauseApplication tests that an application gets successfully unpaused.
 func TestUnpauseApplication(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 	appId := int64(1)
 
 	// Test data preparation = pause the application
 	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
+
 	err := applicationDao.Pause(appId)
 	if err != nil {
 		t.Error(err)
@@ -1639,6 +1697,7 @@ func TestUnpauseApplicationNotFound(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationUnpause := ErrorHandlingContext(ApplicationUnpause)
+
 	err := notFoundApplicationUnpause(c)
 	if err != nil {
 		t.Error(err)
@@ -1664,6 +1723,7 @@ func TestUnpauseApplicationBadRequest(t *testing.T) {
 	c.SetParamValues(appId)
 
 	badRequestApplicationUnpause := ErrorHandlingContext(ApplicationUnpause)
+
 	err := badRequestApplicationUnpause(c)
 	if err != nil {
 		t.Error(err)
@@ -1693,6 +1753,7 @@ func TestUnpauseApplicationInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationUnpause := ErrorHandlingContext(ApplicationUnpause)
+
 	err := notFoundApplicationUnpause(c)
 	if err != nil {
 		t.Error(err)
@@ -1705,6 +1766,7 @@ func TestUnpauseApplicationInvalidTenant(t *testing.T) {
 // for not existing tenant
 func TestUnpauseApplicationTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	appId := int64(1)
 
@@ -1721,6 +1783,7 @@ func TestUnpauseApplicationTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", appId))
 
 	notFoundApplicationUnpause := ErrorHandlingContext(ApplicationUnpause)
+
 	err := notFoundApplicationUnpause(c)
 	if err != nil {
 		t.Error(err)
@@ -1751,12 +1814,14 @@ func TestPauseApplicationPauseRaiseEventCheck(t *testing.T) {
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: MockSender{}} }
 
 	var applicationRaiseEventCallCount int
+
 	raiseEventFunc = func(eventType string, payload []byte, headers []kafka.Header) error {
 		// Set up an error which will get returned. Probably will get overwritten if there are multiple errors, but
 		// we don't mind since we are logging every failure. Essentially, it just to satisfy the function signature.
 		err := applicationEventTestHelper(t, c, "Application.pause", eventType, payload, headers)
 
 		applicationRaiseEventCallCount++
+
 		return err
 	}
 
@@ -1805,12 +1870,14 @@ func TestPauseApplicationUnpauseRaiseEventCheck(t *testing.T) {
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: MockSender{}} }
 
 	var applicationRaiseEventCallCount int
+
 	raiseEventFunc = func(eventType string, payload []byte, headers []kafka.Header) error {
 		// Set up an error which will get returned. Probably will get overwritten if there are multiple errors, but
 		// we don't mind since we are logging every failure. Essentially, it just to satisfy the function signature.
 		err := applicationEventTestHelper(t, c, "Application.unpause", eventType, payload, headers)
 
 		applicationRaiseEventCallCount++
+
 		return err
 	}
 
@@ -1847,6 +1914,7 @@ func applicationEventTestHelper(t *testing.T, c echo.Context, expectedEventType 
 
 	// We have to unmarshal the payload to grab the ID and fetch the fixture from the database.
 	var content map[string]interface{}
+
 	err := json.Unmarshal(payload, &content)
 	if err != nil {
 		t.Errorf(`could not unmarshal the payload: %s`, err)
@@ -1891,15 +1959,16 @@ func applicationEventTestHelper(t *testing.T, c echo.Context, expectedEventType 
 
 	{
 		var h kafka.Header
+
 		for _, header := range headers {
 			if header.Key == "event_type" {
 				h = header
 				break
 			}
-
 		}
 		// The header should contain the expected event type as well.
 		want := expectedEventType
+
 		got := string(h.Value)
 		if want != got {
 			t.Errorf(`incorrect header on raise event. Want "%s", got "%s"`, want, got)
@@ -1944,8 +2013,8 @@ func TestApplicationEditPaused(t *testing.T) {
 	}
 
 	badRequestApplicationEdit := ErrorHandlingContext(ApplicationEdit)
-	err = badRequestApplicationEdit(c)
 
+	err = badRequestApplicationEdit(c)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1961,6 +2030,7 @@ func TestApplicationEditPaused(t *testing.T) {
 	}
 
 	want := "extra"
+
 	got := rec.Body.String()
 	if !strings.Contains(got, want) {
 		t.Errorf(`unexpected body returned. Want "%s" contained in what we got "%s"`, want, got)
@@ -2007,8 +2077,8 @@ func TestApplicationEditPausedIntegration(t *testing.T) {
 	}
 
 	badRequestApplicationEdit := ErrorHandlingContext(ApplicationEdit)
-	err = badRequestApplicationEdit(c)
 
+	err = badRequestApplicationEdit(c)
 	if err != nil {
 		t.Error(err)
 	}
@@ -2024,6 +2094,7 @@ func TestApplicationEditPausedIntegration(t *testing.T) {
 	}
 
 	want := "extra"
+
 	got := rec.Body.String()
 	if !strings.Contains(got, want) {
 		t.Errorf(`unexpected body returned. Want "%s" contained in what we got "%s"`, want, got)
@@ -2072,8 +2143,8 @@ func TestApplicationEditPausedUnit(t *testing.T) {
 	}
 
 	appEdit := ErrorHandlingContext(ApplicationEdit)
-	err := appEdit(c)
 
+	err := appEdit(c)
 	if err != nil {
 		t.Errorf(`unexpected error when editing a paused application: %s`, err)
 	}
@@ -2084,7 +2155,6 @@ func TestApplicationEditPausedUnit(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Errorf("Wrong return code, expected %v got %v", http.StatusOK, rec.Code)
 	}
-
 }
 
 // TestApplicationEditPausedUnitInvalidFields tests that a "bad request" response is returned when a paused application
@@ -2157,7 +2227,6 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 		/*
 		 Test 1 - UserA tries to delete application for userA - expected result: success
 		*/
-
 		id := fmt.Sprintf("%d", suiteData.ApplicationUserA().ID)
 
 		c, rec := request.CreateTestContext(
@@ -2184,18 +2253,21 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 		}
 
 		applicationDao := dao.GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		_, err = applicationDao.GetById(&suiteData.ApplicationUserA().ID)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'application not found', got %s", err)
 		}
 
 		authenticationDao := dao.GetAuthenticationDao(suiteData.GetRequestParamsUserA())
+
 		_, err = authenticationDao.GetById(suiteData.AuthenticationUserA().ID)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'authentication not found', got %s", err)
 		}
 
 		applicationAuthenticationDao := dao.GetApplicationAuthenticationDao(suiteData.GetRequestParamsUserA())
+
 		_, err = applicationAuthenticationDao.GetById(&suiteData.ApplicationAuthenticationUserA().ID)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'application authentication not found', got %s", err)
@@ -2231,18 +2303,21 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 		}
 
 		applicationDao = dao.GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		_, err = applicationDao.GetById(&suiteData.ApplicationNoUser().ID)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'application not found', got %s", err)
 		}
 
 		authenticationDao = dao.GetAuthenticationDao(suiteData.GetRequestParamsUserA())
+
 		_, err = authenticationDao.GetById(suiteData.AuthenticationNoUser().ID)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'authentication not found', got %s", err)
 		}
 
 		applicationAuthenticationDao = dao.GetApplicationAuthenticationDao(suiteData.GetRequestParamsUserA())
+
 		_, err = applicationAuthenticationDao.GetById(&suiteData.ApplicationAuthenticationNoUser().ID)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("expected 'application authentication not found', got %s", err)
@@ -2274,6 +2349,7 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 		}
 
 		applicationDao = dao.GetApplicationDao(suiteData.GetRequestParamsUserB())
+
 		_, err = applicationDao.GetById(&suiteData.ApplicationUserB().ID)
 		if err != nil {
 			t.Errorf("unable to get application, there is err %s", err)
@@ -2281,12 +2357,14 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 
 		authenticationDao = dao.GetAuthenticationDao(suiteData.GetRequestParamsUserB())
 		authId, _ := util.InterfaceToString(suiteData.AuthenticationUserB().DbID)
+
 		_, err = authenticationDao.GetById(authId)
 		if err != nil {
 			t.Errorf("unable to get authentication, there is err %s", err)
 		}
 
 		applicationAuthenticationDao = dao.GetApplicationAuthenticationDao(suiteData.GetRequestParamsUserB())
+
 		_, err = applicationAuthenticationDao.GetById(&suiteData.ApplicationAuthenticationUserB().ID)
 		if err != nil {
 			t.Errorf("unable to get application authentication, there is err %s", err)
@@ -2310,7 +2388,6 @@ func TestApplicationDeleteWithOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -2335,5 +2412,6 @@ func checkAllApplicationsBelongToTenant(tenantId int64, apps []interface{}) erro
 			}
 		}
 	}
+
 	return nil
 }

--- a/application_type_handlers.go
+++ b/application_type_handlers.go
@@ -16,7 +16,6 @@ var getApplicationTypeDao func(c echo.Context) (dao.ApplicationTypeDao, error)
 
 func getApplicationTypeDaoWithTenant(c echo.Context) (dao.ApplicationTypeDao, error) {
 	tenantId, err := echoUtils.GetTenantFromEchoContext(c)
-
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +54,6 @@ func SourceListApplicationTypes(c echo.Context) error {
 	}
 
 	appTypes, count, err = applicationTypeDB.SubCollectionList(m.Source{ID: id}, limit, offset, filters)
-
 	if err != nil {
 		return err
 	}
@@ -92,7 +90,6 @@ func ApplicationTypeList(c echo.Context) error {
 	)
 
 	appTypes, count, err = applicationTypeDB.List(limit, offset, filters)
-
 	if err != nil {
 		return err
 	}
@@ -119,7 +116,6 @@ func ApplicationTypeGet(c echo.Context) error {
 	}
 
 	appType, err := applicationTypeDB.GetById(&id)
-
 	if err != nil {
 		return err
 	}

--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -43,6 +43,7 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -59,6 +60,7 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 	// We are looking for source's applications and then application
 	// types of these applications
 	appTypes := make(map[int64]int)
+
 	for _, app := range fixtures.TestApplicationData {
 		if app.SourceID == sourceId {
 			appTypes[app.ApplicationTypeID]++
@@ -116,6 +118,7 @@ func TestSourceApplicationTypeSubcollectionListEmptyList(t *testing.T) {
 // for not existing tenant
 func TestSourceApplicationTypeSubcollectionListTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
@@ -135,6 +138,7 @@ func TestSourceApplicationTypeSubcollectionListTenantNotExist(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceListApplicationTypes := ErrorHandlingContext(SourceListApplicationTypes)
+
 	err := notFoundSourceListApplicationTypes(c)
 	if err != nil {
 		t.Error(err)
@@ -147,6 +151,7 @@ func TestSourceApplicationTypeSubcollectionListTenantNotExist(t *testing.T) {
 // for tenant who doesn't own the source
 func TestSourceApplicationTypeSubcollectionListInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	sourceId := int64(1)
 
@@ -166,6 +171,7 @@ func TestSourceApplicationTypeSubcollectionListInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceListApplicationTypes := ErrorHandlingContext(SourceListApplicationTypes)
+
 	err := notFoundSourceListApplicationTypes(c)
 	if err != nil {
 		t.Error(err)
@@ -191,6 +197,7 @@ func TestSourceApplicationTypeSubcollectionListNotFound(t *testing.T) {
 	c.SetParamValues("109830938")
 
 	notFoundSourceListApplicationTypes := ErrorHandlingContext(SourceListApplicationTypes)
+
 	err := notFoundSourceListApplicationTypes(c)
 	if err != nil {
 		t.Error(err)
@@ -216,6 +223,7 @@ func TestSourceApplicationTypeSubcollectionListBadRequestInvalidSyntax(t *testin
 	c.SetParamValues("xxx")
 
 	badRequestSourceListApplicationTypes := ErrorHandlingContext(SourceListApplicationTypes)
+
 	err := badRequestSourceListApplicationTypes(c)
 	if err != nil {
 		t.Error(err)
@@ -245,6 +253,7 @@ func TestSourceApplicationTypeSubcollectionListBadRequestInvalidFilter(t *testin
 	c.SetParamValues("1")
 
 	badRequestSourceListApplicationTypes := ErrorHandlingContext(SourceListApplicationTypes)
+
 	err := badRequestSourceListApplicationTypes(c)
 	if err != nil {
 		t.Error(err)
@@ -275,6 +284,7 @@ func TestApplicationTypeList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -349,6 +359,7 @@ func TestApplicationTypeListBadRequestInvalidFilter(t *testing.T) {
 	)
 
 	badRequestApplicationTypeList := ErrorHandlingContext(ApplicationTypeList)
+
 	err := badRequestApplicationTypeList(c)
 	if err != nil {
 		t.Error(err)
@@ -378,6 +389,7 @@ func TestApplicationTypeGet(t *testing.T) {
 	}
 
 	var outAppType m.ApplicationTypeResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &outAppType)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -414,6 +426,7 @@ func TestApplicationTypeGetWithTenant(t *testing.T) {
 	}
 
 	var outAppType m.ApplicationTypeResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &outAppType)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -436,6 +449,7 @@ func TestApplicationTypeGetNotFound(t *testing.T) {
 	c.SetParamValues("12362095")
 
 	notFoundApplicationTypeGet := ErrorHandlingContext(ApplicationTypeGet)
+
 	err := notFoundApplicationTypeGet(c)
 	if err != nil {
 		t.Error(err)
@@ -456,6 +470,7 @@ func TestApplicationTypeGetBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestApplicationTypeGet := ErrorHandlingContext(ApplicationTypeGet)
+
 	err := badRequestApplicationTypeGet(c)
 	if err != nil {
 		t.Error(err)

--- a/authentication_handlers.go
+++ b/authentication_handlers.go
@@ -44,6 +44,7 @@ func AuthenticationList(c echo.Context) error {
 	}
 
 	tenantId := authDao.Tenant()
+
 	out := make([]interface{}, 0, len(authentications))
 	for _, auth := range authentications {
 		// Set the marketplace token —if the auth is of the marketplace type— for the authentication.
@@ -71,6 +72,7 @@ func AuthenticationGet(c echo.Context) error {
 
 	// Set the marketplace token —if the auth is of the marketplace type— for the authentication.
 	tenantId := authDao.Tenant()
+
 	err = marketplace.SetMarketplaceTokenAuthExtraField(*tenantId, auth)
 	if err != nil {
 		return err
@@ -86,6 +88,7 @@ func AuthenticationCreate(c echo.Context) error {
 	}
 
 	createRequest := m.AuthenticationCreateRequest{}
+
 	err = c.Bind(&createRequest)
 	if err != nil {
 		return err
@@ -121,6 +124,7 @@ func AuthenticationCreate(c echo.Context) error {
 
 	// Set the marketplace token —if the auth is of the marketplace type— for the authentication.
 	tenantId := authDao.Tenant()
+
 	err = marketplace.SetMarketplaceTokenAuthExtraField(*tenantId, auth)
 	if err != nil {
 		return err
@@ -133,6 +137,7 @@ func AuthenticationCreate(c echo.Context) error {
 
 	auth.Tenant = m.Tenant{Id: auth.TenantID, ExternalTenant: accountNumber}
 	setEventStreamResource(c, auth)
+
 	return c.JSON(http.StatusCreated, auth.ToResponse())
 }
 
@@ -143,6 +148,7 @@ func AuthenticationEdit(c echo.Context) error {
 	}
 
 	updateRequest := &m.AuthenticationEditRequest{}
+
 	err = c.Bind(updateRequest)
 	if err != nil {
 		return err
@@ -162,6 +168,7 @@ func AuthenticationEdit(c echo.Context) error {
 	if auth.AvailabilityStatus != nil {
 		previousStatus = *auth.AvailabilityStatus
 	}
+
 	err = auth.UpdateFromRequest(updateRequest)
 	if err != nil {
 		return util.NewErrBadRequest(`invalid JSON given in "extra" field`)
@@ -181,10 +188,12 @@ func AuthenticationEdit(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
 	auth.Source = *source
 
 	// Set the marketplace token —if the auth is of the marketplace type— for the authentication.
 	tenantId := authDao.Tenant()
+
 	err = marketplace.SetMarketplaceTokenAuthExtraField(*tenantId, auth)
 	if err != nil {
 		return err
@@ -192,6 +201,7 @@ func AuthenticationEdit(c echo.Context) error {
 
 	setNotificationForAvailabilityStatus(c, previousStatus, auth)
 	setEventStreamResource(c, auth)
+
 	return c.JSON(http.StatusOK, auth.ToResponse())
 }
 
@@ -208,11 +218,13 @@ func AuthenticationDelete(c echo.Context) error {
 
 	// Set the marketplace token —if the auth is of the marketplace type— for the authentication.
 	tenantId := authDao.Tenant()
+
 	err = marketplace.SetMarketplaceTokenAuthExtraField(*tenantId, auth)
 	if err != nil {
 		return err
 	}
 
 	setEventStreamResource(c, auth)
+
 	return c.NoContent(http.StatusNoContent)
 }

--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -53,6 +53,7 @@ func TestAuthenticationList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -67,6 +68,7 @@ func TestAuthenticationList(t *testing.T) {
 	}
 
 	var wantCount int
+
 	for _, a := range fixtures.TestAuthenticationData {
 		if a.TenantID == tenantId {
 			wantCount++
@@ -118,6 +120,7 @@ func TestAuthenticationList(t *testing.T) {
 // for not existing tenant
 func TestAuthenticationTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 
 	c, rec := request.CreateTestContext(
@@ -144,6 +147,7 @@ func TestAuthenticationTenantNotExist(t *testing.T) {
 // for a tenant without authentications
 func TestAuthenticationTenantWithoutAuthentications(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 
 	c, rec := request.CreateTestContext(
@@ -168,6 +172,7 @@ func TestAuthenticationTenantWithoutAuthentications(t *testing.T) {
 
 func TestAuthenticationListBadRequestInvalidFilter(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 
 	c, rec := request.CreateTestContext(
@@ -185,6 +190,7 @@ func TestAuthenticationListBadRequestInvalidFilter(t *testing.T) {
 	)
 
 	badRequestAuthenticationList := ErrorHandlingContext(AuthenticationList)
+
 	err := badRequestAuthenticationList(c)
 	if err != nil {
 		t.Error(err)
@@ -202,6 +208,7 @@ func TestAuthenticationGet(t *testing.T) {
 		conf.SecretStore = s
 
 		var id string
+
 		if config.IsVaultOn() {
 			conf.SecretStore = "vault"
 			id = fixtures.TestAuthenticationData[0].ID
@@ -231,6 +238,7 @@ func TestAuthenticationGet(t *testing.T) {
 		}
 
 		var outAuthentication m.AuthenticationResponse
+
 		err = json.Unmarshal(rec.Body.Bytes(), &outAuthentication)
 		if err != nil {
 			t.Error("Failed unmarshaling output")
@@ -253,6 +261,7 @@ func TestAuthenticationGet(t *testing.T) {
 				if a.TenantID != tenantId {
 					t.Error("ghosts infected the return")
 				}
+
 				break
 			}
 		}
@@ -263,6 +272,7 @@ func TestAuthenticationGet(t *testing.T) {
 
 func TestAuthenticationGetTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	uid := strconv.FormatInt(fixtures.TestAuthenticationData[0].DbID, 10)
 
@@ -279,6 +289,7 @@ func TestAuthenticationGetTenantNotExist(t *testing.T) {
 	c.SetParamValues(uid)
 
 	notFoundAuthenticationGet := ErrorHandlingContext(AuthenticationGet)
+
 	err := notFoundAuthenticationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -303,6 +314,7 @@ func TestAuthenticationGetNotFound(t *testing.T) {
 	c.SetParamValues(uid)
 
 	notFoundAuthenticationGet := ErrorHandlingContext(AuthenticationGet)
+
 	err := notFoundAuthenticationGet(c)
 	if err != nil {
 		t.Error(err)
@@ -355,6 +367,7 @@ func TestAuthenticationCreate(t *testing.T) {
 
 		auth := m.AuthenticationResponse{}
 		raw, _ := io.ReadAll(rec.Body)
+
 		err = json.Unmarshal(raw, &auth)
 		if err != nil {
 			t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -379,10 +392,12 @@ func TestAuthenticationCreate(t *testing.T) {
 		if parser.RunningIntegrationTests {
 			requestParams := dao.RequestParams{TenantID: &tenantId}
 			authenticationDao := dao.GetAuthenticationDao(&requestParams)
+
 			authOut, err := authenticationDao.GetById(auth.ID)
 			if err != nil {
 				t.Error(err)
 			}
+
 			if authOut.TenantID != tenantId {
 				t.Errorf("authentication's tenant id = %d, expected %d", authOut.TenantID, tenantId)
 			}
@@ -419,6 +434,7 @@ func TestAuthenticationCreateBadRequestInvalidResourceType(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestAuthenticationCreate := ErrorHandlingContext(AuthenticationCreate)
+
 	err = badRequestAuthenticationCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -431,10 +447,10 @@ func TestAuthenticationCreateBadRequestInvalidResourceType(t *testing.T) {
 // you try to create authentication for not existing resource
 func TestAuthenticationCreateResourceNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 
 	for _, resourceType := range []string{"Application", "Endpoint", "Source"} {
-
 		requestBody := m.AuthenticationCreateRequest{
 			Username:      util.StringRef("testUser"),
 			Password:      util.StringRef("123456"),
@@ -458,6 +474,7 @@ func TestAuthenticationCreateResourceNotFound(t *testing.T) {
 		c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 		badRequestAuthenticationCreate := ErrorHandlingContext(AuthenticationCreate)
+
 		err = badRequestAuthenticationCreate(c)
 		if err != nil {
 			t.Error(err)
@@ -469,7 +486,9 @@ func TestAuthenticationCreateResourceNotFound(t *testing.T) {
 
 func TestAuthenticationEdit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
+
 	var uid string
 	if config.IsVaultOn() {
 		uid = fixtures.TestAuthenticationData[0].ID
@@ -506,6 +525,7 @@ func TestAuthenticationEdit(t *testing.T) {
 	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	authEditHandlerWithNotifier := middleware.Notifier(AuthenticationEdit)
+
 	err = authEditHandlerWithNotifier(c)
 	if err != nil {
 		t.Error(err)
@@ -517,6 +537,7 @@ func TestAuthenticationEdit(t *testing.T) {
 
 	auth := m.AuthenticationResponse{}
 	raw, _ := io.ReadAll(rec.Body)
+
 	err = json.Unmarshal(raw, &auth)
 	if err != nil {
 		t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -547,6 +568,7 @@ func TestAuthenticationEdit(t *testing.T) {
 	// Check the tenancy of edited authentication
 	requestParams := dao.RequestParams{TenantID: &tenantId}
 	authDao := dao.GetAuthenticationDao(&requestParams)
+
 	authOut, err := authDao.GetById(uid)
 	if err != nil {
 		t.Error(err)
@@ -563,6 +585,7 @@ func TestAuthenticationEdit(t *testing.T) {
 // edit existing not owned authentication
 func TestAuthenticationEditInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	uid := "1"
 
@@ -589,6 +612,7 @@ func TestAuthenticationEditInvalidTenant(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundAuthenticationEdit := ErrorHandlingContext(AuthenticationEdit)
+
 	err = notFoundAuthenticationEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -623,6 +647,7 @@ func TestAuthenticationEditNotFound(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundAuthenticationEdit := ErrorHandlingContext(AuthenticationEdit)
+
 	err = notFoundAuthenticationEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -656,6 +681,7 @@ func TestAuthenticationEditBadRequest(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestAuthenticationEdit := ErrorHandlingContext(AuthenticationEdit)
+
 	err = badRequestAuthenticationEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -667,6 +693,7 @@ func TestAuthenticationEditBadRequest(t *testing.T) {
 func TestAuthenticationDelete(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	tenantId := int64(1)
 
 	// Create new test data (source + authentication) for the test
@@ -751,7 +778,9 @@ func TestAuthenticationDelete(t *testing.T) {
 // for tenant who doesn't own the authentication
 func TestAuthenticationDeleteInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
+
 	var uid string
 	if config.IsVaultOn() {
 		uid = fixtures.TestAuthenticationData[0].ID
@@ -773,6 +802,7 @@ func TestAuthenticationDeleteInvalidTenant(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundAuthenticationDelete := ErrorHandlingContext(AuthenticationDelete)
+
 	err := notFoundAuthenticationDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -796,6 +826,7 @@ func TestAuthenticationDeleteNotFound(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundAuthenticationDelete := ErrorHandlingContext(AuthenticationDelete)
+
 	err := notFoundAuthenticationDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -819,5 +850,6 @@ func checkAllAuthenticationsBelongToTenant(tenantId int64, authentications []int
 			}
 		}
 	}
+
 	return nil
 }

--- a/bulk_handlers.go
+++ b/bulk_handlers.go
@@ -13,6 +13,7 @@ import (
 
 func BulkCreate(c echo.Context) error {
 	req := m.BulkCreateRequest{}
+
 	err := c.Bind(&req)
 	if err != nil {
 		return err
@@ -27,6 +28,7 @@ func BulkCreate(c echo.Context) error {
 	if !ok {
 		c.Logger().Warnf("bad xrhid %v", c.Get(h.XRHID))
 	}
+
 	id, ok := c.Get(h.ParsedIdentity).(*identity.XRHID)
 	if !ok {
 		c.Logger().Warnf("failed to pull identity from request")

--- a/bulk_handlers_test.go
+++ b/bulk_handlers_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestBulkCreateMissingSourceType(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	nameSource := "test"
 	bulkCreateSource := m.BulkCreateSource{SourceCreateRequest: m.SourceCreateRequest{Name: &nameSource}}
 	requestBody := m.BulkCreateRequest{Sources: []m.BulkCreateSource{bulkCreateSource}}
@@ -93,12 +94,14 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 	c.Set(h.ParsedIdentity, identityHeader)
 
 	var user m.User
+
 	err = dao.DB.Model(&m.User{}).Where("user_id = ?", testUserId).First(&user).Error
 	if err.Error() != "record not found" {
 		t.Error(err)
 	}
 
 	bulkCreate := middleware.UserCatcher(BulkCreate)
+
 	err = bulkCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -114,6 +117,7 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 	}
 
 	var source m.Source
+
 	err = dao.DB.Model(&m.Source{}).Where("name = ?", nameSource).First(&source).Error
 	if err != nil {
 		t.Error(err)
@@ -124,12 +128,14 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 	}
 
 	var response m.BulkCreateResponse
+
 	err = json.Unmarshal(res.Body.Bytes(), &response)
 	if err != nil {
 		t.Error(err)
 	}
 
 	var application m.Application
+
 	err = dao.DB.Model(&m.Application{}).Where("id = ?", response.Applications[0].ID).First(&application).Error
 	if err != nil {
 		t.Error(err)
@@ -140,6 +146,7 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 	}
 
 	var authentication m.Authentication
+
 	err = dao.DB.Model(&m.Authentication{}).Where("id = ?", response.Authentications[0].ID).First(&authentication).Error
 	if err != nil {
 		t.Error(err)
@@ -150,6 +157,7 @@ func TestBulkCreateWithUserCreation(t *testing.T) {
 	}
 
 	var applicationAuthentication m.ApplicationAuthentication
+
 	err = dao.DB.Model(&m.ApplicationAuthentication{}).
 		Where("application_id = ? AND authentication_id = ?", response.Applications[0].ID, response.Authentications[0].ID).
 		Find(&applicationAuthentication).Error
@@ -208,6 +216,7 @@ func TestBulkCreate(t *testing.T) {
 	}
 
 	var response m.BulkCreateResponse
+
 	err = json.Unmarshal(res.Body.Bytes(), &response)
 	if err != nil {
 		t.Error(err)
@@ -245,6 +254,7 @@ func TestBulkCreate(t *testing.T) {
 
 func TestBulkCreateSourceValidationBadRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 
 	// Create a source
@@ -289,6 +299,7 @@ func TestBulkCreateSourceValidationBadRequest(t *testing.T) {
 	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	badRequestBulkCreate := ErrorHandlingContext(BulkCreate)
+
 	err = badRequestBulkCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -301,6 +312,7 @@ func TestBulkCreateSourceValidationBadRequest(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	if deletedSource.ID != src.ID {
 		t.Error("wrong source deleted")
 	}
@@ -308,6 +320,7 @@ func TestBulkCreateSourceValidationBadRequest(t *testing.T) {
 
 func cleanSourceForTenant(sourceName string, tenantID *int64) error {
 	source := &m.Source{Name: sourceName}
+
 	err := dao.DB.Model(&m.Source{}).Where("name = ?", source.Name).Find(&source).Error
 	if err != nil {
 		return err

--- a/config/config.go
+++ b/config/config.go
@@ -103,6 +103,7 @@ func (s SourcesApiConfig) String() string {
 	fmt.Fprintf(&b, "%s=%v ", "SecretsManagerPrefix", parsedConfig.SecretsManagerPrefix)
 	fmt.Fprintf(&b, "%s=%v ", "LocalStackURL", parsedConfig.LocalStackURL)
 	fmt.Fprintf(&b, "%s=%v ", "RbacHost", parsedConfig.RbacHost)
+
 	return b.String()
 }
 
@@ -123,6 +124,7 @@ func Get() *SourcesApiConfig {
 		for requestedName, topicConfig := range clowder.KafkaTopics {
 			kafkaTopics[requestedName] = topicConfig.Name
 		}
+
 		options.SetDefault("AwsRegion", cfg.Logging.Cloudwatch.Region)
 		options.SetDefault("AwsAccessKeyId", cfg.Logging.Cloudwatch.AccessKeyId)
 		options.SetDefault("AwsSecretAccessKey", cfg.Logging.Cloudwatch.SecretAccessKey)
@@ -171,6 +173,7 @@ func Get() *SourcesApiConfig {
 			if cfg.FeatureFlags.ClientAccessToken != nil {
 				clientAccessToken = *cfg.FeatureFlags.ClientAccessToken
 			}
+
 			options.SetDefault("FeatureFlagsAPIToken", clientAccessToken)
 		}
 
@@ -221,6 +224,7 @@ func Get() *SourcesApiConfig {
 		} else {
 			options.SetDefault("DatabaseName", "sources_api_development")
 		}
+
 		options.SetDefault("DatabaseSSLMode", "disable")
 
 		options.SetDefault("CacheHost", os.Getenv("REDIS_CACHE_HOST"))
@@ -312,6 +316,7 @@ func Get() *SourcesApiConfig {
 
 	// Grab the Kafka Sasl Settings.
 	var brokerConfig []clowder.BrokerConfig
+
 	bcRaw, ok := options.Get("KafkaBrokerConfig").([]clowder.BrokerConfig)
 	if ok {
 		brokerConfig = bcRaw

--- a/dao/application_authentication_dao.go
+++ b/dao/application_authentication_dao.go
@@ -65,7 +65,6 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByApplicati
 		Where("tenant_id = ?", a.TenantID).
 		Find(&applicationAuthentications).
 		Error
-
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +104,6 @@ func (a *applicationAuthenticationDaoImpl) ApplicationAuthenticationsByAuthentic
 		Where("tenant_id = ?", a.TenantID).
 		Find(&applicationAuthentications).
 		Error
-
 	if err != nil {
 		return nil, err
 	}
@@ -137,6 +135,7 @@ func (a *applicationAuthenticationDaoImpl) List(limit int, offset int, filters [
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}
+
 	return appAuths, count, nil
 }
 
@@ -147,7 +146,6 @@ func (a *applicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAut
 		Where("id = ?", *id).
 		First(&appAuth).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("application authentication")
 	}
@@ -157,6 +155,7 @@ func (a *applicationAuthenticationDaoImpl) GetById(id *int64) (*m.ApplicationAut
 
 func (a *applicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthentication) error {
 	appAuth.TenantID = *a.TenantID
+
 	err := DB.Debug().Create(appAuth).Error
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *a.TenantID}).Errorf(`Unable to create application authentication: %s`, err)
@@ -170,7 +169,6 @@ func (a *applicationAuthenticationDaoImpl) Create(appAuth *m.ApplicationAuthenti
 
 func (a *applicationAuthenticationDaoImpl) Update(appAuth *m.ApplicationAuthentication) error {
 	err := a.getDb().Updates(appAuth).Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *a.TenantID, "application_authentication_id": appAuth.ID}).Errorf(`Unable to update application authentication: %s`, err)
 

--- a/dao/application_authentication_dao_test.go
+++ b/dao/application_authentication_dao_test.go
@@ -44,8 +44,8 @@ func TestDeleteApplicationAuthenticationNotExists(t *testing.T) {
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	nonExistentId := int64(12345)
-	_, err := applicationAuthenticationDao.Delete(&nonExistentId)
 
+	_, err := applicationAuthenticationDao.Delete(&nonExistentId)
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
@@ -62,8 +62,10 @@ func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 
 	tenantId := int64(1)
 
-	var apps []model.Application
-	var appAuthsWant []model.ApplicationAuthentication
+	var (
+		apps         []model.Application
+		appAuthsWant []model.ApplicationAuthentication
+	)
 
 	for _, appAuth := range fixtures.TestApplicationAuthenticationData {
 		if appAuth.TenantID == tenantId {
@@ -74,6 +76,7 @@ func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 
 	daoParams := RequestParams{TenantID: &tenantId}
 	appAuthDao := GetApplicationAuthenticationDao(&daoParams)
+
 	appAuthsOut, err := appAuthDao.ApplicationAuthenticationsByResource("Source", apps, nil)
 	if err != nil {
 		t.Error(err)
@@ -86,12 +89,14 @@ func TestApplicationAuthenticationsByApplicationsDatabase(t *testing.T) {
 	// Check the IDs of returned app auths
 	for _, aaOut := range appAuthsOut {
 		var aaFound bool
+
 		for _, aaWant := range appAuthsWant {
 			if aaWant.ID == aaOut.ID {
 				aaFound = true
 				break
 			}
 		}
+
 		if !aaFound {
 			t.Errorf("application authentication with id = %d returned as output but was not expected", aaOut.ID)
 		}
@@ -115,8 +120,11 @@ func TestApplicationAuthenticationsByAuthenticationsDatabase(t *testing.T) {
 	maxCreatedAuths := 5
 
 	// Store both the authentications and the application authentications for later.
-	var createdAuths = make([]model.Authentication, 0, maxCreatedAuths)
-	var createdAppAuths = make([]model.ApplicationAuthentication, 0, maxCreatedAuths)
+	var (
+		createdAuths    = make([]model.Authentication, 0, maxCreatedAuths)
+		createdAppAuths = make([]model.ApplicationAuthentication, 0, maxCreatedAuths)
+	)
+
 	for i := 0; i < maxCreatedAuths; i++ {
 		// Create the authentication.
 		auth := setUpValidAuthentication()
@@ -205,6 +213,7 @@ func TestApplicationAuthenticationListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(appAuths)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -213,16 +222,19 @@ func TestApplicationAuthenticationListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
 func TestApplicationAuthenticationListUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -233,6 +245,7 @@ func TestApplicationAuthenticationListUserOwnership(t *testing.T) {
 
 	applicationTypeID := fixtures.TestApplicationTypeData[3].Id
 	sourceTypeID := fixtures.TestSourceTypeData[2].Id
+
 	recordsWithUserID, user, err := CreateSourceWithSubResources(sourceTypeID, applicationTypeID, accountNumber, &userIDWithOwnRecords)
 	if err != nil {
 		t.Errorf("unable to create source: %v", err)
@@ -307,6 +320,7 @@ func TestApplicationAuthenticationListUserOwnership(t *testing.T) {
 func TestApplicationAuthenticationGetUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -315,6 +329,7 @@ func TestApplicationAuthenticationGetUserOwnership(t *testing.T) {
 		   Test 1 - UserA tries to GET userA's application authentication - expected result: success
 		*/
 		applicationAuthenticationDaoUserA := GetApplicationAuthenticationDao(suiteData.GetRequestParamsUserA())
+
 		applicationAuthenticationUserA, err := applicationAuthenticationDaoUserA.GetById(&suiteData.ApplicationAuthenticationUserA().ID)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the application authentication: %s`, err)
@@ -353,7 +368,6 @@ func TestApplicationAuthenticationGetUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -364,6 +378,7 @@ func TestApplicationAuthenticationGetUserOwnership(t *testing.T) {
 func TestApplicationAuthenticationDeleteUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -372,6 +387,7 @@ func TestApplicationAuthenticationDeleteUserOwnership(t *testing.T) {
 		  Test 1 - UserA tries to delete application authentication for userA - expected result: success
 		*/
 		applicationAuthenticationDaoUserA := GetApplicationAuthenticationDao(suiteData.GetRequestParamsUserA())
+
 		_, err := applicationAuthenticationDaoUserA.Delete(&suiteData.ApplicationAuthenticationUserA().ID)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Delete: %v`, err)
@@ -407,6 +423,7 @@ func TestApplicationAuthenticationDeleteUserOwnership(t *testing.T) {
 		}
 
 		applicationAuthenticationDaoUserB := GetApplicationAuthenticationDao(suiteData.GetRequestParamsUserB())
+
 		_, err = applicationAuthenticationDaoUserB.GetById(&suiteData.ApplicationAuthenticationUserB().ID)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById: %v`, err)
@@ -414,7 +431,6 @@ func TestApplicationAuthenticationDeleteUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}

--- a/dao/application_dao.go
+++ b/dao/application_dao.go
@@ -75,6 +75,7 @@ func (a *applicationDaoImpl) getDbWithModel() *gorm.DB {
 
 func (a *applicationDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.Application, int64, error) {
 	applications := make([]m.Application, 0, limit)
+
 	relationObject, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
 		return nil, 0, err
@@ -95,6 +96,7 @@ func (a *applicationDaoImpl) SubCollectionList(primaryCollection interface{}, li
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}
+
 	return applications, count, nil
 }
 
@@ -117,6 +119,7 @@ func (a *applicationDaoImpl) List(limit int, offset int, filters []util.Filter) 
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}
+
 	return applications, count, nil
 }
 
@@ -127,7 +130,6 @@ func (a *applicationDaoImpl) GetById(id *int64) (*m.Application, error) {
 		Where("id = ?", *id).
 		First(&app).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("application")
 	}
@@ -145,10 +147,10 @@ func (a *applicationDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (
 	}
 
 	var app m.Application
+
 	err := q.
 		First(&app).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("application")
 	}
@@ -183,7 +185,6 @@ func (a *applicationDaoImpl) Create(app *m.Application) error {
 
 func (a *applicationDaoImpl) Update(app *m.Application) error {
 	err := a.getDb().Omit(clause.Associations).Updates(app).Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *a.TenantID, "source_id": app.SourceID, "application_id": app.ID}).Errorf("Unable to update application: %s", err)
 
@@ -252,7 +253,6 @@ func (a *applicationDaoImpl) BulkMessage(resource util.Resource) (map[string]int
 		Preload("Source").
 		Find(&application).
 		Error
-
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,6 @@ func (a *applicationDaoImpl) Pause(id int64) error {
 		Where("id = ?", id).
 		Update("paused_at", time.Now()).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *a.TenantID, "application_id": id}).Errorf("Unable to pause application: %s", err)
 
@@ -322,7 +321,6 @@ func (a *applicationDaoImpl) Unpause(id int64) error {
 		Where("id = ?", id).
 		Update("paused_at", nil).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *a.TenantID, "application_id": id}).Errorf("Unable to resume application: %s", err)
 
@@ -335,8 +333,10 @@ func (a *applicationDaoImpl) Unpause(id int64) error {
 }
 
 func (a *applicationDaoImpl) DeleteCascade(applicationId int64) ([]m.ApplicationAuthentication, *m.Application, error) {
-	var applicationAuthentications []m.ApplicationAuthentication
-	var application *m.Application
+	var (
+		applicationAuthentications []m.ApplicationAuthentication
+		application                *m.Application
+	)
 
 	// The application authentications are fetched with the "Tenant" table preloaded, so that all the objects are
 	// returned with the "external_tenant" column populated. This is required to be able to raise events with the
@@ -356,7 +356,6 @@ func (a *applicationDaoImpl) DeleteCascade(applicationId int64) ([]m.Application
 				Where("tenant_id = ?", a.TenantID).
 				Find(&applicationAuthentications).
 				Error
-
 			if err != nil {
 				return err
 			}
@@ -365,7 +364,6 @@ func (a *applicationDaoImpl) DeleteCascade(applicationId int64) ([]m.Application
 				err = tx.
 					Delete(&applicationAuthentications).
 					Error
-
 				if err != nil {
 					logger.Log.WithFields(logrus.Fields{"tenant_id": *a.TenantID, "application_id": applicationId}).Errorf("Unable to cascade delete application: unable to delete application authentications: %s", err)
 
@@ -419,7 +417,6 @@ func (a *applicationDaoImpl) Exists(applicationId int64) (bool, error) {
 		Where("id = ?", applicationId).
 		Scan(&applicationExists).
 		Error
-
 	if err != nil {
 		return false, err
 	}

--- a/dao/application_dao_test.go
+++ b/dao/application_dao_test.go
@@ -23,6 +23,7 @@ func TestPausingApplication(t *testing.T) {
 	SwitchSchema("pause_unpause")
 
 	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	err := applicationDao.Pause(testApplication.ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -47,8 +48,8 @@ func TestResumeApplication(t *testing.T) {
 	SwitchSchema("pause_unpause")
 
 	applicationDao := GetApplicationDao(&RequestParams{TenantID: &testApplication.TenantID})
-	err := applicationDao.Unpause(testApplication.ID)
 
+	err := applicationDao.Unpause(testApplication.ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
@@ -123,8 +124,8 @@ func TestDeleteApplicationNotExists(t *testing.T) {
 	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
 
 	nonExistentId := int64(12345)
-	_, err := applicationDao.Delete(&nonExistentId)
 
+	_, err := applicationDao.Delete(&nonExistentId)
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
@@ -161,6 +162,7 @@ func TestApplicationDeleteCascade(t *testing.T) {
 
 	// Store the application authentications to perform checks later.
 	var createdAppAuths []m.ApplicationAuthentication
+
 	for i := 0; i < maxAuthenticationsCreated; i++ {
 		// Create the authentication.
 		authentication := setUpValidAuthentication()
@@ -195,6 +197,7 @@ func TestApplicationDeleteCascade(t *testing.T) {
 
 	// Count the application authentications from the given application, to check that they were deleted.
 	var appAuthCount int64
+
 	err = DB.
 		Debug().
 		Model(m.ApplicationAuthentication{}).
@@ -202,7 +205,6 @@ func TestApplicationDeleteCascade(t *testing.T) {
 		Where("tenant_id = ?", tenantId).
 		Count(&appAuthCount).
 		Error
-
 	if err != nil {
 		t.Errorf(`error counting the application authentications related to the application: %s`, err)
 	}
@@ -210,6 +212,7 @@ func TestApplicationDeleteCascade(t *testing.T) {
 	// Check if the application authentications were deleted or not.
 	{
 		want := int64(0)
+
 		got := appAuthCount
 		if want != got {
 			t.Errorf(`the application authentications were not deleted. Want a count of "%d", got "%d"`, want, got)
@@ -240,6 +243,7 @@ func TestApplicationDeleteCascade(t *testing.T) {
 
 	// Try to fetch the deleted application.
 	var deletedApplicationCheck *m.Application
+
 	err = DB.
 		Debug().
 		Model(m.Application{}).
@@ -247,7 +251,6 @@ func TestApplicationDeleteCascade(t *testing.T) {
 		Where(`tenant_id = ?`, tenantId).
 		Find(&deletedApplicationCheck).
 		Error
-
 	if err != nil {
 		t.Errorf(`unexpected error: %s`, err)
 	}
@@ -335,6 +338,7 @@ func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	sourceId := fixtures.TestSourceData[0].ID
 
 	var wantCount int64
+
 	for _, i := range fixtures.TestApplicationData {
 		if i.SourceID == sourceId {
 			wantCount++
@@ -352,6 +356,7 @@ func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(applications)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -360,10 +365,12 @@ func TestApplicationSubcollectionListWithOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
@@ -387,6 +394,7 @@ func TestApplicationListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(applications)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -395,16 +403,19 @@ func TestApplicationListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
 func TestApplicationListUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -415,6 +426,7 @@ func TestApplicationListUserOwnership(t *testing.T) {
 
 	applicationTypeID := fixtures.TestApplicationTypeData[3].Id
 	sourceTypeID := fixtures.TestSourceTypeData[2].Id
+
 	recordsWithUserID, user, err := CreateSourceWithSubResources(sourceTypeID, applicationTypeID, accountNumber, &userIDWithOwnRecords)
 	if err != nil {
 		t.Errorf("unable to create source: %v", err)
@@ -489,6 +501,7 @@ func TestApplicationListUserOwnership(t *testing.T) {
 func TestApplicationIsSuperkeyTrue(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("application_superkey_true")
+
 	defer DropSchema("application_superkey_true")
 
 	src := m.Source{
@@ -499,6 +512,7 @@ func TestApplicationIsSuperkeyTrue(t *testing.T) {
 		TenantID:            fixtures.TestTenantData[0].Id,
 	}
 	srcDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	err := srcDao.Create(&src)
 	if err != nil {
 		t.Error(err)
@@ -510,6 +524,7 @@ func TestApplicationIsSuperkeyTrue(t *testing.T) {
 		TenantID:          fixtures.TestTenantData[0].Id,
 	}
 	appDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	err = appDao.Create(&app)
 	if err != nil {
 		t.Error(err)
@@ -524,6 +539,7 @@ func TestApplicationIsSuperkeyTrue(t *testing.T) {
 func TestApplicationIsSuperkeyFalse(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("application_superkey_false")
+
 	defer DropSchema("application_superkey_false")
 
 	src := m.Source{
@@ -534,6 +550,7 @@ func TestApplicationIsSuperkeyFalse(t *testing.T) {
 		TenantID:            fixtures.TestTenantData[0].Id,
 	}
 	srcDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	err := srcDao.Create(&src)
 	if err != nil {
 		t.Error(err)
@@ -545,6 +562,7 @@ func TestApplicationIsSuperkeyFalse(t *testing.T) {
 		TenantID:          fixtures.TestTenantData[0].Id,
 	}
 	appDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	err = appDao.Create(&app)
 	if err != nil {
 		t.Error(err)
@@ -559,6 +577,7 @@ func TestApplicationIsSuperkeyFalse(t *testing.T) {
 func TestApplicationGetUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -567,6 +586,7 @@ func TestApplicationGetUserOwnership(t *testing.T) {
 		   Test 1 - UserA tries to GET userA's application - expected result: success
 		*/
 		applicationDaoUserA := GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		applicationUserA, err := applicationDaoUserA.GetById(&suiteData.ApplicationUserA().ID)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the application: %s`, err)
@@ -605,7 +625,6 @@ func TestApplicationGetUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -616,6 +635,7 @@ func TestApplicationGetUserOwnership(t *testing.T) {
 func TestApplicationEditUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -627,6 +647,7 @@ func TestApplicationEditUserOwnership(t *testing.T) {
 
 		newAvailabilityStatusError := "new error"
 		newApplicationUserA := &m.Application{ID: suiteData.ApplicationUserA().ID, AvailabilityStatusError: newAvailabilityStatusError}
+
 		err := applicationDaoUserA.Update(newApplicationUserA)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
@@ -645,6 +666,7 @@ func TestApplicationEditUserOwnership(t *testing.T) {
 		   Test 2 - UserA tries to update application without user - expected result: success
 		*/
 		newApplicationNoUser := &m.Application{ID: suiteData.ApplicationNoUser().ID, AvailabilityStatusError: newAvailabilityStatusError}
+
 		err = applicationDaoUserA.Update(newApplicationNoUser)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
@@ -667,12 +689,14 @@ func TestApplicationEditUserOwnership(t *testing.T) {
 
 		newAvailabilityStatusError = "new error"
 		newApplicationUserB := &m.Application{ID: suiteData.ApplicationUserB().ID, AvailabilityStatusError: newAvailabilityStatusError}
+
 		err = applicationDaoWithUser.Update(newApplicationUserB)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
 		}
 
 		applicationDaoUserB := GetApplicationDao(suiteData.GetRequestParamsUserB())
+
 		updatedApplication, err = applicationDaoUserB.GetById(&suiteData.ApplicationUserB().ID)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById: %v`, err)
@@ -684,7 +708,6 @@ func TestApplicationEditUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -701,6 +724,7 @@ func TestPausingApplicationWithOwnership(t *testing.T) {
 		  Test 1 - UserA tries to pause application for userA - expected result: success
 		*/
 		applicationDao := GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		err := applicationDao.Pause(suiteData.ApplicationUserA().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -720,6 +744,7 @@ func TestPausingApplicationWithOwnership(t *testing.T) {
 		  Test 2 - UserA tries to pause application without user - expected result: success
 		*/
 		applicationDao = GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		err = applicationDao.Pause(suiteData.ApplicationNoUser().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -757,7 +782,6 @@ func TestPausingApplicationWithOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -774,6 +798,7 @@ func TestUnpauseApplicationWithOwnership(t *testing.T) {
 		 Test 1 - UserA tries to unpause application for userA - expected result: success
 		*/
 		applicationDao := GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		err := applicationDao.Pause(suiteData.ApplicationUserA().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -797,6 +822,7 @@ func TestUnpauseApplicationWithOwnership(t *testing.T) {
 		  Test 2 - UserA tries to unpause application without user - expected result: success
 		*/
 		applicationDao = GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		err = applicationDao.Pause(suiteData.ApplicationNoUser().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -823,6 +849,7 @@ func TestUnpauseApplicationWithOwnership(t *testing.T) {
 		applicationDaoWithUser := GetApplicationDao(requestParams)
 
 		applicationDaoUserB := GetApplicationDao(suiteData.GetRequestParamsUserB())
+
 		err = applicationDaoUserB.Pause(suiteData.ApplicationUserB().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -844,7 +871,6 @@ func TestUnpauseApplicationWithOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -855,6 +881,7 @@ func TestUnpauseApplicationWithOwnership(t *testing.T) {
 func TestApplicationSubcollectionWithUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -863,6 +890,7 @@ func TestApplicationSubcollectionWithUserOwnership(t *testing.T) {
 		 Test 1- UserA tries to GET userA's application of certain source - expected result: success
 		*/
 		applicationDaoUserA := GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		applications, _, err := applicationDaoUserA.SubCollectionList(*suiteData.SourceUserA(), 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling SubCollectionList for the source: %s`, err)
@@ -886,6 +914,7 @@ func TestApplicationSubcollectionWithUserOwnership(t *testing.T) {
 		  Test 2 - UserA tries to GET applications of certain source without ownership - expected result: success
 		*/
 		applicationDaoUserA = GetApplicationDao(suiteData.GetRequestParamsUserA())
+
 		applications, _, err = applicationDaoUserA.SubCollectionList(*suiteData.SourceNoUser(), 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling SubCollectionList for the source: %s`, err)
@@ -910,6 +939,7 @@ func TestApplicationSubcollectionWithUserOwnership(t *testing.T) {
 		*/
 		requestParams := &RequestParams{TenantID: suiteData.TenantID(), UserID: &suiteData.userWithoutOwnershipRecords.Id}
 		applicationsDaoWithUser := GetApplicationDao(requestParams)
+
 		applications, _, err = applicationsDaoWithUser.SubCollectionList(*suiteData.SourceUserA(), 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling SubCollectionList: %s`, err)
@@ -921,7 +951,6 @@ func TestApplicationSubcollectionWithUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}

--- a/dao/application_type_dao.go
+++ b/dao/application_type_dao.go
@@ -89,7 +89,6 @@ func (at *applicationTypeDaoImpl) GetById(id *int64) (*m.ApplicationType, error)
 		Where("id = ?", *id).
 		First(&appType).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("application type")
 	}
@@ -106,11 +105,13 @@ func (at *applicationTypeDaoImpl) GetByName(name string) (*m.ApplicationType, er
 	if result.Error != nil {
 		return nil, result.Error
 	}
+
 	if result.RowsAffected > int64(1) {
 		return nil, util.NewErrBadRequest("Found more than one of the same application type name")
 	} else if result.RowsAffected == int64(0) {
 		return nil, util.NewErrNotFound("application type")
 	}
+
 	return &appTypes[0], nil
 }
 
@@ -137,7 +138,6 @@ func (at *applicationTypeDaoImpl) ApplicationTypeCompatibleWithSource(typeId, so
 		Preload("SourceType").
 		Find(&source).
 		Error
-
 	if err != nil {
 		return fmt.Errorf("source not found")
 	}

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -20,11 +20,13 @@ func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
 	sourceId := int64(1)
 
 	var appTypeList []int64
+
 	for _, app := range fixtures.TestApplicationData {
 		if app.SourceID == sourceId {
 			appTypeList = append(appTypeList, app.ApplicationTypeID)
 		}
 	}
+
 	wantCount := int64(len(appTypeList))
 
 	for _, d := range fixtures.TestDataOffsetLimit {
@@ -38,6 +40,7 @@ func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(appTypes)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -46,10 +49,12 @@ func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
@@ -73,6 +78,7 @@ func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(appTypes)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -81,20 +87,24 @@ func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
 func TestApplicationTypeGetByName(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("app_type_by_name")
+
 	wantAppType := fixtures.TestApplicationTypeData[1]
 
 	tenantId := int64(1)
 	appTypeDao := GetApplicationTypeDao(&tenantId)
+
 	gotAppType, err := appTypeDao.GetByName(wantAppType.Name)
 	if err != nil {
 		t.Error(err)
@@ -110,6 +120,7 @@ func TestApplicationTypeGetByName(t *testing.T) {
 func TestApplicationTypeGetByNameNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("app_type_by_name")
+
 	wantAppType := m.ApplicationType{Name: "not existing name"}
 
 	tenantId := int64(1)
@@ -129,6 +140,7 @@ func TestApplicationTypeGetByNameNotFound(t *testing.T) {
 func TestApplicationTypeGetByNameBadRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("app_type_by_name")
+
 	wantAppType := m.ApplicationType{Name: "app type"}
 	tenantId := int64(1)
 	appTypeDao := GetApplicationTypeDao(&tenantId)

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -49,6 +49,7 @@ func TestAuthFromVault(t *testing.T) {
 	if !ok {
 		t.Errorf(`wrong type for the secret's data object. Want "map[string]interface{}", got "%s"'`, reflect.TypeOf(vaultData["data"]))
 	}
+
 	data["last_available_at"] = authentication.LastAvailableAt.Format(time.RFC3339Nano)
 	data["last_checked_at"] = authentication.LastCheckedAt.Format(time.RFC3339Nano)
 	// setting the password manually due to the fact that it can be null therefore not in the db. and if it _were_ in
@@ -80,6 +81,7 @@ func TestAuthFromVault(t *testing.T) {
 	} else {
 		{
 			want := data["name"]
+
 			got := *resultingAuth.Name
 			if want != got {
 				t.Errorf(`authentication names are different. Want "%v", got "%v"`, want, got)
@@ -88,6 +90,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := authentication.AuthType
+
 			got := resultingAuth.AuthType
 			if want != got {
 				t.Errorf(`authentication types are different. Want "%s", got "%s"`, want, got)
@@ -96,6 +99,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := data["username"]
+
 			got := *resultingAuth.Username
 			if want != got {
 				t.Errorf(`authentication usernames are different. Want "%v", got "%v"`, want, got)
@@ -104,6 +108,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := data["password"]
+
 			got := *resultingAuth.Password
 			if want != got {
 				t.Errorf(`authentication passwords are different. Want "%v", got "%v"`, want, got)
@@ -112,6 +117,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := authentication.ResourceType
+
 			got := resultingAuth.ResourceType
 			if want != got {
 				t.Errorf(`authentication resoource types are different. Want "%s", got "%s"`, want, got)
@@ -120,6 +126,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := authentication.ResourceID
+
 			got := resultingAuth.ResourceID
 			if want != got {
 				t.Errorf(`authentication resource IDs are different. Want "%d", got "%d"`, want, got)
@@ -128,6 +135,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := authentication.SourceID
+
 			got := resultingAuth.SourceID
 			if want != got {
 				t.Errorf(`authentication passwords are different. Want "%d", got "%d"`, want, got)
@@ -136,6 +144,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := data["availability_status"]
+
 			got := *resultingAuth.AvailabilityStatus
 			if want != got {
 				t.Errorf(`authentication availability statuses are different. Want "%v", got "%v"`, want, got)
@@ -144,6 +153,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := authentication.LastAvailableAt.Format(time.RFC3339Nano)
+
 			got := resultingAuth.LastAvailableAt.Format(time.RFC3339Nano)
 			if want != got {
 				t.Errorf(`authentication last available at statuses are different. Want "%s", got "%s"`, want, got)
@@ -152,6 +162,7 @@ func TestAuthFromVault(t *testing.T) {
 
 		{
 			want := authentication.LastCheckedAt.Format(time.RFC3339Nano)
+
 			got := resultingAuth.LastCheckedAt.Format(time.RFC3339Nano)
 			if want != got {
 				t.Errorf(`authentication last checked at statuses are different. Want "%s", got "%s"`, want, got)
@@ -256,6 +267,7 @@ func TestFindKeysByResourceTypeAndId(t *testing.T) {
 func TestAuthenticationListOffsetAndLimit(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("offset_limit")
+
 	originalSecretStore := conf.SecretStore
 
 	wantCount := int64(len(fixtures.TestAuthenticationData))
@@ -285,6 +297,7 @@ func TestAuthenticationListOffsetAndLimit(t *testing.T) {
 			}
 
 			got := len(authentications)
+
 			want := int(wantCount) - d.Offset
 			if want < 0 {
 				want = 0
@@ -293,18 +306,22 @@ func TestAuthenticationListOffsetAndLimit(t *testing.T) {
 			if want > d.Limit {
 				want = d.Limit
 			}
+
 			if got != want {
 				t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 			}
 		}
 	}
+
 	DropSchema("offset_limit")
+
 	conf.SecretStore = originalSecretStore
 }
 
 func TestAuthenticationListUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -315,6 +332,7 @@ func TestAuthenticationListUserOwnership(t *testing.T) {
 
 	applicationTypeID := fixtures.TestApplicationTypeData[3].Id
 	sourceTypeID := fixtures.TestSourceTypeData[2].Id
+
 	recordsWithUserID, user, err := CreateSourceWithSubResources(sourceTypeID, applicationTypeID, accountNumber, &userIDWithOwnRecords)
 	if err != nil {
 		t.Errorf("unable to create source: %v", err)
@@ -389,6 +407,7 @@ func TestAuthenticationListUserOwnership(t *testing.T) {
 func TestListForApplicationAuthenticationWithUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -398,6 +417,7 @@ func TestListForApplicationAuthenticationWithUserOwnership(t *testing.T) {
 		*/
 		authenticationDaoUserA := GetAuthenticationDao(suiteData.GetRequestParamsUserA())
 		aa := suiteData.resourcesUserA.ApplicationAuthentications[0]
+
 		authentications, _, err := authenticationDaoUserA.ListForApplicationAuthentication(aa.ID, 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -417,6 +437,7 @@ func TestListForApplicationAuthenticationWithUserOwnership(t *testing.T) {
 		*/
 		authenticationDaoUserA = GetAuthenticationDao(suiteData.GetRequestParamsUserA())
 		aa = suiteData.resourcesNoUser.ApplicationAuthentications[0]
+
 		authentications, _, err = authenticationDaoUserA.ListForApplicationAuthentication(aa.ID, 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -438,6 +459,7 @@ func TestListForApplicationAuthenticationWithUserOwnership(t *testing.T) {
 		requestParams := &RequestParams{TenantID: suiteData.TenantID(), UserID: &suiteData.userWithoutOwnershipRecords.Id}
 		authenticationDaoWithUser := GetAuthenticationDao(requestParams)
 		aa = suiteData.resourcesUserA.ApplicationAuthentications[0]
+
 		_, _, err = authenticationDaoWithUser.ListForApplicationAuthentication(aa.ID, 1000, 0, []util.Filter{})
 		if err.Error() != "application authentication not found" {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -445,7 +467,6 @@ func TestListForApplicationAuthenticationWithUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -456,6 +477,7 @@ func TestListForApplicationAuthenticationWithUserOwnership(t *testing.T) {
 func TestListForSourceWithUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -464,6 +486,7 @@ func TestListForSourceWithUserOwnership(t *testing.T) {
 		  Test 1 - UserA tries to GET userA's authentications of certain application authentication - expected result: success
 		*/
 		authenticationDaoUserA := GetAuthenticationDao(suiteData.GetRequestParamsUserA())
+
 		authentications, _, err := authenticationDaoUserA.ListForSource(suiteData.SourceUserA().ID, 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -482,6 +505,7 @@ func TestListForSourceWithUserOwnership(t *testing.T) {
 		  Test 2 - UserA tries to authentications without ownership of certain application authentication - expected result: success
 		*/
 		authenticationDaoUserA = GetAuthenticationDao(suiteData.GetRequestParamsUserA())
+
 		authentications, _, err = authenticationDaoUserA.ListForSource(suiteData.SourceNoUser().ID, 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -502,6 +526,7 @@ func TestListForSourceWithUserOwnership(t *testing.T) {
 		*/
 		requestParams := &RequestParams{TenantID: suiteData.TenantID(), UserID: &suiteData.userWithoutOwnershipRecords.Id}
 		authenticationDaoWithUser := GetAuthenticationDao(requestParams)
+
 		authentications, _, err = authenticationDaoWithUser.ListForSource(suiteData.SourceUserA().ID, 1000, 0, []util.Filter{})
 		if len(authentications) != 0 {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -509,7 +534,6 @@ func TestListForSourceWithUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}

--- a/dao/authentication_db_dao.go
+++ b/dao/authentication_db_dao.go
@@ -52,12 +52,12 @@ func (add *authenticationDaoDbImpl) List(limit, offset int, filters []util.Filte
 
 	// limiting + running the actual query.
 	authentications := make([]m.Authentication, 0, limit)
+
 	err = query.
 		Limit(limit).
 		Offset(offset).
 		Find(&authentications).
 		Error
-
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
@@ -72,7 +72,6 @@ func (add *authenticationDaoDbImpl) GetById(id string) (*m.Authentication, error
 		Where("id = ?", id).
 		First(&authentication).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("authentication")
 	}
@@ -83,6 +82,7 @@ func (add *authenticationDaoDbImpl) GetById(id string) (*m.Authentication, error
 func (add *authenticationDaoDbImpl) ListForSource(sourceID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
 	// Check that the source exists before continuing.
 	var sourceExists bool
+
 	err := DB.Debug().
 		Model(&m.Source{}).
 		Select(`1`).
@@ -90,7 +90,6 @@ func (add *authenticationDaoDbImpl) ListForSource(sourceID int64, limit, offset 
 		Where(`tenant_id = ?`, add.TenantID).
 		Scan(&sourceExists).
 		Error
-
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
@@ -115,12 +114,12 @@ func (add *authenticationDaoDbImpl) ListForSource(sourceID int64, limit, offset 
 
 	// limiting + running the actual query.
 	authentications := make([]m.Authentication, 0, limit)
+
 	err = query.
 		Limit(limit).
 		Offset(offset).
 		Find(&authentications).
 		Error
-
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
@@ -131,6 +130,7 @@ func (add *authenticationDaoDbImpl) ListForSource(sourceID int64, limit, offset 
 func (add *authenticationDaoDbImpl) ListForApplication(applicationID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
 	// Check that the application exists before continuing.
 	var applicationExists bool
+
 	err := DB.Debug().
 		Model(&m.Application{}).
 		Select(`1`).
@@ -138,7 +138,6 @@ func (add *authenticationDaoDbImpl) ListForApplication(applicationID int64, limi
 		Where(`tenant_id = ?`, add.TenantID).
 		Scan(&applicationExists).
 		Error
-
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
@@ -164,6 +163,7 @@ func (add *authenticationDaoDbImpl) ListForApplication(applicationID int64, limi
 
 	// limiting + running the actual query.
 	authentications := make([]m.Authentication, 0, limit)
+
 	err = query.
 		Where("resource_id = ?", applicationID).
 		Where("resource_type = 'Application'").
@@ -171,7 +171,6 @@ func (add *authenticationDaoDbImpl) ListForApplication(applicationID int64, limi
 		Offset(offset).
 		Find(&authentications).
 		Error
-
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
@@ -187,7 +186,6 @@ func (add *authenticationDaoDbImpl) ListForApplicationAuthentication(appAuthID i
 		Where("id = ?", appAuthID).
 		First(&appAuth).
 		Error
-
 	if err != nil {
 		return nil, 0, util.NewErrNotFound("application authentication")
 	}
@@ -206,6 +204,7 @@ func (add *authenticationDaoDbImpl) ListForApplicationAuthentication(appAuthID i
 func (add *authenticationDaoDbImpl) ListForEndpoint(endpointID int64, limit, offset int, filters []util.Filter) ([]m.Authentication, int64, error) {
 	// Check that the endpoint exists before continuing.
 	var endpointExists bool
+
 	err := DB.Debug().
 		Model(&m.Endpoint{}).
 		Select(`1`).
@@ -213,7 +212,6 @@ func (add *authenticationDaoDbImpl) ListForEndpoint(endpointID int64, limit, off
 		Where(`tenant_id = ?`, add.TenantID).
 		Scan(&endpointExists).
 		Error
-
 	if err != nil {
 		return nil, 0, err
 	}
@@ -239,6 +237,7 @@ func (add *authenticationDaoDbImpl) ListForEndpoint(endpointID int64, limit, off
 
 	// limiting + running the actual query.
 	authentications := make([]m.Authentication, 0, limit)
+
 	err = query.
 		Where("resource_id = ?", endpointID).
 		Where("resource_type = 'Endpoint'").
@@ -246,7 +245,6 @@ func (add *authenticationDaoDbImpl) ListForEndpoint(endpointID int64, limit, off
 		Offset(offset).
 		Find(&authentications).
 		Error
-
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
@@ -261,12 +259,12 @@ func (add *authenticationDaoDbImpl) Create(authentication *m.Authentication) err
 	switch strings.ToLower(authentication.ResourceType) {
 	case "application":
 		var app m.Application
+
 		err := query.
 			Model(&m.Application{}).
 			Where("id = ?", authentication.ResourceID).
 			First(&app).
 			Error
-
 		if err != nil {
 			return fmt.Errorf("resource not found with type [%v], id [%v]", authentication.ResourceType, authentication.ResourceID)
 		}
@@ -274,12 +272,12 @@ func (add *authenticationDaoDbImpl) Create(authentication *m.Authentication) err
 		authentication.SourceID = app.SourceID
 	case "endpoint":
 		var endpoint m.Endpoint
+
 		err := query.
 			Model(&m.Endpoint{}).
 			Where("id = ?", authentication.ResourceID).
 			First(&endpoint).
 			Error
-
 		if err != nil {
 			return fmt.Errorf("resource not found with type [%v], id [%v]", authentication.ResourceType, authentication.ResourceID)
 		}
@@ -287,12 +285,12 @@ func (add *authenticationDaoDbImpl) Create(authentication *m.Authentication) err
 		authentication.SourceID = endpoint.SourceID
 	case "source":
 		var source m.Source
+
 		err := query.
 			Model(&m.Source{}).
 			Where("id = ?", authentication.ResourceID).
 			First(&source).
 			Error
-
 		if err != nil {
 			return fmt.Errorf("resource not found with type [%v], id [%v]", authentication.ResourceType, authentication.ResourceID)
 		}
@@ -308,7 +306,6 @@ func (add *authenticationDaoDbImpl) Create(authentication *m.Authentication) err
 		Debug().
 		Create(authentication).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *add.TenantID, "resource_type": authentication.ResourceType, "resource_id": authentication.ResourceID}).Errorf("Unable to create authentication: %s", err)
 
@@ -332,7 +329,6 @@ func (add *authenticationDaoDbImpl) Update(authentication *m.Authentication) err
 		Omit(clause.Associations).
 		Updates(authentication).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *add.TenantID, "resource_type": authentication.ResourceType, "resource_id": authentication.ResourceID}).Errorf("Unable to update authentication: %s", err)
 
@@ -351,7 +347,6 @@ func (add *authenticationDaoDbImpl) Delete(id string) (*m.Authentication, error)
 		Where("id = ?", id).
 		First(&authentication).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("authentication")
 	}
@@ -359,7 +354,6 @@ func (add *authenticationDaoDbImpl) Delete(id string) (*m.Authentication, error)
 	err = add.getDb().
 		Delete(&authentication).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *add.TenantID, "resource_type": authentication.ResourceType, "resource_id": authentication.ResourceID}).Errorf("Unable to delete authentication: %s", err)
 
@@ -376,8 +370,10 @@ func (add *authenticationDaoDbImpl) Tenant() *int64 {
 }
 
 func (add *authenticationDaoDbImpl) AuthenticationsByResource(authentication *m.Authentication) ([]m.Authentication, error) {
-	var err error
-	var resourceAuthentications []m.Authentication
+	var (
+		err                     error
+		resourceAuthentications []m.Authentication
+	)
 
 	switch authentication.ResourceType {
 	case "Source":
@@ -399,6 +395,7 @@ func (add *authenticationDaoDbImpl) AuthenticationsByResource(authentication *m.
 
 func (add *authenticationDaoDbImpl) BulkMessage(resource util.Resource) (map[string]interface{}, error) {
 	add.TenantID = &resource.TenantID
+
 	authentication, err := add.GetById(resource.ResourceUID)
 	if err != nil {
 		return nil, err
@@ -417,16 +414,19 @@ func (add *authenticationDaoDbImpl) FetchAndUpdateBy(resource util.Resource, upd
 	if err != nil {
 		return nil, err
 	}
+
 	err = add.Update(authentication)
 	if err != nil {
 		return nil, err
 	}
 
 	sourceDao := GetSourceDao(&RequestParams{TenantID: add.TenantID})
+
 	source, err := sourceDao.GetById(&authentication.SourceID)
 	if err != nil {
 		return nil, err
 	}
+
 	authentication.Source = *source
 
 	return authentication, nil
@@ -434,6 +434,7 @@ func (add *authenticationDaoDbImpl) FetchAndUpdateBy(resource util.Resource, upd
 
 func (add *authenticationDaoDbImpl) ToEventJSON(resource util.Resource) ([]byte, error) {
 	add.TenantID = &resource.TenantID
+
 	auth, err := add.GetById(resource.ResourceUID)
 	if err != nil {
 		return nil, err
@@ -442,6 +443,7 @@ func (add *authenticationDaoDbImpl) ToEventJSON(resource util.Resource) ([]byte,
 	auth.TenantID = resource.TenantID
 	auth.Tenant = m.Tenant{ExternalTenant: resource.AccountNumber}
 	authEvent := auth.ToEvent()
+
 	data, err := json.Marshal(authEvent)
 	if err != nil {
 		return nil, err
@@ -461,7 +463,6 @@ func (add *authenticationDaoDbImpl) ListIdsForResource(resourceType string, reso
 		Where("tenant_id = ?", add.TenantID).
 		Find(&authentications).
 		Error
-
 	if err != nil {
 		return nil, err
 	}
@@ -483,6 +484,7 @@ func (add *authenticationDaoDbImpl) BulkDelete(authentications []m.Authenticatio
 	// delete without a where condition" error. In theory this should not happen, since this function is expected to
 	// be called with a "len(authentications) != 0" slice, but just to be safe...
 	var dbAuths []m.Authentication
+
 	err := DB.
 		Debug().
 		Preload("Tenant").
@@ -490,7 +492,6 @@ func (add *authenticationDaoDbImpl) BulkDelete(authentications []m.Authenticatio
 		Where("tenant_id = ?", add.TenantID).
 		Find(&dbAuths).
 		Error
-
 	if err != nil {
 		return nil, err
 	}
@@ -501,7 +502,6 @@ func (add *authenticationDaoDbImpl) BulkDelete(authentications []m.Authenticatio
 			Where("tenant_id = ?", add.TenantID).
 			Delete(&dbAuths).
 			Error
-
 		if err != nil {
 			logger.Log.WithFields(logrus.Fields{"tenant_id": *add.TenantID, "authentication_ids": authIds}).Errorf("Unable to bulk delete authentications: %s", err)
 

--- a/dao/authentication_db_dao_test.go
+++ b/dao/authentication_db_dao_test.go
@@ -98,6 +98,7 @@ func TestAuthenticationDbList(t *testing.T) {
 
 	// We should have the authentication from the fixtures plus the one we just created.
 	want := len(fixtures.TestAuthenticationData) + 1
+
 	got := int(count)
 	if want != got {
 		t.Errorf(`incorrect number of authentications fetched. Want "%d", got "%d"`, want, got)
@@ -105,6 +106,7 @@ func TestAuthenticationDbList(t *testing.T) {
 
 	// Check that we can find the inserted fixture in the list.
 	var foundInsertedFixture bool
+
 	for _, auth := range authentications {
 		if auth.AuthType == TestAuthType {
 			foundInsertedFixture = true
@@ -142,6 +144,7 @@ func TestAuthenticationDbGetById(t *testing.T) {
 	}
 
 	want := TestAuthType
+
 	got := dbAuth.AuthType
 	if want != got {
 		t.Errorf(`wrong authentication fetched. Want "%s" authtype, got "%s"`, want, got)
@@ -184,6 +187,7 @@ func TestAuthenticationDbUpdate(t *testing.T) {
 	}
 
 	want := updatedAuthType
+
 	got := updatedAuthentication.AuthType
 	if want != got {
 		t.Errorf(`deleted the wrong authentication. Want authtype "%s", got "%s"`, want, got)
@@ -217,6 +221,7 @@ func TestAuthenticationDbDelete(t *testing.T) {
 
 	{
 		want := TestAuthType
+
 		got := deletedAuth.AuthType
 		if want != got {
 			t.Errorf(`deleted the wrong authentication. Want authtype "%s", got "%s"`, want, got)
@@ -239,6 +244,7 @@ func TestAuthenticationDbDeleteNotFound(t *testing.T) {
 	SwitchSchema("authentications_db")
 
 	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	_, err := dao.Delete("12345")
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
@@ -284,8 +290,12 @@ func TestListForSource(t *testing.T) {
 
 	// Create three new authentications for the new source.
 	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
-	var i int
-	var maxAuths = 3
+
+	var (
+		i        int
+		maxAuths = 3
+	)
+
 	for i < maxAuths {
 		auth := &model.Authentication{
 			AuthType:     TestAuthType,
@@ -296,7 +306,8 @@ func TestListForSource(t *testing.T) {
 		}
 
 		// Using bulk create so we don't check to see if the resource is there first
-		if err = dao.BulkCreate(auth); err != nil {
+		err = dao.BulkCreate(auth)
+		if err != nil {
 			t.Errorf(`error creating authentication: %s`, err)
 		}
 
@@ -310,6 +321,7 @@ func TestListForSource(t *testing.T) {
 	}
 
 	want := maxAuths
+
 	got := int(count)
 	if want != got {
 		t.Errorf(`incorrect amount of authentications fetched. Want "%d", got "%d"`, want, got)
@@ -335,7 +347,6 @@ func TestListForSourceNotFound(t *testing.T) {
 
 	// Call the function under test.
 	_, _, err := dao.ListForSource(12345, 100, 0, []util.Filter{})
-
 	if err == nil {
 		t.Errorf(`want error, got nil`)
 	}
@@ -384,8 +395,12 @@ func TestListForApplication(t *testing.T) {
 
 	// Create three new authentications for the new application.
 	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
-	var i int
-	var maxAuths = 3
+
+	var (
+		i        int
+		maxAuths = 3
+	)
+
 	for i < maxAuths {
 		auth := &model.Authentication{
 			AuthType:     TestAuthType,
@@ -395,7 +410,8 @@ func TestListForApplication(t *testing.T) {
 		}
 
 		// Using bulk create so we don't check to see if the resource is there first
-		if err = dao.BulkCreate(auth); err != nil {
+		err = dao.BulkCreate(auth)
+		if err != nil {
 			t.Errorf(`error creating authentication: %s`, err)
 		}
 
@@ -409,6 +425,7 @@ func TestListForApplication(t *testing.T) {
 	}
 
 	want := maxAuths
+
 	got := int(count)
 	if want != got {
 		t.Errorf(`incorrect amount of authentications fetched. Want "%d", got "%d"`, want, got)
@@ -434,7 +451,6 @@ func TestListForApplicationNotFound(t *testing.T) {
 
 	// Call the function under test.
 	_, _, err := dao.ListForApplication(12345, 100, 0, []util.Filter{})
-
 	if err == nil {
 		t.Errorf(`want error, got nil`)
 	}
@@ -492,7 +508,8 @@ func TestListForApplicationAuthentication(t *testing.T) {
 	}
 
 	// Using bulk create so we don't check to see if the resource is there first
-	if err = dao.BulkCreate(auth); err != nil {
+	err = dao.BulkCreate(auth)
+	if err != nil {
 		t.Errorf(`error creating authentication: %s`, err)
 	}
 
@@ -516,6 +533,7 @@ func TestListForApplicationAuthentication(t *testing.T) {
 	}
 
 	want := 1
+
 	got := int(count)
 	if want != got {
 		t.Errorf(`incorrect amount of authentications fetched. Want "%d", got "%d"`, want, got)
@@ -541,7 +559,6 @@ func TestListForApplicationAuthenticationNotFound(t *testing.T) {
 
 	// Call the function under test.
 	_, _, err := dao.ListForApplicationAuthentication(12345, 100, 0, []util.Filter{})
-
 	if err == nil {
 		t.Errorf(`want error, got nil`)
 	}
@@ -588,8 +605,12 @@ func TestListForEndpoint(t *testing.T) {
 
 	// Create three new authentications for the new application authentication.
 	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[1].Id})
-	var i int
-	var maxAuths = 3
+
+	var (
+		i        int
+		maxAuths = 3
+	)
+
 	for i < maxAuths {
 		auth := &model.Authentication{
 			AuthType:     TestAuthType,
@@ -599,7 +620,8 @@ func TestListForEndpoint(t *testing.T) {
 		}
 
 		// Using bulk create so we don't check to see if the resource is there first
-		if err = dao.BulkCreate(auth); err != nil {
+		err = dao.BulkCreate(auth)
+		if err != nil {
 			t.Errorf(`error creating authentication: %s`, err)
 		}
 
@@ -613,6 +635,7 @@ func TestListForEndpoint(t *testing.T) {
 	}
 
 	want := maxAuths
+
 	got := int(count)
 	if want != got {
 		t.Errorf(`incorrect amount of authentications fetched. Want "%d", got "%d"`, want, got)
@@ -638,7 +661,6 @@ func TestListForEndpointNotFound(t *testing.T) {
 
 	// Call the function under test.
 	_, _, err := dao.ListForEndpoint(12345, 0, 0, []util.Filter{})
-
 	if err == nil {
 		t.Errorf(`want error, got nil`)
 	}
@@ -761,6 +783,7 @@ func TestToEventJSON(t *testing.T) {
 	if err != nil {
 		t.Errorf(`could not fetch the authentication from the database: %s`, err)
 	}
+
 	want, err := json.Marshal(dbAuth.ToEvent())
 	if err != nil {
 		t.Errorf(`error marshalling the authentication fixture to JSON: %s`, err)
@@ -771,6 +794,7 @@ func TestToEventJSON(t *testing.T) {
 		ResourceUID: id,
 		TenantID:    fixtures.TestTenantData[0].Id,
 	}
+
 	got, err := dao.ToEventJSON(resource)
 	if err != nil {
 		t.Errorf(`error on "ToEventJSON": %s`, err)
@@ -797,6 +821,7 @@ func TestBulkMessage(t *testing.T) {
 	authFixture.ResourceType = "Source"
 
 	dao := GetAuthenticationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	err := dao.BulkCreate(authFixture)
 	if err != nil {
 		t.Errorf(`error creating the authentication: %s`, err)
@@ -810,7 +835,9 @@ func TestBulkMessage(t *testing.T) {
 	if err != nil {
 		t.Errorf(`could not fetch the authentication from the database: %s`, err)
 	}
+
 	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
+
 	source, err := sourceDao.GetById(&authFixture.SourceID)
 	if err != nil {
 		t.Errorf(`could not fetch source: %s`, err)
@@ -827,6 +854,7 @@ func TestBulkMessage(t *testing.T) {
 		ResourceUID: id,
 		TenantID:    fixtures.TestTenantData[0].Id,
 	}
+
 	bulkMessageOutput, err := dao.BulkMessage(resource)
 	if err != nil {
 		t.Errorf(`error on "ToEventJSON": %s`, err)
@@ -894,8 +922,11 @@ func TestListIdsForResource(t *testing.T) {
 
 	// Create the authentications.
 	for _, resource := range resources {
-		var createdAuthentications = make([]model.Authentication, 0, maxAuthenticationsPerResource)
-		var resourceIds = make([]int64, 0, maxAuthenticationsPerResource)
+		var (
+			createdAuthentications = make([]model.Authentication, 0, maxAuthenticationsPerResource)
+			resourceIds            = make([]int64, 0, maxAuthenticationsPerResource)
+		)
+
 		for i := 0; i < maxAuthenticationsPerResource; i++ {
 			authFixture := setUpValidAuthentication()
 			authFixture.ResourceID = resource.ValidResourceId
@@ -922,6 +953,7 @@ func TestListIdsForResource(t *testing.T) {
 		// We shouldn't have fetched more authentications than the ones we have inserted.
 		{
 			want := len(createdAuthentications)
+
 			got := len(fetchedAuthentications)
 			if want != got {
 				t.Errorf(`incorrect number of authentications fetched. Want "%d", got "%d"`, want, got)
@@ -1043,6 +1075,7 @@ func TestBulkDelete(t *testing.T) {
 	// Make sure that we haven't deleted more authentications than expected.
 	{
 		want := len(createdAuthentications)
+
 		got := len(deletedAuths)
 		if want != got {
 			t.Errorf(`the deleted authentications don't match the created ones. Want "%d" auths deleted, got "%d"`, want, got)
@@ -1053,6 +1086,7 @@ func TestBulkDelete(t *testing.T) {
 		for i := 0; i < len(createdAuthentications); i++ {
 			{
 				want := createdAuthentications[i].DbID
+
 				got := deletedAuths[i].DbID
 				if want != got {
 					t.Errorf(`wrong authentication deleted. Want ID "%d", got ID "%d"`, want, got)
@@ -1060,6 +1094,7 @@ func TestBulkDelete(t *testing.T) {
 			}
 			{
 				want := *createdAuthentications[i].Username
+
 				got := *deletedAuths[i].Username
 				if want != got {
 					t.Errorf(`wrong authentication deleted. Want username "%s", got username "%s"`, want, got)
@@ -1134,6 +1169,7 @@ func TestBulkDeleteRegression(t *testing.T) {
 	// Make sure that we haven't deleted more authentications than expected.
 	{
 		want := 0
+
 		got := len(deletedAuths)
 		if want != got {
 			t.Errorf(`there shouldn't be any deleted authentications. Want "%d" auths deleted, got "%d"`, want, got)
@@ -1146,6 +1182,7 @@ func TestBulkDeleteRegression(t *testing.T) {
 func TestAuthenticationGetUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -1155,6 +1192,7 @@ func TestAuthenticationGetUserOwnership(t *testing.T) {
 		*/
 		authenticationDaoUserA := GetAuthenticationDao(suiteData.GetRequestParamsUserA())
 		authId, _ := util.InterfaceToString(suiteData.AuthenticationUserA().DbID)
+
 		authenticationUserA, err := authenticationDaoUserA.GetById(authId)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the authenticationD: %s`, err)
@@ -1168,6 +1206,7 @@ func TestAuthenticationGetUserOwnership(t *testing.T) {
 		  Test 2 - UserA tries to GET authentication without user - expected result: success
 		*/
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationNoUser().DbID)
+
 		authenticationNoUser, err := authenticationDaoUserA.GetById(authId)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the authentication: %s`, err)
@@ -1184,6 +1223,7 @@ func TestAuthenticationGetUserOwnership(t *testing.T) {
 		authenticationDaoWithUser := GetAuthenticationDao(requestParams)
 
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationUserA().DbID)
+
 		_, err = authenticationDaoWithUser.GetById(authId)
 		if err == nil {
 			t.Errorf(`unexpected error after calling GetById for the authentication: %v`, suiteData.AuthenticationNoUser().DbID)
@@ -1195,7 +1235,6 @@ func TestAuthenticationGetUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -1206,6 +1245,7 @@ func TestAuthenticationGetUserOwnership(t *testing.T) {
 func TestAuthenticationEditUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -1216,12 +1256,14 @@ func TestAuthenticationEditUserOwnership(t *testing.T) {
 		authenticationDaoUserA := GetAuthenticationDao(suiteData.GetRequestParamsUserA())
 		newName := "new error"
 		newAuthenticationUserA := &model.Authentication{DbID: suiteData.AuthenticationUserA().DbID, Name: &newName}
+
 		err := authenticationDaoUserA.Update(newAuthenticationUserA)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
 		}
 
 		authId, _ := util.InterfaceToString(suiteData.AuthenticationUserA().DbID)
+
 		updatedAuthentication, err := authenticationDaoUserA.GetById(authId)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById: %v`, err)
@@ -1235,12 +1277,14 @@ func TestAuthenticationEditUserOwnership(t *testing.T) {
 		  Test 2 - UserA tries to update authentication without user - expected result: success
 		*/
 		newAuthenticationNoUser := &model.Authentication{DbID: suiteData.AuthenticationNoUser().DbID, Name: &newName}
+
 		err = authenticationDaoUserA.Update(newAuthenticationNoUser)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
 		}
 
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationUserA().DbID)
+
 		updatedAuthentication, err = authenticationDaoUserA.GetById(authId)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById: %v`, err)
@@ -1258,6 +1302,7 @@ func TestAuthenticationEditUserOwnership(t *testing.T) {
 
 		newName = "new error"
 		newAuthenticationUserB := &model.Authentication{DbID: suiteData.AuthenticationUserB().DbID, Name: &newName}
+
 		err = authenticationDaoWithUser.Update(newAuthenticationUserB)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
@@ -1265,6 +1310,7 @@ func TestAuthenticationEditUserOwnership(t *testing.T) {
 
 		authenticationDaoUserB := GetAuthenticationDao(suiteData.GetRequestParamsUserB())
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationUserB().DbID)
+
 		updatedAuthentication, err = authenticationDaoUserB.GetById(authId)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById: %v`, err)
@@ -1276,7 +1322,6 @@ func TestAuthenticationEditUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -1287,6 +1332,7 @@ func TestAuthenticationEditUserOwnership(t *testing.T) {
 func TestAuthenticationDeleteUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -1296,12 +1342,14 @@ func TestAuthenticationDeleteUserOwnership(t *testing.T) {
 		*/
 		authenticationDaoUserA := GetAuthenticationDao(suiteData.GetRequestParamsUserA())
 		authId, _ := util.InterfaceToString(suiteData.AuthenticationUserA().DbID)
+
 		_, err := authenticationDaoUserA.Delete(authId)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Delete: %v`, err)
 		}
 
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationUserA().DbID)
+
 		_, err = authenticationDaoUserA.GetById(authId)
 		if err.Error() != "authentication not found" {
 			t.Errorf(`expected 'authentication not found', got %s`, err)
@@ -1311,12 +1359,14 @@ func TestAuthenticationDeleteUserOwnership(t *testing.T) {
 		  Test 2 - UserA tries to delete application without user - expected result: success
 		*/
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationNoUser().DbID)
+
 		_, err = authenticationDaoUserA.Delete(authId)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Delete: %v`, err)
 		}
 
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationNoUser().DbID)
+
 		_, err = authenticationDaoUserA.GetById(authId)
 		if err.Error() != "authentication not found" {
 			t.Errorf(`expected 'authentication not found', got %s`, err)
@@ -1329,6 +1379,7 @@ func TestAuthenticationDeleteUserOwnership(t *testing.T) {
 		authenticationDaoWithUser := GetAuthenticationDao(requestParams)
 
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationUserB().DbID)
+
 		_, err = authenticationDaoWithUser.Delete(authId)
 		if err.Error() != "authentication not found" {
 			t.Errorf(`expected 'authentication not found', got %s`, err)
@@ -1336,6 +1387,7 @@ func TestAuthenticationDeleteUserOwnership(t *testing.T) {
 
 		authenticationDaoUserB := GetAuthenticationDao(suiteData.GetRequestParamsUserB())
 		authId, _ = util.InterfaceToString(suiteData.AuthenticationUserB().DbID)
+
 		_, err = authenticationDaoUserB.GetById(authId)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById: %v`, err)
@@ -1343,7 +1395,6 @@ func TestAuthenticationDeleteUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}

--- a/dao/authentication_secrets_manager_dao.go
+++ b/dao/authentication_secrets_manager_dao.go
@@ -35,6 +35,7 @@ func (a *authenticationSecretsManagerDaoImpl) Create(auth *m.Authentication) err
 		}
 
 		auth.TenantID = *a.TenantID
+
 		arn, err := sm.CreateSecret(auth, *auth.Password)
 		if err != nil {
 			return err
@@ -81,6 +82,7 @@ func (a *authenticationSecretsManagerDaoImpl) BulkCreate(auth *m.Authentication)
 		}
 
 		auth.TenantID = *a.TenantID
+
 		arn, err := sm.CreateSecret(auth, *auth.Password)
 		if err != nil {
 			return err
@@ -90,6 +92,7 @@ func (a *authenticationSecretsManagerDaoImpl) BulkCreate(auth *m.Authentication)
 		if err != nil {
 			return err
 		}
+
 		hitAmazon = true
 	}
 
@@ -119,6 +122,7 @@ func (a *authenticationSecretsManagerDaoImpl) Update(auth *m.Authentication) err
 	if auth.Password != nil && !strings.HasPrefix(*auth.Password, config.Get().SecretsManagerPrefix) {
 		// fetch the ARN of the current password (since we overwrote it in memory)
 		arns := make([]*string, 1)
+
 		err := a.getDbWithModel().
 			Where("id = ?", auth.GetID()).
 			Limit(1).
@@ -126,6 +130,7 @@ func (a *authenticationSecretsManagerDaoImpl) Update(auth *m.Authentication) err
 		if err != nil {
 			return err
 		}
+
 		if *arns[0] == "" {
 			return fmt.Errorf("failed to fetch ARN for authentication %v", auth.GetID())
 		}

--- a/dao/common.go
+++ b/dao/common.go
@@ -15,6 +15,7 @@ const (
 
 func GetFromResourceType(resourceType string, tenantID int64) (m.EventModelDao, error) {
 	var resource m.EventModelDao
+
 	switch strings.ToLower(resourceType) {
 	case "source":
 		resource = GetSourceDao(&RequestParams{TenantID: &tenantID})
@@ -38,36 +39,43 @@ func GetAvailabilityStatusFromStatusMessage(tenantID int64, resourceID string, r
 		if err != nil {
 			return "", err
 		}
+
 		resource, err := GetSourceDao(&RequestParams{TenantID: &tenantID}).GetById(&recordID)
 		if err != nil {
 			return "", err
 		}
+
 		return resource.AvailabilityStatus, err
 	case "Endpoint":
 		recordID, err := util.InterfaceToInt64(resourceID)
 		if err != nil {
 			return "", err
 		}
+
 		resource, err := GetEndpointDao(&tenantID).GetById(&recordID)
 		if err != nil {
 			return "", err
 		}
+
 		return resource.AvailabilityStatus, err
 	case "Application":
 		recordID, err := util.InterfaceToInt64(resourceID)
 		if err != nil {
 			return "", err
 		}
+
 		resource, err := GetApplicationDao(&RequestParams{TenantID: &tenantID}).GetById(&recordID)
 		if err != nil {
 			return "", err
 		}
+
 		return resource.AvailabilityStatus, err
 	case "Authentication":
 		resource, err := GetAuthenticationDao(&RequestParams{TenantID: &tenantID}).GetById(resourceID)
 		if err != nil || resource.AvailabilityStatus == nil {
 			return "", err
 		}
+
 		return *resource.AvailabilityStatus, err
 	default:
 		return "", fmt.Errorf("invalid resource_type (%s) to get DAO instance", resourceType)
@@ -111,6 +119,7 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 	bulkMessage["applications"] = applications
 
 	authDao := GetAuthenticationDao(&RequestParams{TenantID: &source.TenantID})
+
 	authenticationsByResource, err := authDao.AuthenticationsByResource(authentication)
 	if err != nil {
 		return nil, err
@@ -123,8 +132,8 @@ func BulkMessageFromSource(source *m.Source, authentication *m.Authentication) (
 	}
 
 	applicationAuthenticationDao := GetApplicationAuthenticationDao(&RequestParams{TenantID: &source.TenantID})
-	applicationAuthenticationsFromResource, err := applicationAuthenticationDao.ApplicationAuthenticationsByResource(authentication.ResourceType, source.Applications, authenticationsByResource)
 
+	applicationAuthenticationsFromResource, err := applicationAuthenticationDao.ApplicationAuthenticationsByResource(authentication.ResourceType, source.Applications, authenticationsByResource)
 	if err != nil {
 		return nil, err
 	}

--- a/dao/db.go
+++ b/dao/db.go
@@ -45,6 +45,7 @@ func Init() {
 
 		// Terminate any other connections to the database, since otherwise Postgres will not allow deleting a database.
 		disconnectSql := fmt.Sprintf(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s'`, conf.DatabaseName)
+
 		err := DB.Exec(disconnectSql).Error
 		if err != nil {
 			log.Fatalln(err)
@@ -52,6 +53,7 @@ func Init() {
 
 		// Perform the database deletion.
 		dropDbSql := fmt.Sprintf(`DROP DATABASE %s`, conf.DatabaseName)
+
 		err = DB.Exec(dropDbSql).Error
 		if err != nil {
 			log.Fatalln(err)
@@ -59,6 +61,7 @@ func Init() {
 
 		// Recreate the database.
 		createDb := fmt.Sprintf(`CREATE DATABASE %s`, conf.DatabaseName)
+
 		err = DB.Exec(createDb).Error
 		if err != nil {
 			log.Fatalln(err)
@@ -92,11 +95,14 @@ func Init() {
 	if err != nil {
 		panic(err)
 	}
+
 	DB = db
+
 	rawDB, err := db.DB()
 	if err != nil {
 		panic(err)
 	}
+
 	rawDB.SetMaxOpenConns(20)
 
 	// Perform database migrations.

--- a/dao/endpoint_dao.go
+++ b/dao/endpoint_dao.go
@@ -33,6 +33,7 @@ type endpointDaoImpl struct {
 
 func (a *endpointDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.Endpoint, int64, error) {
 	endpoints := make([]m.Endpoint, 0, limit)
+
 	relationObject, err := m.NewRelationObject(primaryCollection, *a.TenantID, DB.Debug())
 	if err != nil {
 		return nil, 0, err
@@ -90,6 +91,7 @@ func (a *endpointDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.
 	}
 
 	var endpoint m.Endpoint
+
 	err := q.
 		First(&endpoint).
 		Error
@@ -106,7 +108,6 @@ func (a *endpointDaoImpl) GetById(id *int64) (*m.Endpoint, error) {
 		Where("tenant_id = ?", a.TenantID).
 		First(&endpoint).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("endpoint")
 	}
@@ -131,7 +132,6 @@ func (a *endpointDaoImpl) Create(endpoint *m.Endpoint) error {
 
 func (a *endpointDaoImpl) Update(endpoint *m.Endpoint) error {
 	err := DB.Omit(clause.Associations).Updates(endpoint).Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *a.TenantID, "source_id": endpoint.SourceID, "endpoint_id": endpoint.ID}).Errorf("Unable to update endpoint: %s", err)
 
@@ -177,6 +177,7 @@ func (a *endpointDaoImpl) CanEndpointBeSetAsDefaultForSource(sourceId int64) boo
 
 	// add double quotes to the "default" column to avoid any clashes with postgres' "default" keyword
 	result := DB.Debug().Where(`"default" = true AND source_id = ?`, sourceId).First(&endpoint)
+
 	return result.Error != nil
 }
 
@@ -205,7 +206,6 @@ func (a *endpointDaoImpl) BulkMessage(resource util.Resource) (map[string]interf
 		Preload("Source").
 		Find(&endpoint).
 		Error
-
 	if err != nil {
 		return nil, err
 	}
@@ -235,6 +235,7 @@ func (a *endpointDaoImpl) FetchAndUpdateBy(resource util.Resource, updateAttribu
 	logger.Log.WithFields(logrus.Fields{"tenant_id": *a.TenantID, "resource_type": resource.ResourceType, "resource_id": resource.ResourceID}).Info("Endpoint updated")
 
 	a.TenantID = &resource.TenantID
+
 	endpoint, err := a.GetByIdWithPreload(&resource.ResourceID, "Source")
 	if err != nil {
 		return nil, err
@@ -272,7 +273,6 @@ func (a *endpointDaoImpl) Exists(endpointId int64) (bool, error) {
 		Where("tenant_id = ?", a.TenantID).
 		Scan(&endpointExists).
 		Error
-
 	if err != nil {
 		return false, err
 	}

--- a/dao/endpoint_dao_test.go
+++ b/dao/endpoint_dao_test.go
@@ -66,8 +66,8 @@ func TestDeleteEndpointNotExists(t *testing.T) {
 	endpointDao := GetEndpointDao(&fixtures.TestSourceData[0].TenantID)
 
 	nonExistentId := int64(12345)
-	_, err := endpointDao.Delete(&nonExistentId)
 
+	_, err := endpointDao.Delete(&nonExistentId)
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
@@ -133,6 +133,7 @@ func TestEndpointListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(endpoints)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -141,10 +142,12 @@ func TestEndpointListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
@@ -158,6 +161,7 @@ func TestEndpointSubCollectionListOffsetAndLimit(t *testing.T) {
 	sourceId := int64(1)
 
 	var wantCount int64
+
 	for _, e := range fixtures.TestEndpointData {
 		if e.SourceID == sourceId {
 			wantCount++
@@ -175,6 +179,7 @@ func TestEndpointSubCollectionListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(endpoints)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -183,9 +188,11 @@ func TestEndpointSubCollectionListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }

--- a/dao/filtering.go
+++ b/dao/filtering.go
@@ -16,8 +16,11 @@ func applyFilters(query *gorm.DB, filters []util.Filter) (*gorm.DB, error) {
 		}
 	}
 
-	var filterName string
-	var alreadyJoined = make(map[string]bool)
+	var (
+		filterName    string
+		alreadyJoined = make(map[string]bool)
+	)
+
 	for _, filter := range filters {
 		// subresource filtering!
 		if filter.Subresource != "" {
@@ -31,6 +34,7 @@ func applyFilters(query *gorm.DB, filters []util.Filter) (*gorm.DB, error) {
 					query = query.Joins("SourceType")
 					alreadyJoined[filter.Subresource] = true
 				}
+
 				filterName = fmt.Sprintf("%v.%v", `"SourceType"`, filter.Name)
 			case "application_type":
 				if query.Statement.Table != "applications" {
@@ -41,6 +45,7 @@ func applyFilters(query *gorm.DB, filters []util.Filter) (*gorm.DB, error) {
 					query = query.Joins("ApplicationType")
 					alreadyJoined[filter.Subresource] = true
 				}
+
 				filterName = fmt.Sprintf("%v.%v", `"ApplicationType"`, filter.Name)
 			case "application":
 				if query.Statement.Table != "sources" {
@@ -51,6 +56,7 @@ func applyFilters(query *gorm.DB, filters []util.Filter) (*gorm.DB, error) {
 					query = query.Joins(`Applications`)
 					alreadyJoined[filter.Subresource] = true
 				}
+
 				filterName = fmt.Sprintf("%v.%v", `"Applications"`, filter.Name)
 			default:
 				return nil, fmt.Errorf("invalid subresource type [%v]", filter.Subresource)

--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -32,10 +32,12 @@ func TestMain(t *testing.M) {
 
 	if flags.Integration {
 		Vault = &mocks.MockVault{}
+
 		ConnectAndMigrateDB("dao")
 	}
 
 	logging.InitLogger(config.Get())
+
 	code := t.Run()
 
 	if flags.Integration {
@@ -83,7 +85,6 @@ func ConnectToTestDB(dbSchema string) {
 			TablePrefix: dbSchema + ".",
 		},
 	})
-
 	if err != nil {
 		log.Fatalf(`could not connect to database: %s`, err)
 	}
@@ -92,6 +93,7 @@ func ConnectToTestDB(dbSchema string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	rawDB.SetMaxOpenConns(20)
 
 	// Set the dao.DB in case any tests want to use it
@@ -101,7 +103,6 @@ func ConnectToTestDB(dbSchema string) {
 		Debug().
 		Exec(fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, dbSchema)).
 		Error
-
 	if err != nil {
 		log.Fatalf(`could not create schema "%s": %s`, dbSchema, err)
 	}
@@ -112,7 +113,6 @@ func ConnectToTestDB(dbSchema string) {
 		Debug().
 		Exec(fmt.Sprintf(`SET search_path TO %s`, dbSchema)).
 		Error
-
 	if err != nil {
 		log.Fatalf(`could not set search path to "%s": %s`, dbSchema, err)
 	}
@@ -147,7 +147,6 @@ func DropSchema(dbSchema string) {
 		Debug().
 		Exec(fmt.Sprintf("DROP SCHEMA %s CASCADE", dbSchema)).
 		Error
-
 	if err != nil {
 		log.Fatalf(`Error when dropping the schema "%s": %s`, dbSchema, err)
 	}
@@ -157,8 +156,8 @@ func DropSchema(dbSchema string) {
 func MigrateSchema() {
 	// Perform the migrations and store the error for a proper return.
 	migrateTool := gormigrate.New(DB, gormigrate.DefaultOptions, migrations.MigrationsCollection)
-	err := migrateTool.Migrate()
 
+	err := migrateTool.Migrate()
 	if err != nil {
 		log.Fatalf(`error migrating the schema: %s`, err)
 	}
@@ -185,7 +184,6 @@ func SwitchSchema(schema string) {
 		Debug().
 		Exec(fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, schema)).
 		Error
-
 	if err != nil {
 		log.Fatalf(`could not create schema "%s": %s`, schema, err)
 	}
@@ -196,7 +194,6 @@ func SwitchSchema(schema string) {
 		Debug().
 		Exec(fmt.Sprintf(`SET search_path TO %s`, schema)).
 		Error
-
 	if err != nil {
 		log.Fatalf(`could not switch schema to "%s": %s`, schema, err)
 	}

--- a/dao/mappers/rhcConnection_row_mapper_test.go
+++ b/dao/mappers/rhcConnection_row_mapper_test.go
@@ -56,6 +56,7 @@ func TestMapRowToRhcConnection(t *testing.T) {
 
 	{
 		want := validId
+
 		got := result.ID
 		if want != got {
 			t.Errorf(`Unexpected different ids found. Want "%d", got "%d"`, want, got)
@@ -64,6 +65,7 @@ func TestMapRowToRhcConnection(t *testing.T) {
 
 	{
 		want := validRhcId
+
 		got := result.RhcId
 		if want != got {
 			t.Errorf(`Unexpected different rhcIds found. Want "%s", got "%s"`, want, got)
@@ -72,6 +74,7 @@ func TestMapRowToRhcConnection(t *testing.T) {
 
 	{
 		want := datatypes.JSON(validExtra)
+
 		got := result.Extra
 		if !bytes.Equal(want, got) {
 			t.Errorf(`Unexpected different extra fields found. Want "%d", got "%d"`, want, got)
@@ -80,6 +83,7 @@ func TestMapRowToRhcConnection(t *testing.T) {
 
 	{
 		want := validAvailabilityStatus
+
 		got := result.AvailabilityStatus
 		if want != got {
 			t.Errorf(`Unexpected different availability statuses found. Want "%s", got "%s"`, want, got)
@@ -88,6 +92,7 @@ func TestMapRowToRhcConnection(t *testing.T) {
 
 	{
 		want := validAvailabilityStatusError
+
 		got := result.AvailabilityStatusError
 		if want != got {
 			t.Errorf(`Unexpected different availability status error found. Want "%s", got "%s"`, want, got)
@@ -128,13 +133,13 @@ func TestIdListToRhcConnection(t *testing.T) {
 	var rhcConnection model.RhcConnection
 
 	err := MapIdListToRhcConnection(validSourceIdList, &rhcConnection)
-
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
 
 	{
 		want := validNumberOfSourceIds
+
 		got := len(rhcConnection.Sources)
 		if want != got {
 			t.Errorf(`want "%d" soruces, got "%d"`, want, got)
@@ -158,7 +163,6 @@ func TestIdListEmpty(t *testing.T) {
 	var rhcConnection model.RhcConnection
 
 	err := MapIdListToRhcConnection("", &rhcConnection)
-
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}

--- a/dao/meta_data_dao.go
+++ b/dao/meta_data_dao.go
@@ -30,6 +30,7 @@ type metaDataDaoImpl struct{}
 
 func (md *metaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limit int, offset int, filters []util.Filter) ([]m.MetaData, int64, error) {
 	metadatas := make([]m.MetaData, 0, limit)
+
 	relationObject, err := m.NewRelationObject(primaryCollection, -1, DB.Debug())
 	if err != nil {
 		return nil, 0, err
@@ -50,6 +51,7 @@ func (md *metaDataDaoImpl) SubCollectionList(primaryCollection interface{}, limi
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}
+
 	return metadatas, count, result.Error
 }
 
@@ -69,6 +71,7 @@ func (md *metaDataDaoImpl) List(limit int, offset int, filters []util.Filter) ([
 	if result.Error != nil {
 		return nil, 0, util.NewErrBadRequest(result.Error)
 	}
+
 	return metaData, count, nil
 }
 
@@ -81,7 +84,6 @@ func (md *metaDataDaoImpl) GetById(id *int64) (*m.MetaData, error) {
 		Where("id = ?", *id).
 		First(&metaData).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("metadata")
 	}
@@ -103,6 +105,7 @@ func (md *metaDataDaoImpl) GetSuperKeySteps(applicationTypeId int64) ([]m.MetaDa
 
 func (md *metaDataDaoImpl) GetSuperKeyAccountNumber(applicationTypeId int64) (string, error) {
 	var account string
+
 	result := DB.Model(&m.MetaData{}).
 		Select("payload").
 		Where("type = ?", m.AppMetaData).

--- a/dao/meta_data_dao_test.go
+++ b/dao/meta_data_dao_test.go
@@ -20,6 +20,7 @@ func TestMetaDataSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	appTypeId := fixtures.TestApplicationTypeData[0].Id
 	// How many meta data with given application type id is in fixtures
 	var wantCount int64
+
 	for _, appMetaData := range fixtures.TestMetaDataData {
 		if appMetaData.ApplicationTypeID == appTypeId {
 			wantCount++
@@ -37,6 +38,7 @@ func TestMetaDataSubcollectionListWithOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(metaDatas)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -45,10 +47,12 @@ func TestMetaDataSubcollectionListWithOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
@@ -74,6 +78,7 @@ func TestMetaDataListOffsetAndLimit(t *testing.T) {
 
 		// Check of object's count returned from List()
 		got := len(metaDatas)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -82,9 +87,11 @@ func TestMetaDataListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }

--- a/dao/request_params.go
+++ b/dao/request_params.go
@@ -30,6 +30,7 @@ func NewRequestParamsFromContext(c echo.Context) (*RequestParams, error) {
 	// context (which usually has a deadline we're trying to get around)
 	case c.Get("override_context") != nil:
 		var ok bool
+
 		ctx, ok = c.Get("override_context").(context.Context)
 		if !ok {
 			c.Logger().Warn("Failed to pull overridden context")

--- a/dao/rhc_connection_dao.go
+++ b/dao/rhc_connection_dao.go
@@ -72,12 +72,14 @@ func (s *rhcConnectionDaoImpl) List(limit, offset int, filters []util.Filter) ([
 
 	// Loop through the rows to map both the connection and its related sources.
 	var rows []map[string]interface{}
+
 	err = DB.ScanRows(result, &rows)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	rhcConnections := make([]m.RhcConnection, 0)
+
 	for _, row := range rows {
 		rhcConnection, err := mappers.MapRowToRhcConnection(row)
 		if err != nil {
@@ -119,6 +121,7 @@ func (s *rhcConnectionDaoImpl) GetById(id *int64) (*m.RhcConnection, error) {
 
 	// Loop through the rows to map both the connection and its related sources.
 	var rows []map[string]interface{}
+
 	err = DB.ScanRows(result, &rows)
 	if err != nil {
 		return nil, err
@@ -145,6 +148,7 @@ func (s *rhcConnectionDaoImpl) Create(rhcConnection *m.RhcConnection) (*m.RhcCon
 	// If the source doesn't exist we cannot create the RhcConnection, since it needs to be linked to at least one
 	// source.
 	var sourceExists bool
+
 	err := s.getDb().
 		Model(&m.Source{}).
 		Select(`1`).
@@ -168,7 +172,6 @@ func (s *rhcConnectionDaoImpl) Create(rhcConnection *m.RhcConnection) (*m.RhcCon
 			Omit(clause.Associations).
 			FirstOrCreate(&rhcConnection).
 			Error
-
 		if err != nil {
 			logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": rhcConnection.Sources[0].ID}).Errorf("Unable to create RHC connection: %s", err)
 
@@ -184,6 +187,7 @@ func (s *rhcConnectionDaoImpl) Create(rhcConnection *m.RhcConnection) (*m.RhcCon
 
 		// Check if it exists first.
 		var relationExists bool
+
 		err = tx.Debug().
 			Model(&m.SourceRhcConnection{}).
 			Select(`1`).
@@ -227,7 +231,6 @@ func (s *rhcConnectionDaoImpl) Update(rhcConnection *m.RhcConnection) error {
 		Select("*").
 		Updates(rhcConnection).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_ids": rhcConnection.Sources, "rhc_connection_id": rhcConnection.ID}).Errorf("Unable to update RHC connection: %s", err)
 

--- a/dao/rhc_connection_dao_test.go
+++ b/dao/rhc_connection_dao_test.go
@@ -41,8 +41,8 @@ func TestRhcConnectionCreate(t *testing.T) {
 	SwitchSchema(RhcConnectionSchema)
 
 	want := setUpValidRhcConnection()
-	got, err := rhcConnectionDao.Create(want)
 
+	got, err := rhcConnectionDao.Create(want)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
@@ -68,12 +68,12 @@ func TestRhcConnectionCreate(t *testing.T) {
 	}
 
 	var gotJoinTable model.SourceRhcConnection
+
 	err = DB.Debug().
 		Model(&model.SourceRhcConnection{}).
 		Where(`rhc_connection_id = ?`, got.ID).
 		Find(&gotJoinTable).
 		Error
-
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
@@ -111,6 +111,7 @@ func TestRhcConnectionCreateExistingSourceDifferentTenant(t *testing.T) {
 
 	// Set the tenant back to its original value
 	rhcConnectionDao.TenantID = &tenantId
+
 	DropSchema(RhcConnectionSchema)
 }
 
@@ -126,7 +127,6 @@ func TestRhcConnectionCreateExisting(t *testing.T) {
 	want.Sources[0].ID = fixtures.TestSourceData[0].ID
 
 	got, err := rhcConnectionDao.Create(want)
-
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
@@ -152,12 +152,12 @@ func TestRhcConnectionCreateExisting(t *testing.T) {
 	}
 
 	var gotJoinTable = make([]model.SourceRhcConnection, 0, 2)
+
 	err = DB.Debug().
 		Model(&model.SourceRhcConnection{}).
 		Where(`rhc_connection_id = ?`, got.ID).
 		Find(&gotJoinTable).
 		Error
-
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
@@ -170,6 +170,7 @@ func TestRhcConnectionCreateExisting(t *testing.T) {
 
 	// We have to loop through the fetched sources' ids, since it's a many-to-many relationship.
 	var found = false
+
 	for _, joinTableRow := range gotJoinTable {
 		if want.Sources[0].ID == joinTableRow.SourceId {
 			found = true
@@ -194,7 +195,6 @@ func TestRhcConnectionCreateSourceNotExists(t *testing.T) {
 	rhcConnection.Sources[0].ID = 12345
 
 	_, err := rhcConnectionDao.Create(rhcConnection)
-
 	if err == nil {
 		t.Errorf("want non nil error, got nil error")
 	}
@@ -241,13 +241,13 @@ func TestRhcConnectionDelete(t *testing.T) {
 	}
 
 	var rhcConnectionExists bool
+
 	err = DB.Debug().
 		Model(&model.RhcConnection{}).
 		Select(`1`).
 		Where(`id = ?`, fixtures.TestRhcConnectionData[0].ID).
 		Find(&rhcConnectionExists).
 		Error
-
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
@@ -268,7 +268,6 @@ func TestRhcConnectionDeleteNotFound(t *testing.T) {
 	nonExistentId := int64(12345)
 
 	_, err := rhcConnectionDao.Delete(&nonExistentId)
-
 	if err == nil {
 		t.Errorf(`want error, got nil`)
 	}
@@ -297,6 +296,7 @@ func TestRhcConnectionListForSources(t *testing.T) {
 	// with different types.
 	{
 		want := 2
+
 		got := len(rhcConnections)
 		if want != got {
 			t.Errorf(`incorrect amount of related rhc connections fetched. Want "%d", got "%d"`, want, got)
@@ -305,6 +305,7 @@ func TestRhcConnectionListForSources(t *testing.T) {
 
 	{
 		want := fixtures.TestSourceRhcConnectionData[0].RhcConnectionId
+
 		got := rhcConnections[0].ID
 		if want != got {
 			t.Errorf(`incorrect related rhc connection fetched. Want "%d", got "%d"`, want, got)
@@ -313,11 +314,11 @@ func TestRhcConnectionListForSources(t *testing.T) {
 
 	{
 		want := fixtures.TestSourceRhcConnectionData[1].RhcConnectionId
+
 		got := rhcConnections[1].ID
 		if want != got {
 			t.Errorf(`incorrect related rhc connection fetched. Want "%d", got "%d"`, want, got)
 		}
-
 	}
 
 	DropSchema(RhcConnectionSchema)
@@ -332,11 +333,11 @@ func TestRhcConnectionRowsClosed(t *testing.T) {
 
 	// Find all the connections that we will remove from the DB.
 	dbRhcConnections := make([]model.RhcConnection, 0)
+
 	err := DB.Debug().
 		Model(&model.RhcConnection{}).
 		Find(&dbRhcConnections).
 		Error
-
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
 	}
@@ -347,7 +348,6 @@ func TestRhcConnectionRowsClosed(t *testing.T) {
 		err = DB.Debug().
 			Delete(conn).
 			Error
-
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
 		}
@@ -360,6 +360,7 @@ func TestRhcConnectionRowsClosed(t *testing.T) {
 	}
 
 	want := 0
+
 	got := len(rhcConnections)
 	if want != got {
 		t.Errorf(`want "%d" connections from the database, got "%d"`, want, got)
@@ -420,8 +421,8 @@ func TestDeleteRhcConnectionNotExists(t *testing.T) {
 	RhcConnectionDao := GetRhcConnectionDao(&RequestParams{TenantID: &fixtures.TestSourceData[0].TenantID})
 
 	nonExistentId := int64(12345)
-	_, err := RhcConnectionDao.Delete(&nonExistentId)
 
+	_, err := RhcConnectionDao.Delete(&nonExistentId)
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
@@ -448,6 +449,7 @@ func TestRhcConnectionListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(rhcConnections)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -456,10 +458,12 @@ func TestRhcConnectionListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
@@ -472,6 +476,7 @@ func TestRhcConnectionListForSourceOffsetAndLimit(t *testing.T) {
 	sourceId := int64(1)
 
 	var wantCount int64
+
 	for _, i := range fixtures.TestSourceRhcConnectionData {
 		if i.SourceId == sourceId {
 			wantCount++
@@ -489,6 +494,7 @@ func TestRhcConnectionListForSourceOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(rhcConnections)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -497,9 +503,11 @@ func TestRhcConnectionListForSourceOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }

--- a/dao/secret_db_dao.go
+++ b/dao/secret_db_dao.go
@@ -44,7 +44,6 @@ func (secret *secretDaoDbImpl) GetById(id *int64) (*m.Authentication, error) {
 		Where("id = ?", id).
 		First(&secretAuthentication).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("secret")
 	}
@@ -61,7 +60,6 @@ func (secret *secretDaoDbImpl) Create(authentication *m.Authentication) error {
 		Debug().
 		Create(authentication).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *secret.TenantID}).Errorf("Unable to create secret: %s", err)
 
@@ -80,7 +78,6 @@ func (secret *secretDaoDbImpl) Delete(id *int64) error {
 		Where("id = ?", id).
 		First(&authentication).
 		Error
-
 	if err != nil {
 		return util.NewErrNotFound("secret")
 	}
@@ -88,7 +85,6 @@ func (secret *secretDaoDbImpl) Delete(id *int64) error {
 	err = secret.getDb().
 		Delete(&authentication).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *secret.TenantID, "secret_id": *id}).Errorf("Unable to delete secret: %s", err)
 
@@ -121,12 +117,12 @@ func (secret *secretDaoDbImpl) List(limit, offset int, filters []util.Filter) ([
 	query.Count(&count)
 
 	secrets := make([]m.Authentication, 0, limit)
+
 	err = query.
 		Limit(limit).
 		Offset(offset).
 		Find(&secrets).
 		Error
-
 	if err != nil {
 		return nil, 0, util.NewErrBadRequest(err)
 	}
@@ -139,7 +135,6 @@ func (secret *secretDaoDbImpl) Update(authentication *m.Authentication) error {
 		Omit(clause.Associations).
 		Updates(authentication).
 		Error
-
 	if err != nil {
 		logger.Log.WithFields(logrus.Fields{"tenant_id": *secret.TenantID, "secret_id": authentication.ID}).Errorf("Unable to update secret: %s", err)
 

--- a/dao/secret_db_dao_test.go
+++ b/dao/secret_db_dao_test.go
@@ -11,6 +11,7 @@ import (
 func TestSecretListUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 	// Set the encryption key

--- a/dao/secret_secrets_manager_dao.go
+++ b/dao/secret_secrets_manager_dao.go
@@ -27,6 +27,7 @@ func (s *secretDaoSecretsManagerImpl) Create(auth *m.Authentication) error {
 		}
 
 		auth.TenantID = *s.TenantID
+
 		arn, err := sm.CreateSecret(auth, *auth.Password)
 		if err != nil {
 			return err
@@ -47,6 +48,7 @@ func (s *secretDaoSecretsManagerImpl) Create(auth *m.Authentication) error {
 			if err != nil {
 				return err
 			}
+
 			err = sm.DeleteSecret(*auth.Password)
 			if err != nil {
 				return err
@@ -108,6 +110,7 @@ func (s *secretDaoSecretsManagerImpl) Update(auth *m.Authentication) error {
 	if auth.Password != nil && !strings.HasPrefix(*auth.Password, config.Get().SecretsManagerPrefix) {
 		// fetch the ARN of the current password (since we overwrote it in memory)
 		arns := make([]*string, 1)
+
 		err := s.getDbWithModel().
 			Where("id = ?", auth.GetID()).
 			Limit(1).
@@ -115,6 +118,7 @@ func (s *secretDaoSecretsManagerImpl) Update(auth *m.Authentication) error {
 		if err != nil {
 			return err
 		}
+
 		if *arns[0] == "" {
 			return fmt.Errorf("failed to fetch ARN for authentication %v", auth.GetID())
 		}

--- a/dao/seeding.go
+++ b/dao/seeding.go
@@ -19,18 +19,21 @@ var seedsFS embed.FS
 
 func seedDatabase() error {
 	l.Log.Infof("Seeding SourceType Table")
+
 	err := seedSourceTypes()
 	if err != nil {
 		return err
 	}
 
 	l.Log.Infof("Seeding ApplicationType Table")
+
 	err = seedApplicationTypes()
 	if err != nil {
 		return err
 	}
 
 	l.Log.Infof("Seeding MetaData Table")
+
 	err = seedMetaData()
 	if err != nil {
 		return err
@@ -79,6 +82,7 @@ func seedSourceTypes() error {
 		// if the source type was not found - we are creating it
 		if st == nil {
 			l.Log.Debugf("New SourceType found %v", name)
+
 			st = &m.SourceType{}
 		}
 
@@ -112,6 +116,7 @@ func seedSourceTypes() error {
 	// and need deleted
 	for name := range sourceTypes {
 		l.Log.Infof("Deleting SourceType %v", name)
+
 		result := DB.Delete(sourceTypes[name])
 		if result.Error != nil {
 			return result.Error
@@ -156,6 +161,7 @@ func seedApplicationTypes() error {
 		// if the app type was not found - we are creating it
 		if at == nil {
 			l.Log.Debugf("New ApplicationType found %v", name)
+
 			at = &m.ApplicationType{}
 		}
 
@@ -198,6 +204,7 @@ func seedApplicationTypes() error {
 	// and need deleted
 	for name := range appTypes {
 		l.Log.Infof("Deleting ApplicationType %v", name)
+
 		result := DB.Delete(appTypes[name])
 		if result.Error != nil {
 			return result.Error
@@ -221,6 +228,7 @@ func seedMetaData() error {
 	if err != nil {
 		return err
 	}
+
 	err = seedAppMetadata(appTypes)
 	if err != nil {
 		return err
@@ -255,6 +263,7 @@ func seedSuperkeyMetadata(appTypes map[string]*m.ApplicationType) error {
 			if err != nil {
 				return err
 			}
+
 			substitutions, err := json.Marshal(values.Substitutions)
 			if err != nil {
 				return err
@@ -296,6 +305,7 @@ func seedAppMetadata(appTypes map[string]*m.ApplicationType) error {
 	env, ok := os.LookupEnv("SOURCES_ENV")
 	if !ok {
 		l.Log.Infof("Defaulting SOURCES_ENV to eph")
+
 		env = "eph"
 	}
 
@@ -332,6 +342,7 @@ func seedAppMetadata(appTypes map[string]*m.ApplicationType) error {
 // pointer to the record
 func loadSourceTypeSeeds() map[string]*m.SourceType {
 	sourceTypes := make([]m.SourceType, 0)
+
 	result := DB.Model(&m.SourceType{}).Scan(&sourceTypes)
 	if result.Error != nil {
 		return nil
@@ -351,6 +362,7 @@ func loadSourceTypeSeeds() map[string]*m.SourceType {
 func loadApplicationTypeSeeds() map[string]*m.ApplicationType {
 	// load all the seeds from the db
 	appTypes := make([]m.ApplicationType, 0)
+
 	result := DB.Model(&m.ApplicationType{}).Scan(&appTypes)
 	if result.Error != nil {
 		return nil

--- a/dao/seeding_test.go
+++ b/dao/seeding_test.go
@@ -30,6 +30,7 @@ func TestSeedingSourceTypes(t *testing.T) {
 	}
 
 	seedsDir := getSeedFilesystemDir()
+
 	err := seedSourceTypes()
 	if err != nil {
 		t.Fatal(err)
@@ -37,12 +38,14 @@ func TestSeedingSourceTypes(t *testing.T) {
 
 	bytes, _ := os.ReadFile(seedsDir + "source_types.yml")
 	seeds := make(sourceTypeSeedMap)
+
 	err = yaml.Unmarshal(bytes, &seeds)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	stypes := make([]m.SourceType, 0)
+
 	result := DB.Model(&m.SourceType{}).Scan(&stypes)
 	if result.Error != nil {
 		t.Fatalf("failed to list sourcetypes: %v", result.Error)
@@ -61,6 +64,7 @@ func TestSeedingApplicationTypes(t *testing.T) {
 	}
 
 	seedsDir := getSeedFilesystemDir()
+
 	err := seedApplicationTypes()
 	if err != nil {
 		t.Fatal(err)
@@ -68,12 +72,14 @@ func TestSeedingApplicationTypes(t *testing.T) {
 
 	bytes, _ := os.ReadFile(seedsDir + "application_types.yml")
 	seeds := make(applicationTypeSeedMap)
+
 	err = yaml.Unmarshal(bytes, &seeds)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	appTypes := make([]m.ApplicationType, 0)
+
 	result := DB.Model(&m.ApplicationType{}).Scan(&appTypes)
 	if result.Error != nil {
 		t.Fatalf("failed to list app types: %v", result.Error)
@@ -101,12 +107,14 @@ func TestSeedingSuperkeyMetadata(t *testing.T) {
 
 	bytes, _ := os.ReadFile(seedsDir + "superkey_metadata.yml")
 	seeds := make(superkeyMetadataSeedMap)
+
 	err = yaml.Unmarshal(bytes, &seeds)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	skeymdata := make([]m.MetaData, 0)
+
 	result := DB.Model(&m.MetaData{}).
 		Where("type = ?", m.SuperKeyMetaData).
 		Scan(&skeymdata)
@@ -141,12 +149,14 @@ func TestSeedingApplicationMetadata(t *testing.T) {
 
 	bytes, _ := os.ReadFile(seedsDir + "app_metadata.yml")
 	seeds := make(appMetadataSeedMap)
+
 	err = yaml.Unmarshal(bytes, &seeds)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	appmdata := make([]m.MetaData, 0)
+
 	result := DB.Model(&m.MetaData{}).
 		Where("type = ?", m.AppMetaData).
 		Scan(&appmdata)

--- a/dao/source_dao.go
+++ b/dao/source_dao.go
@@ -83,6 +83,7 @@ func (s *sourceDaoImpl) SubCollectionList(primaryCollection interface{}, limit, 
 	if err != nil {
 		return nil, 0, err
 	}
+
 	query := relationObject.HasMany(&m.Source{}, DB.Debug())
 
 	query = s.getDbWithTable(query, "sources")
@@ -202,7 +203,6 @@ func (s *sourceDaoImpl) GetById(id *int64) (*m.Source, error) {
 		Where("id = ?", *id).
 		First(&src).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("source")
 	}
@@ -220,10 +220,10 @@ func (s *sourceDaoImpl) GetByIdWithPreload(id *int64, preloads ...string) (*m.So
 	}
 
 	var src m.Source
+
 	err := q.
 		First(&src).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("source")
 	}
@@ -303,6 +303,7 @@ func (s *sourceDaoImpl) NameExistsInCurrentTenant(name string) bool {
 
 func (s *sourceDaoImpl) IsSuperkey(id int64) bool {
 	var valid bool
+
 	result := s.getDbWithModel().
 		Select("app_creation_workflow = ?", m.AccountAuth).
 		Where("id = ?", id).
@@ -323,7 +324,6 @@ func (s *sourceDaoImpl) BulkMessage(resource util.Resource) (map[string]interfac
 		Where("id = ?", resource.ResourceID).
 		Find(&src).
 		Error
-
 	if err != nil {
 		return nil, err
 	}
@@ -413,7 +413,6 @@ func (s *sourceDaoImpl) Pause(id int64) error {
 			Where("tenant_id = ?", s.TenantID).
 			Update("paused_at", time.Now()).
 			Error
-
 		if err != nil {
 			logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": id}).Errorf(`Unable to pause source: %s`, err)
 
@@ -426,7 +425,6 @@ func (s *sourceDaoImpl) Pause(id int64) error {
 			Where("tenant_id = ?", s.TenantID).
 			Update("paused_at", time.Now()).
 			Error
-
 		if err != nil {
 			logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": id}).Errorf(`Unable to pause source's applications': %s`, err)
 
@@ -448,7 +446,6 @@ func (s *sourceDaoImpl) Unpause(id int64) error {
 			Where("tenant_id = ?", s.TenantID).
 			Update("paused_at", nil).
 			Error
-
 		if err != nil {
 			logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": id}).Errorf(`Unable to resume source: %s`, err)
 
@@ -461,7 +458,6 @@ func (s *sourceDaoImpl) Unpause(id int64) error {
 			Where("tenant_id = ?", s.TenantID).
 			Update("paused_at", nil).
 			Error
-
 		if err != nil {
 			logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": id}).Errorf(`Unable to resume source's applications': %s`, err)
 
@@ -477,11 +473,13 @@ func (s *sourceDaoImpl) Unpause(id int64) error {
 }
 
 func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentication, []m.Application, []m.Endpoint, []m.RhcConnection, *m.Source, error) {
-	var applicationAuthentications []m.ApplicationAuthentication
-	var applications []m.Application
-	var endpoints []m.Endpoint
-	var rhcConnections []m.RhcConnection
-	var source *m.Source
+	var (
+		applicationAuthentications []m.ApplicationAuthentication
+		applications               []m.Application
+		endpoints                  []m.Endpoint
+		rhcConnections             []m.RhcConnection
+		source                     *m.Source
+	)
 
 	// The different items are fetched with the "Tenant" table preloaded, so that all the objects are returned with the
 	// "external_tenant" column populated. This is required to be able to raise events with the "tenant" key populated.
@@ -501,7 +499,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				Where(`"applications"."tenant_id" = ?`, s.TenantID).
 				Find(&applicationAuthentications).
 				Error
-
 			if err != nil {
 				return err
 			}
@@ -510,7 +507,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				err = tx.
 					Delete(&applicationAuthentications).
 					Error
-
 				if err != nil {
 					logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": sourceId}).Errorf("Unable to cascade delete source: unable to delete application authentications: %s", err)
 
@@ -526,7 +522,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				Where("tenant_id = ?", s.TenantID).
 				Find(&applications).
 				Error
-
 			if err != nil {
 				return err
 			}
@@ -535,7 +530,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				err = tx.
 					Delete(&applications).
 					Error
-
 				if err != nil {
 					logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": sourceId}).Errorf("Unable to cascade delete source: unable to delete applications: %s", err)
 
@@ -551,7 +545,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				Where("tenant_id = ?", s.TenantID).
 				Find(&endpoints).
 				Error
-
 			if err != nil {
 				return err
 			}
@@ -560,7 +553,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				err = tx.
 					Delete(&endpoints).
 					Error
-
 				if err != nil {
 					logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": sourceId}).Errorf("Unable to cascade delete source: unable to delete endpoints: %s", err)
 
@@ -576,7 +568,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				Where(`"source_rhc_connections"."tenant_id" = ?`, s.TenantID).
 				Find(&rhcConnections).
 				Error
-
 			if err != nil {
 				return err
 			}
@@ -585,7 +576,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				err = tx.
 					Delete(&rhcConnections).
 					Error
-
 				if err != nil {
 					logger.Log.WithFields(logrus.Fields{"tenant_id": *s.TenantID, "source_id": sourceId}).Errorf("Unable to cascade delete source: unable to delete RHC connections: %s", err)
 
@@ -600,7 +590,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				Where("tenant_id = ?", s.TenantID).
 				Find(&source).
 				Error
-
 			if err != nil {
 				return err
 			}
@@ -619,7 +608,6 @@ func (s *sourceDaoImpl) DeleteCascade(sourceId int64) ([]m.ApplicationAuthentica
 				return nil
 			}
 		})
-
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -654,7 +642,6 @@ func (s *sourceDaoImpl) Exists(sourceId int64) (bool, error) {
 		Where("id = ?", sourceId).
 		Scan(&sourceExists).
 		Error
-
 	if err != nil {
 		return false, err
 	}

--- a/dao/source_dao_test.go
+++ b/dao/source_dao_test.go
@@ -34,6 +34,7 @@ func TestSourcesListForRhcConnections(t *testing.T) {
 	// with different types.
 	{
 		want := 2
+
 		got := len(sources)
 		if want != got {
 			t.Errorf(`incorrect amount of related sources fetched. Want "%d", got "%d"`, want, got)
@@ -42,6 +43,7 @@ func TestSourcesListForRhcConnections(t *testing.T) {
 
 	{
 		want := fixtures.TestSourceRhcConnectionData[0].SourceId
+
 		got := sources[0].ID
 		if want != got {
 			t.Errorf(`incorrect related source fetched. Want "%d", got "%d"`, want, got)
@@ -50,11 +52,11 @@ func TestSourcesListForRhcConnections(t *testing.T) {
 
 	{
 		want := fixtures.TestSourceRhcConnectionData[2].SourceId
+
 		got := sources[1].ID
 		if want != got {
 			t.Errorf(`incorrect related source fetched. Want "%d", got "%d"`, want, got)
 		}
-
 	}
 
 	DropSchema(RhcConnectionSchema)
@@ -70,6 +72,7 @@ func TestPausingSource(t *testing.T) {
 	SwitchSchema("pause_unpause")
 
 	sourceDao := GetSourceDao(&RequestParams{TenantID: &testSource.TenantID})
+
 	err := sourceDao.Pause(testSource.ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -103,6 +106,7 @@ func TestPausingSourceWithOwnership(t *testing.T) {
 		 Test 1 - UserA tries to pause source for userA - expected result: success
 		*/
 		sourceDao := GetSourceDao(suiteData.GetRequestParamsUserA())
+
 		err := sourceDao.Pause(suiteData.SourceUserA().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -128,6 +132,7 @@ func TestPausingSourceWithOwnership(t *testing.T) {
 		 Test 2 - UserA tries to pause source without user - expected result: success
 		*/
 		sourceDao = GetSourceDao(suiteData.GetRequestParamsUserA())
+
 		err = sourceDao.Pause(suiteData.SourceNoUser().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -177,7 +182,6 @@ func TestPausingSourceWithOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -194,6 +198,7 @@ func TestUnpauseSourceWithOwnership(t *testing.T) {
 		 Test 1 - UserA tries to unpause source for userA - expected result: success
 		*/
 		sourceDao := GetSourceDao(suiteData.GetRequestParamsUserA())
+
 		err := sourceDao.Pause(suiteData.SourceUserA().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -223,6 +228,7 @@ func TestUnpauseSourceWithOwnership(t *testing.T) {
 		 Test 2 - UserA tries to unpause source without user - expected result: success
 		*/
 		sourceDao = GetSourceDao(suiteData.GetRequestParamsUserA())
+
 		err = sourceDao.Pause(suiteData.SourceNoUser().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -255,6 +261,7 @@ func TestUnpauseSourceWithOwnership(t *testing.T) {
 		sourceDaoWithUser := GetSourceDao(requestParams)
 
 		sourceDaoUserB := GetSourceDao(suiteData.GetRequestParamsUserB())
+
 		err = sourceDaoUserB.Pause(suiteData.SourceUserB().ID)
 		if err != nil {
 			t.Errorf(`want nil error, got "%s"`, err)
@@ -282,7 +289,6 @@ func TestUnpauseSourceWithOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -296,6 +302,7 @@ func TestResumingSource(t *testing.T) {
 	SwitchSchema("pause_unpause")
 
 	sourceDao := GetSourceDao(&RequestParams{TenantID: &testSource.TenantID})
+
 	err := sourceDao.Unpause(fixtures.TestSourceData[0].ID)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -375,8 +382,8 @@ func TestDeleteSourceNotExists(t *testing.T) {
 	sourceDao := GetSourceDao(&RequestParams{TenantID: &fixtures.TestSourceData[0].TenantID})
 
 	nonExistentId := int64(12345)
-	_, err := sourceDao.Delete(&nonExistentId)
 
+	_, err := sourceDao.Delete(&nonExistentId)
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`incorrect error returned. Want "%s", got "%s"`, util.ErrNotFound{}, reflect.TypeOf(err))
 	}
@@ -392,6 +399,7 @@ func TestDeleteSourceNotExists(t *testing.T) {
 func TestDeleteCascade(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
+
 	tenantId := int64(1)
 
 	// Create a new source fixture to avoid mixing the applications with the ones that already exist.
@@ -405,6 +413,7 @@ func TestDeleteCascade(t *testing.T) {
 	// Try inserting the source in the database.
 	sourceDaoParams := RequestParams{TenantID: &tenantId}
 	sourceDao := GetSourceDao(&sourceDaoParams)
+
 	err := sourceDao.Create(&fixtureSource)
 	if err != nil {
 		t.Errorf(`error creating a fixture source: %s`, err)
@@ -490,7 +499,9 @@ func TestDeleteCascade(t *testing.T) {
 		if len(deletedApplicationAuthentications) != 1 {
 			t.Errorf("different count of app auths deleted, want %d, deleted %d", 1, len(deletedApplicationAuthentications))
 		}
+
 		id := deletedApplicationAuthentications[0].ID
+
 		_, err = applicationAuthenticationDao.GetById(&id)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
@@ -502,7 +513,9 @@ func TestDeleteCascade(t *testing.T) {
 		if len(deletedApplications) != 1 {
 			t.Errorf("different count of apps deleted, want %d, deleted %d", 1, len(deletedApplications))
 		}
+
 		id := deletedApplications[0].ID
+
 		_, err = applicationsDao.GetById(&id)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
@@ -514,7 +527,9 @@ func TestDeleteCascade(t *testing.T) {
 		if len(deletedEndpoints) != 1 {
 			t.Errorf("different count of apps deleted, want %d, deleted %d", 1, len(deletedEndpoints))
 		}
+
 		id := deletedEndpoints[0].ID
+
 		_, err = endpointDao.GetById(&id)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
@@ -526,7 +541,9 @@ func TestDeleteCascade(t *testing.T) {
 		if len(deletedRhcConnections) != 1 {
 			t.Errorf("different count of apps deleted, want %d, deleted %d", 1, len(deletedRhcConnections))
 		}
+
 		id := deletedRhcConnections[0].ID
+
 		_, err = rhcConnectionsDao.GetById(&id)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
@@ -536,6 +553,7 @@ func TestDeleteCascade(t *testing.T) {
 	// Check that deleted source is not in the database
 	{
 		id := deletedSource.ID
+
 		_, err = sourceDao.GetById(&id)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Errorf("Expected not found error, got %s", err)
@@ -544,19 +562,24 @@ func TestDeleteCascade(t *testing.T) {
 
 	// Check that created authentication was not deleted
 	id := fmt.Sprintf("%d", authentication.DbID)
+
 	authOut, err := authenticationDao.GetById(id)
 	if err != nil {
 		t.Error(err)
 	}
+
 	if authOut.DbID != authentication.DbID {
 		t.Errorf("ghost infected the return")
 	}
+
 	if authOut.ResourceType != authentication.ResourceType {
 		t.Errorf("ghost infected the return")
 	}
+
 	if authOut.ResourceID != authentication.ResourceID {
 		t.Errorf("ghost infected the return")
 	}
+
 	if authOut.SourceID != authentication.SourceID {
 		t.Errorf("ghost infected the return")
 	}
@@ -580,6 +603,7 @@ func TestDeleteCascade(t *testing.T) {
 func TestDeleteCascadeSourceWithoutSubresources(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("delete")
+
 	tenantId := int64(1)
 
 	// Create a new source fixture to avoid mixing the applications with the ones that already exist.
@@ -593,6 +617,7 @@ func TestDeleteCascadeSourceWithoutSubresources(t *testing.T) {
 	// Try inserting the source in the database.
 	sourceDaoParams := RequestParams{TenantID: &tenantId}
 	sourceDao := GetSourceDao(&sourceDaoParams)
+
 	err := sourceDao.Create(&fixtureSource)
 	if err != nil {
 		t.Errorf(`error creating a fixture source: %s`, err)
@@ -607,6 +632,7 @@ func TestDeleteCascadeSourceWithoutSubresources(t *testing.T) {
 	// Double-check the "deleted" resources and the source itself.
 	{
 		want := 0
+
 		got := len(applicationAuthentications)
 		if want != got {
 			t.Errorf(`unexpected application authentications deleted. Want "%d", got "%d"`, want, got)
@@ -615,6 +641,7 @@ func TestDeleteCascadeSourceWithoutSubresources(t *testing.T) {
 
 	{
 		want := 0
+
 		got := len(applications)
 		if want != got {
 			t.Errorf(`unexpected applications deleted. Want "%d", got "%d"`, want, got)
@@ -623,6 +650,7 @@ func TestDeleteCascadeSourceWithoutSubresources(t *testing.T) {
 
 	{
 		want := 0
+
 		got := len(endpoints)
 		if len(endpoints) != 0 {
 			t.Errorf(`unexpected endpoints deleted. Want "%d", got "%d"`, want, got)
@@ -631,6 +659,7 @@ func TestDeleteCascadeSourceWithoutSubresources(t *testing.T) {
 
 	{
 		want := 0
+
 		got := len(rhcConnections)
 		if len(rhcConnections) != 0 {
 			t.Errorf(`unexpected rhcConnections deleted. Want "%d", got "%d"`, want, got)
@@ -639,6 +668,7 @@ func TestDeleteCascadeSourceWithoutSubresources(t *testing.T) {
 
 	{
 		want := fixtureSource.ID
+
 		got := deletedSource.ID
 		if want != got {
 			t.Errorf(`wrong source deleted. Want source with ID "%d", got ID "%d"`, want, got)
@@ -695,6 +725,7 @@ func TestSourceSubcollectionListWithOffsetAndLimit(t *testing.T) {
 	sourceTypeId := fixtures.TestSourceTypeData[0].Id
 
 	var wantCount int64
+
 	for _, i := range fixtures.TestSourceData {
 		if i.SourceTypeID == sourceTypeId {
 			wantCount++
@@ -712,6 +743,7 @@ func TestSourceSubcollectionListWithOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(sources)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -720,10 +752,12 @@ func TestSourceSubcollectionListWithOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
@@ -746,6 +780,7 @@ func TestSourceListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(sources)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -754,10 +789,12 @@ func TestSourceListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
@@ -780,6 +817,7 @@ func TestSourceListInternalOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(sources)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -788,10 +826,12 @@ func TestSourceListInternalOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
@@ -825,7 +865,9 @@ func TestSourceListInternalSkipCostManagementSources(t *testing.T) {
 	}
 
 	applicationDao := GetApplicationDao(&RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
-	if err := applicationDao.Create(application); err != nil {
+
+	err = applicationDao.Create(application)
+	if err != nil {
 		t.Errorf("unable to create Cost Management application: %s", err)
 	}
 
@@ -849,7 +891,8 @@ func TestSourceListInternalSkipCostManagementSources(t *testing.T) {
 		AvailabilityStatus: "available",
 	}
 
-	if _, err := rhcConnectionDao.Create(rhcConnection); err != nil {
+	_, err = rhcConnectionDao.Create(rhcConnection)
+	if err != nil {
 		t.Errorf("unable to create the RHC Connection: %s", err)
 	}
 
@@ -878,6 +921,7 @@ func TestSourceListForRhcConnectionWithOffsetAndLimit(t *testing.T) {
 	rhcConnectionId := fixtures.TestRhcConnectionData[0].ID
 
 	var wantCount int64
+
 	for _, i := range fixtures.TestSourceRhcConnectionData {
 		if i.RhcConnectionId == rhcConnectionId {
 			wantCount++
@@ -895,6 +939,7 @@ func TestSourceListForRhcConnectionWithOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(sources)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -903,16 +948,19 @@ func TestSourceListForRhcConnectionWithOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
 func TestSourceListUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -923,6 +971,7 @@ func TestSourceListUserOwnership(t *testing.T) {
 
 	applicationTypeID := fixtures.TestApplicationTypeData[3].Id
 	sourceTypeID := fixtures.TestSourceTypeData[2].Id
+
 	recordsWithUserID, user, err := CreateSourceWithSubResources(sourceTypeID, applicationTypeID, accountNumber, &userIDWithOwnRecords)
 	if err != nil {
 		t.Errorf("unable to create source: %v", err)
@@ -997,6 +1046,7 @@ func TestSourceListUserOwnership(t *testing.T) {
 func TestSourceGetUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -1005,6 +1055,7 @@ func TestSourceGetUserOwnership(t *testing.T) {
 		 Test 1 - UserA tries to GET userA's source - expected result: success
 		*/
 		sourceDaoUserA := GetSourceDao(suiteData.GetRequestParamsUserA())
+
 		sourceUserA, err := sourceDaoUserA.GetById(&suiteData.SourceUserA().ID)
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -1043,7 +1094,6 @@ func TestSourceGetUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -1054,6 +1104,7 @@ func TestSourceGetUserOwnership(t *testing.T) {
 func TestSourceEditUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -1065,6 +1116,7 @@ func TestSourceEditUserOwnership(t *testing.T) {
 
 		newNameSource := "new name"
 		newSourceUserA := &m.Source{ID: suiteData.SourceUserA().ID, Name: newNameSource}
+
 		err := sourceDaoUserA.Update(newSourceUserA)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
@@ -1083,6 +1135,7 @@ func TestSourceEditUserOwnership(t *testing.T) {
 		 Test 2 - UserA tries to update source without user - expected result: success
 		*/
 		newSourceNoUser := &m.Source{ID: suiteData.SourceNoUser().ID, Name: newNameSource}
+
 		err = sourceDaoUserA.Update(newSourceNoUser)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
@@ -1105,6 +1158,7 @@ func TestSourceEditUserOwnership(t *testing.T) {
 
 		newNameSource = "amazon"
 		newSourceUserB := &m.Source{ID: suiteData.SourceUserA().ID, Name: newNameSource}
+
 		err = sourceDaoWithUser.Update(newSourceUserB)
 		if err != nil {
 			t.Errorf(`unexpected error after calling Update: %v`, err)
@@ -1121,7 +1175,6 @@ func TestSourceEditUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}
@@ -1132,6 +1185,7 @@ func TestSourceEditUserOwnership(t *testing.T) {
 func TestSourceSubcollectionWithUserOwnership(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	testutils.SkipIfNotSecretStoreDatabase(t)
+
 	schema := "user_ownership"
 	SwitchSchema(schema)
 
@@ -1141,6 +1195,7 @@ func TestSourceSubcollectionWithUserOwnership(t *testing.T) {
 		*/
 		sourceDaoUserA := GetSourceDao(suiteData.GetRequestParamsUserA())
 		applicationType := m.ApplicationType{Id: fixtures.TestApplicationTypeData[3].Id}
+
 		sources, _, err := sourceDaoUserA.SubCollectionList(applicationType, 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -1162,6 +1217,7 @@ func TestSourceSubcollectionWithUserOwnership(t *testing.T) {
 		requestParams := &RequestParams{TenantID: suiteData.TenantID(), UserID: &suiteData.userWithoutOwnershipRecords.Id}
 		sourceDaoWithUser := GetSourceDao(requestParams)
 		applicationType = m.ApplicationType{Id: fixtures.TestApplicationTypeData[3].Id}
+
 		sources, _, err = sourceDaoWithUser.SubCollectionList(applicationType, 1000, 0, []util.Filter{})
 		if err != nil {
 			t.Errorf(`unexpected error after calling GetById for the source: %s`, err)
@@ -1177,6 +1233,7 @@ func TestSourceSubcollectionWithUserOwnership(t *testing.T) {
 		}
 
 		rhcDAO := GetRhcConnectionDao(requestParams)
+
 		rhcSourceUserA, errRhc := rhcDAO.Create(&m.RhcConnection{Sources: suiteData.resourcesUserA.Sources})
 		if errRhc != nil {
 			t.Errorf(`unexpected error after calling Create for rhc connection: %v`, errRhc)
@@ -1210,7 +1267,6 @@ func TestSourceSubcollectionWithUserOwnership(t *testing.T) {
 
 		return nil
 	})
-
 	if err != nil {
 		t.Errorf("test run was not successful %v", err)
 	}

--- a/dao/source_type_dao.go
+++ b/dao/source_type_dao.go
@@ -54,7 +54,6 @@ func (st *sourceTypeDaoImpl) GetById(id *int64) (*m.SourceType, error) {
 		Where("id = ?", *id).
 		First(&sourceType).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("source type")
 	}
@@ -71,11 +70,13 @@ func (st *sourceTypeDaoImpl) GetByName(name string) (*m.SourceType, error) {
 	if result.Error != nil {
 		return nil, result.Error
 	}
+
 	if result.RowsAffected > int64(1) {
 		return nil, util.NewErrBadRequest("Found more than one of the same source type name")
 	} else if result.RowsAffected == int64(0) {
 		return nil, util.NewErrNotFound("source type")
 	}
+
 	return &sourceTypes[0], nil
 }
 

--- a/dao/source_type_dao_test.go
+++ b/dao/source_type_dao_test.go
@@ -30,6 +30,7 @@ func TestSourceTypeListOffsetAndLimit(t *testing.T) {
 		}
 
 		got := len(sourceTypes)
+
 		want := int(wantCount) - d.Offset
 		if want < 0 {
 			want = 0
@@ -38,19 +39,23 @@ func TestSourceTypeListOffsetAndLimit(t *testing.T) {
 		if want > d.Limit {
 			want = d.Limit
 		}
+
 		if got != want {
 			t.Errorf(`objects passed back from DB: want "%v", got "%v"`, want, got)
 		}
 	}
+
 	DropSchema("offset_limit")
 }
 
 func TestSourceTypeGetByName(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("source_type_by_name")
+
 	wantSourceType := fixtures.TestSourceTypeData[1]
 
 	sourceTypeDao := GetSourceTypeDao()
+
 	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
 	if err != nil {
 		t.Error(err)
@@ -66,9 +71,11 @@ func TestSourceTypeGetByName(t *testing.T) {
 func TestSourceTypeGetByNameNotFound(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("source_type_by_name")
+
 	wantSourceType := m.SourceType{Name: "not existing name"}
 
 	sourceTypeDao := GetSourceTypeDao()
+
 	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
 	if gotSourceType != nil {
 		t.Error("got source type object, want nil")
@@ -84,9 +91,11 @@ func TestSourceTypeGetByNameNotFound(t *testing.T) {
 func TestSourceTypeGetByNameBadRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("source_type_by_name")
+
 	wantSourceType := m.SourceType{Name: "amazon"}
 
 	sourceTypeDao := GetSourceTypeDao()
+
 	gotSourceType, err := sourceTypeDao.GetByName(wantSourceType.Name)
 	if gotSourceType != nil {
 		t.Error("got source type object, want nil")

--- a/dao/tenant_dao.go
+++ b/dao/tenant_dao.go
@@ -38,8 +38,10 @@ type tenantDaoImpl struct{}
 
 func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenant, error) {
 	// Try to find the tenant. Prefer fetching it by its OrgId first, since EBS account numbers are deprecated.
-	var tenant m.Tenant
-	var err error
+	var (
+		tenant m.Tenant
+		err    error
+	)
 
 	err = DB.
 		Debug().
@@ -63,7 +65,6 @@ func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenan
 			Where("external_tenant = ? AND external_tenant != ''", identity.AccountNumber).
 			First(&tenant).
 			Error
-
 		if err == nil && tenant != (m.Tenant{}) {
 			logger.Log.WithFields(logrus.Fields{"account_number": identity.AccountNumber}).Warn("tenant found by its EBS account number")
 		}
@@ -85,7 +86,6 @@ func (t *tenantDaoImpl) GetOrCreateTenant(identity *identity.Identity) (*m.Tenan
 			Debug().
 			Create(&tenant).
 			Error
-
 		if err != nil {
 			logger.Log.WithFields(logrus.Fields{"org_id": identity.OrgID, "account_number": identity.AccountNumber}).Errorf("Unable to create tenant: %s", err)
 
@@ -110,7 +110,6 @@ func (t *tenantDaoImpl) TenantByIdentity(id *identity.Identity) (*m.Tenant, erro
 		Or("external_tenant = ? AND external_tenant != ''", id.AccountNumber).
 		First(&tenant).
 		Error
-
 	if err != nil {
 		return nil, util.NewErrNotFound("tenant")
 	}
@@ -126,7 +125,6 @@ func (t *tenantDaoImpl) GetUntranslatedTenants() ([]m.Tenant, error) {
 		Where(untranslatedTenantsWhereCondition).
 		Find(&tenants).
 		Error
-
 	if err != nil {
 		return nil, err
 	}
@@ -151,15 +149,16 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 			Where(untranslatedTenantsWhereCondition).
 			Count(&translatableTenants).
 			Error
-
 		if err != nil {
 			return fmt.Errorf("unable to count untranslated tenants: %w", err)
 		}
 
 		translator := tenantid.NewTranslator(config.Get().TenantTranslatorUrl)
+
 		for i := int64(0); i < translatableTenants; i += 100 {
 			// Grab all the EBS account numbers to be processed.
 			var ebsAccountNumbers []string
+
 			err := tx.
 				Model(&m.Tenant{}).
 				Where(untranslatedTenantsWhereCondition).
@@ -168,7 +167,6 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 				Order(clause.OrderByColumn{Column: clause.Column{Name: "external_tenant"}, Desc: false}).
 				Limit(100).
 				Error
-
 			if err != nil {
 				return fmt.Errorf("unable to fetch the tenants to translate them: %w", err)
 			}
@@ -191,6 +189,7 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 					tenantTranslations = append(tenantTranslations, tenantTranslation)
 
 					untranslatedTenants++
+
 					continue
 				}
 
@@ -215,6 +214,7 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 					tenantTranslations = append(tenantTranslations, tenantTranslation)
 
 					untranslatedTenants++
+
 					continue
 				}
 
@@ -230,6 +230,7 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 					tenantTranslations = append(tenantTranslations, tenantTranslation)
 
 					untranslatedTenants++
+
 					continue
 				}
 
@@ -248,7 +249,6 @@ func (t *tenantDaoImpl) TranslateTenants() (int64, uint64, uint64, []m.TenantTra
 
 		return nil
 	})
-
 	if err != nil {
 		return 0, 0, 0, nil, err
 	}

--- a/dao/tenant_dao_test.go
+++ b/dao/tenant_dao_test.go
@@ -30,13 +30,13 @@ func TestGetOrCreateTenantIDEbsNumberCreate(t *testing.T) {
 	}
 
 	var tenant model.Tenant
+
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
 		Where(`id = ?`, dbTenant.Id).
 		First(&tenant).
 		Error
-
 	if err != nil {
 		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
 	}
@@ -69,13 +69,13 @@ func TestGetOrCreateTenantIDEbsNumberFind(t *testing.T) {
 	}
 
 	var tenant model.Tenant
+
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
 		Where(`id = ?`, dbTenant.Id).
 		First(&tenant).
 		Error
-
 	if err != nil {
 		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
 	}
@@ -108,13 +108,13 @@ func TestGetOrCreateTenantIDOrgIdCreate(t *testing.T) {
 	}
 
 	var tenant model.Tenant
+
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
 		Where(`id = ?`, dbTenant.Id).
 		First(&tenant).
 		Error
-
 	if err != nil {
 		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
 	}
@@ -146,13 +146,13 @@ func TestGetOrCreateTenantIDOrgIdFind(t *testing.T) {
 	}
 
 	var tenant model.Tenant
+
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
 		Where(`id = ?`, dbTenant.Id).
 		First(&tenant).
 		Error
-
 	if err != nil {
 		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
 	}
@@ -222,7 +222,6 @@ func TestTenantByIdentityNotFound(t *testing.T) {
 	_, err := tenantDao.TenantByIdentity(&identity.Identity{
 		AccountNumber: "invalid",
 	})
-
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
@@ -231,7 +230,6 @@ func TestTenantByIdentityNotFound(t *testing.T) {
 	_, err = tenantDao.TenantByIdentity(&identity.Identity{
 		OrgID: "invalid",
 	})
-
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
@@ -258,13 +256,13 @@ func TestCreateTenantNullEbsOrgId(t *testing.T) {
 	// Fetch the created tenant. We need to use a "map[string]interface{}" because the tenant model doesn't use a
 	// pointer value, and therefore the "NULL" value from the database would get mapped as an empty string.
 	var createdTenant map[string]interface{}
+
 	err = DB.
 		Debug().
 		Model(&model.Tenant{}).
 		Where("id = ?", tenant.Id).
 		Find(&createdTenant).
 		Error
-
 	if err != nil {
 		t.Errorf(`error when trying to find the created tenant: %s`, err)
 	}

--- a/dao/test_factories.go
+++ b/dao/test_factories.go
@@ -16,6 +16,7 @@ func CreateTenantForAccountNumber(accountNumber string) (*int64, error) {
 	}
 
 	tenantDao := GetTenantDao()
+
 	tenant, err := tenantDao.GetOrCreateTenant(&identityStruct)
 	if err != nil {
 		return nil, fmt.Errorf("error getting or creating the tenant")
@@ -26,6 +27,7 @@ func CreateTenantForAccountNumber(accountNumber string) (*int64, error) {
 
 func CreateUserForUserID(userIDFromHeader string, tenantID int64) (*m.User, error) {
 	userDao := GetUserDao(&tenantID)
+
 	user, err := userDao.FindOrCreate(userIDFromHeader)
 	if err != nil {
 		return nil, fmt.Errorf("error getting or creating the user")
@@ -40,6 +42,7 @@ func CreateSource(sourceTypeID int64, tenantID int64, userID *int64) (*m.Source,
 	source := &m.Source{Name: name, UserID: userID, SourceTypeID: sourceTypeID, Uid: &uid}
 	requestParamsForCreate := &RequestParams{TenantID: &tenantID, UserID: userID}
 	sourceDaoForCreate := GetSourceDao(requestParamsForCreate)
+
 	err := sourceDaoForCreate.Create(source)
 	if err != nil {
 		return nil, fmt.Errorf("error creating the source")
@@ -52,6 +55,7 @@ func CreateApplication(sourceID int64, applicationTypeID int64, tenantID int64, 
 	app := &m.Application{UserID: userID, ApplicationTypeID: applicationTypeID, SourceID: sourceID}
 	requestParamsForCreate := &RequestParams{TenantID: &tenantID, UserID: userID}
 	appDaoForCreate := GetApplicationDao(requestParamsForCreate)
+
 	err := appDaoForCreate.Create(app)
 	if err != nil {
 		return nil, fmt.Errorf("error creating the application")
@@ -65,6 +69,7 @@ func CreateAuthenticationFromApplication(appID int64, tenantID int64, userID *in
 	auth := &m.Authentication{Name: &name, UserID: userID, ResourceType: "Application", ResourceID: appID}
 	requestParamsForCreate := &RequestParams{TenantID: &tenantID, UserID: userID}
 	authDaoForCreate := GetAuthenticationDao(requestParamsForCreate)
+
 	err := authDaoForCreate.Create(auth)
 	if err != nil {
 		return nil, fmt.Errorf("error creating the application")
@@ -77,6 +82,7 @@ func CreateApplicationAuthentication(authID int64, appID int64, hello int64, use
 	aa := &m.ApplicationAuthentication{UserID: userID, ApplicationID: appID, AuthenticationID: authID}
 	requestParamsForCreate := &RequestParams{TenantID: &hello, UserID: userID}
 	appAuthDaoForCreate := GetApplicationAuthenticationDao(requestParamsForCreate)
+
 	err := appAuthDaoForCreate.Create(aa)
 	if err != nil {
 		return nil, fmt.Errorf("error creating the application")
@@ -93,14 +99,17 @@ func CreateSourceWithSubResources(sourceTypeID int64, applicationTypeID int64, a
 		return nil, nil, err
 	}
 
-	var userID *int64
-	var user *m.User
+	var (
+		userID *int64
+		user   *m.User
+	)
 
 	if userIDFromHeader != nil {
 		user, err = CreateUserForUserID(*userIDFromHeader, *tenantID)
 		if err != nil {
 			return nil, nil, err
 		}
+
 		userID = &user.Id
 	}
 
@@ -243,6 +252,7 @@ func TestSuiteForSourceWithOwnership(performTest func(suiteData *SourceOwnership
 
 	applicationTypeID := fixtures.TestApplicationTypeData[3].Id
 	sourceTypeID := fixtures.TestSourceTypeData[2].Id
+
 	resourcesUserA, userA, err := CreateSourceWithSubResources(sourceTypeID, applicationTypeID, accountNumber, &userIDA)
 	if err != nil {
 		return fmt.Errorf("unable to create source with subresources: %v for user %v", err, userIDA)
@@ -301,5 +311,6 @@ func CreateSecretByName(name string, tenantID *int64, userID *int64) (*m.Authent
 	}
 
 	err := secretDao.Create(secret)
+
 	return secret, err
 }

--- a/dao/type_cache.go
+++ b/dao/type_cache.go
@@ -86,17 +86,20 @@ func PopulateStaticTypeCache() error {
 	if err != nil {
 		return err
 	}
+
 	err = populateApplicationTypes(tc)
 	if err != nil {
 		return err
 	}
 
 	Static = tc
+
 	return nil
 }
 
 func populateSourceTypes(cache typeCache) error {
 	sourceTypes := make([]m.SourceType, 0)
+
 	result := DB.Model(&m.SourceType{}).Scan(&sourceTypes)
 	if result.Error != nil {
 		return result.Error
@@ -111,6 +114,7 @@ func populateSourceTypes(cache typeCache) error {
 
 func populateApplicationTypes(cache typeCache) error {
 	appTypes := make([]m.ApplicationType, 0)
+
 	result := DB.Model(&m.ApplicationType{}).Scan(&appTypes)
 	if result.Error != nil {
 		return result.Error

--- a/dao/type_cache_mock.go
+++ b/dao/type_cache_mock.go
@@ -16,5 +16,6 @@ func PopulateMockStaticTypeCache() error {
 	}
 
 	Static = tc
+
 	return nil
 }

--- a/dao/user_dao.go
+++ b/dao/user_dao.go
@@ -40,7 +40,6 @@ func (u *userDaoImpl) FindOrCreate(userID string) (*m.User, error) {
 		Where("tenant_id = ?", *u.TenantID).
 		First(&user).
 		Error
-
 	if err != nil {
 		user.TenantID = *u.TenantID
 		user.UserID = userID

--- a/dao/user_dao_test.go
+++ b/dao/user_dao_test.go
@@ -23,13 +23,13 @@ func TestFindOrCreateUser(t *testing.T) {
 	}
 
 	var expectedUser model.User
+
 	err = DB.
 		Debug().
 		Model(&model.User{}).
 		Where("id = ? AND tenant_id = ?", user.Id, user.TenantID).
 		First(&expectedUser).
 		Error
-
 	if err != nil {
 		t.Errorf(`error fetching the tenant. Want nil error, got "%s"`, err)
 	}

--- a/dao/vault/vault_client.go
+++ b/dao/vault/vault_client.go
@@ -19,6 +19,7 @@ func NewClient() VaultClient {
 	if cfg == nil {
 		panic("Failed to parse Vault Config")
 	}
+
 	err := cfg.ReadEnvironment()
 	if err != nil {
 		panic(fmt.Sprintf("Failed to read Vault Environment: %v", err))

--- a/db/migrations/20220510112000_add_application_constraint.go
+++ b/db/migrations/20220510112000_add_application_constraint.go
@@ -9,6 +9,7 @@ import (
 func AddApplicationConstraint() *gormigrate.Migration {
 	type Application struct {
 		gorm.Model
+
 		SourceID          int64 `gorm:"uniqueIndex:applications_app_type_id_source_id_tenant_id_idx"`
 		ApplicationTypeID int64 `gorm:"uniqueIndex:applications_app_type_id_source_id_tenant_id_idx"`
 		TenantID          int64 `gorm:"uniqueIndex:applications_app_type_id_source_id_tenant_id_idx"`

--- a/db/migrations/20220608090500_remove_duplicated_tenant_ids_org_ids.go
+++ b/db/migrations/20220608090500_remove_duplicated_tenant_ids_org_ids.go
@@ -212,7 +212,6 @@ func updateTenantFromTable(tx *gorm.DB, table string, oldTenantId int64, newTena
 		Debug().
 		Exec(updateQuery, newTenantId, oldTenantId).
 		Error
-
 	if err != nil {
 		return err
 	}
@@ -232,7 +231,6 @@ func markExternalTenantAsDuplicate(tx *gorm.DB, mark string, tenantId int64) err
 		Where("id = ?", tenantId).
 		Update("external_tenant", mark).
 		Error
-
 	if err != nil {
 		return err
 	}
@@ -252,7 +250,6 @@ func markOrgIdAsDuplicate(tx *gorm.DB, mark string, tenantId int64) error {
 		Where("id = ?", tenantId).
 		Update("org_id", mark).
 		Error
-
 	if err != nil {
 		return err
 	}

--- a/db/migrations/20220705103000_rename_indexes_foreign_keys.go
+++ b/db/migrations/20220705103000_rename_indexes_foreign_keys.go
@@ -11,13 +11,21 @@ import (
 // RenameForeignKeysIndexes renames the foreign keys and indexes to what Postgres names them by default.
 func RenameForeignKeysIndexes() *gormigrate.Migration {
 	type ApplicationAuthentications struct{}
+
 	type ApplicationTypes struct{}
+
 	type Applications struct{}
+
 	type Authentications struct{}
+
 	type Endpoints struct{}
+
 	type RhcConnections struct{}
+
 	type SourceRhcConnections struct{}
+
 	type SourceTypes struct{}
+
 	type Sources struct{}
 
 	type renameStruct struct {

--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -78,6 +78,7 @@ func Migrate(db *gorm.DB) {
 
 	// Perform the migrations and store the error for a proper return.
 	migrateTool := gormigrate.New(db, gormigrate.DefaultOptions, MigrationsCollection)
+
 	err = migrateTool.Migrate()
 	if err != nil {
 		logging.Log.Fatalf(`error when performing the database migrations: %s. The Redis lock is going to try to be released...`, err)

--- a/endpoint_handlers.go
+++ b/endpoint_handlers.go
@@ -19,7 +19,6 @@ var getEndpointDao func(c echo.Context) (dao.EndpointDao, error)
 
 func getEndpointDaoWithTenant(c echo.Context) (dao.EndpointDao, error) {
 	tenantId, err := echoUtils.GetTenantFromEchoContext(c)
-
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +53,6 @@ func SourceListEndpoint(c echo.Context) error {
 	}
 
 	endpoints, count, err = endpointDB.SubCollectionList(m.Source{ID: id}, limit, offset, filters)
-
 	if err != nil {
 		return err
 	}
@@ -119,7 +117,6 @@ func EndpointGet(c echo.Context) error {
 	c.Logger().Infof("Getting Endpoint ID %v", id)
 
 	app, err := endpointDB.GetById(&id)
-
 	if err != nil {
 		return err
 	}
@@ -134,6 +131,7 @@ func EndpointCreate(c echo.Context) error {
 	}
 
 	input := &m.EndpointCreateRequest{}
+
 	err = c.Bind(input)
 	if err != nil {
 		return err
@@ -184,6 +182,7 @@ func EndpointCreate(c echo.Context) error {
 	}
 
 	setEventStreamResource(c, endpoint)
+
 	return c.JSON(http.StatusCreated, endpoint.ToResponse())
 }
 
@@ -209,20 +208,26 @@ func EndpointEdit(c echo.Context) error {
 	// If "PausedAt" contains a date it means that the endpoint was paused back then.
 	if endpoint.PausedAt != nil {
 		input := &m.ResourceEditPausedRequest{}
-		if err := c.Bind(input); err != nil {
+
+		err := c.Bind(input)
+		if err != nil {
 			return err
 		}
 
-		if err := endpoint.UpdateFromRequestPaused(input); err != nil {
+		err = endpoint.UpdateFromRequestPaused(input)
+		if err != nil {
 			return util.NewErrBadRequest(err)
 		}
 	} else {
 		input := &m.EndpointEditRequest{}
-		if err := c.Bind(input); err != nil {
+
+		err := c.Bind(input)
+		if err != nil {
 			return err
 		}
 
-		if err = service.ValidateEndpointEditRequest(endpointDao, endpoint.SourceID, input); err != nil {
+		err = service.ValidateEndpointEditRequest(endpointDao, endpoint.SourceID, input)
+		if err != nil {
 			return util.NewErrBadRequest(err)
 		}
 
@@ -268,6 +273,7 @@ func EndpointDelete(c echo.Context) error {
 	if err != nil {
 		return err
 	}
+
 	err = service.DeleteCascade(endpointDao.Tenant(), nil, "Endpoint", id, forwardableHeaders)
 	if err != nil {
 		return util.NewErrBadRequest(err)
@@ -303,6 +309,7 @@ func EndpointListAuthentications(c echo.Context) error {
 	}
 
 	tenantId := authDB.Tenant()
+
 	out := make([]interface{}, len(auths))
 	for i := 0; i < len(auths); i++ {
 		// Set the marketplace token —if the auth is of the marketplace type— for the authentication.

--- a/endpoint_handlers_test.go
+++ b/endpoint_handlers_test.go
@@ -56,6 +56,7 @@ func TestSourceEndpointSubcollectionList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -70,6 +71,7 @@ func TestSourceEndpointSubcollectionList(t *testing.T) {
 	}
 
 	var wantCount int
+
 	for _, e := range fixtures.TestEndpointData {
 		if e.TenantID == tenantId && e.SourceID == sourceId {
 			wantCount++
@@ -141,6 +143,7 @@ func TestSourceEndpointSubcollectionListEmptyList(t *testing.T) {
 // for not existing tenant
 func TestSourceEndpointSubcollectionListTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
@@ -160,6 +163,7 @@ func TestSourceEndpointSubcollectionListTenantNotExist(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceListEndpoint := ErrorHandlingContext(SourceListEndpoint)
+
 	err := notFoundSourceListEndpoint(c)
 	if err != nil {
 		t.Error(err)
@@ -172,6 +176,7 @@ func TestSourceEndpointSubcollectionListTenantNotExist(t *testing.T) {
 // for existing tenant who doesn't own the source
 func TestSourceEndpointSubcollectionListInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	sourceId := int64(1)
 
@@ -191,6 +196,7 @@ func TestSourceEndpointSubcollectionListInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceListEndpoint := ErrorHandlingContext(SourceListEndpoint)
+
 	err := notFoundSourceListEndpoint(c)
 	if err != nil {
 		t.Error(err)
@@ -216,6 +222,7 @@ func TestSourceEndpointSubcollectionListNotFound(t *testing.T) {
 	c.SetParamValues("983749387")
 
 	notFoundSourceListEndpoint := ErrorHandlingContext(SourceListEndpoint)
+
 	err := notFoundSourceListEndpoint(c)
 	if err != nil {
 		t.Error(err)
@@ -241,6 +248,7 @@ func TestSourceEndpointSubcollectionListBadRequestInvalidSyntax(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestSourceListEndpoint := ErrorHandlingContext(SourceListEndpoint)
+
 	err := badRequestSourceListEndpoint(c)
 	if err != nil {
 		t.Error(err)
@@ -270,6 +278,7 @@ func TestSourceEndpointSubcollectionListBadRequestInvalidFilter(t *testing.T) {
 	c.SetParamValues("1")
 
 	badRequestSourceListEndpoint := ErrorHandlingContext(SourceListEndpoint)
+
 	err := badRequestSourceListEndpoint(c)
 	if err != nil {
 		t.Error(err)
@@ -303,6 +312,7 @@ func TestEndpointList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -317,11 +327,13 @@ func TestEndpointList(t *testing.T) {
 	}
 
 	var wantCount int
+
 	for _, e := range fixtures.TestEndpointData {
 		if e.TenantID == tenantId {
 			wantCount++
 		}
 	}
+
 	if len(out.Data) != wantCount {
 		t.Error("not enough objects passed back from DB")
 	}
@@ -358,6 +370,7 @@ func TestEndpointList(t *testing.T) {
 // not existing tenant
 func TestEndpointListTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 
 	c, rec := request.CreateTestContext(
@@ -384,6 +397,7 @@ func TestEndpointListTenantNotExist(t *testing.T) {
 // existing tenant without endpoints
 func TestEndpointListInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 
 	c, rec := request.CreateTestContext(
@@ -424,6 +438,7 @@ func TestEndpointListBadRequestInvalidFilter(t *testing.T) {
 	)
 
 	badRequestEndpointList := ErrorHandlingContext(EndpointList)
+
 	err := badRequestEndpointList(c)
 	if err != nil {
 		t.Error(err)
@@ -458,6 +473,7 @@ func TestEndpointGet(t *testing.T) {
 	}
 
 	var outEndpoint m.EndpointResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &outEndpoint)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -482,6 +498,7 @@ func TestEndpointGet(t *testing.T) {
 // a tenant who doesn't own the endpoint
 func TestEndpointGetInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	endpointId := int64(1)
 
@@ -498,6 +515,7 @@ func TestEndpointGetInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", endpointId))
 
 	notFoundEndpointGet := ErrorHandlingContext(EndpointGet)
+
 	err := notFoundEndpointGet(c)
 	if err != nil {
 		t.Error(err)
@@ -510,6 +528,7 @@ func TestEndpointGetInvalidTenant(t *testing.T) {
 // not existing tenant
 func TestEndpointGetTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	endpointId := int64(1)
 
@@ -526,6 +545,7 @@ func TestEndpointGetTenantNotExist(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", endpointId))
 
 	notFoundEndpointGet := ErrorHandlingContext(EndpointGet)
+
 	err := notFoundEndpointGet(c)
 	if err != nil {
 		t.Error(err)
@@ -548,6 +568,7 @@ func TestEndpointGetNotFound(t *testing.T) {
 	c.SetParamValues("970283452983")
 
 	notFoundEndpointGet := ErrorHandlingContext(EndpointGet)
+
 	err := notFoundEndpointGet(c)
 	if err != nil {
 		t.Error(err)
@@ -570,6 +591,7 @@ func TestEndpointGetBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestEndpointGet := ErrorHandlingContext(EndpointGet)
+
 	err := badRequestEndpointGet(c)
 	if err != nil {
 		t.Error(err)
@@ -581,6 +603,7 @@ func TestEndpointGetBadRequest(t *testing.T) {
 // Tests that the endpoint is properly creating "endpoints" and returning a 201 code.
 func TestEndpointCreate(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 	sourceId := int64(1)
 
@@ -629,6 +652,7 @@ func TestEndpointCreate(t *testing.T) {
 	}
 
 	var endpointOut m.EndpointResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &endpointOut)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -649,6 +673,7 @@ func TestEndpointCreate(t *testing.T) {
 
 	// Delete the created endpoint
 	endpointDao := dao.GetEndpointDao(&tenantId)
+
 	deletedEndpoint, err := endpointDao.Delete(&endpointOutId)
 	if err != nil {
 		t.Error(err)
@@ -682,6 +707,7 @@ func TestEndpointCreateBadRequest(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestEndpointCreate := ErrorHandlingContext(EndpointCreate)
+
 	err = badRequestEndpointCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -694,6 +720,7 @@ func TestEndpointCreateBadRequest(t *testing.T) {
 // when create request contains source id that is not owned by tenant
 func TestEndpointCreateInvalidSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	sourceId := int64(1)
 
@@ -718,6 +745,7 @@ func TestEndpointCreateInvalidSource(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestEndpointCreate := ErrorHandlingContext(EndpointCreate)
+
 	err = badRequestEndpointCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -759,6 +787,7 @@ func TestEndpointEdit(t *testing.T) {
 	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: fixtures.TestTenantData[0].ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(EndpointEdit)
+
 	err := sourceEditHandlerWithNotifier(c)
 	if err != nil {
 		t.Error(err)
@@ -770,6 +799,7 @@ func TestEndpointEdit(t *testing.T) {
 
 	endpointOut := m.EndpointResponse{}
 	raw, _ := io.ReadAll(rec.Body)
+
 	err = json.Unmarshal(raw, &endpointOut)
 	if err != nil {
 		t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -778,6 +808,7 @@ func TestEndpointEdit(t *testing.T) {
 	if *endpointOut.AvailabilityStatus != "available" {
 		t.Errorf("Wrong availability status, wanted %v got %v", "available", *endpointOut.AvailabilityStatus)
 	}
+
 	notificationProducer, ok := service.NotificationProducer.(*mocks.MockAvailabilityStatusNotificationProducer)
 	if !ok {
 		t.Errorf("unable to cast notification producer")
@@ -841,6 +872,7 @@ func TestEndpointEdit(t *testing.T) {
 // tries to edit not owned endpoint
 func TestEndpointEditInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	endpointId := int64(1)
 
@@ -864,6 +896,7 @@ func TestEndpointEditInvalidTenant(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundApplicationEdit := ErrorHandlingContext(EndpointEdit)
+
 	err := notFoundApplicationEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -894,6 +927,7 @@ func TestEndpointEditNotFound(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundApplicationEdit := ErrorHandlingContext(EndpointEdit)
+
 	err := notFoundApplicationEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -924,6 +958,7 @@ func TestEndpointEditBadRequest(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestEndpointEdit := ErrorHandlingContext(EndpointEdit)
+
 	err := badRequestEndpointEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -1041,6 +1076,7 @@ func TestEndpointDelete(t *testing.T) {
 // to delete not owned endpoint
 func TestEndpointDeleteInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	endpointId := int64(1)
 
@@ -1057,6 +1093,7 @@ func TestEndpointDeleteInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", endpointId))
 
 	notFoundEndpointDelete := ErrorHandlingContext(EndpointDelete)
+
 	err := notFoundEndpointDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -1079,6 +1116,7 @@ func TestEndpointDeleteBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestEndpointDelete := ErrorHandlingContext(EndpointDelete)
+
 	err := badRequestEndpointDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -1103,6 +1141,7 @@ func TestEndpointDeleteNotFound(t *testing.T) {
 	c.SetParamValues("5789395389375")
 
 	notFoundEndpointDelete := ErrorHandlingContext(EndpointDelete)
+
 	err := notFoundEndpointDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -1262,6 +1301,7 @@ func TestEndpointListAuthentications(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -1276,6 +1316,7 @@ func TestEndpointListAuthentications(t *testing.T) {
 	}
 
 	var wantCount int
+
 	for _, a := range fixtures.TestAuthenticationData {
 		if a.ResourceType == "Endpoint" && a.TenantID == tenantId {
 			wantCount++
@@ -1340,6 +1381,7 @@ func TestEndpointListAuthenticationsEmptyList(t *testing.T) {
 // for not existing tenant
 func TestEndpointListAuthenticationsTenantNotExist(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	endpointId := int64(1)
 
@@ -1359,6 +1401,7 @@ func TestEndpointListAuthenticationsTenantNotExist(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", endpointId))
 
 	notFoundEndpointListAuthentications := ErrorHandlingContext(EndpointListAuthentications)
+
 	err := notFoundEndpointListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1371,6 +1414,7 @@ func TestEndpointListAuthenticationsTenantNotExist(t *testing.T) {
 // for tenant who doesn't own the endpoint
 func TestEndpointListAuthenticationsInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	endpointId := int64(1)
 
@@ -1390,6 +1434,7 @@ func TestEndpointListAuthenticationsInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", endpointId))
 
 	notFoundEndpointListAuthentications := ErrorHandlingContext(EndpointListAuthentications)
+
 	err := notFoundEndpointListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1415,6 +1460,7 @@ func TestEndpointListAuthenticationsBadRequestInvalidEndpointId(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestEndpointListAuthentications := ErrorHandlingContext(EndpointListAuthentications)
+
 	err := badRequestEndpointListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1444,6 +1490,7 @@ func TestEndpointListAuthenticationsBadRequestInvalidFilter(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestEndpointListAuthentications := ErrorHandlingContext(EndpointListAuthentications)
+
 	err := badRequestEndpointListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1469,6 +1516,7 @@ func TestEndpointListAuthenticationsNotFound(t *testing.T) {
 	c.SetParamValues("09834098349")
 
 	notFoundEndpointListAuthentications := ErrorHandlingContext(EndpointListAuthentications)
+
 	err := notFoundEndpointListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -1487,6 +1535,7 @@ func checkAllEndpointsBelongToTenant(tenantId int64, endpoints []interface{}) er
 		if err != nil {
 			return err
 		}
+
 		for _, e := range fixtures.TestEndpointData {
 			if e.ID == endpointOutId {
 				if e.TenantID != tenantId {
@@ -1495,5 +1544,6 @@ func checkAllEndpointsBelongToTenant(tenantId int64, endpoints []interface{}) er
 			}
 		}
 	}
+
 	return nil
 }

--- a/graph/arguments.go
+++ b/graph/arguments.go
@@ -35,6 +35,7 @@ func parseSortBy(sortBy []*generated_model.SortBy) []util.Filter {
 	if len(sorts) == 0 {
 		sorts = append(sorts, util.Filter{Operation: "sort_by", Value: []string{"id ASC"}})
 	}
+
 	return sorts
 }
 
@@ -63,5 +64,6 @@ func parseFilters(filters []*generated_model.Filter) []util.Filter {
 
 		outFilters[i] = filter
 	}
+
 	return outFilters
 }

--- a/graphql_handlers_test.go
+++ b/graphql_handlers_test.go
@@ -38,7 +38,9 @@ func TestGraphQL(t *testing.T) {
 	}
 
 	bytes, _ := io.ReadAll(rec.Body)
+
 	var body map[string]interface{}
+
 	err = json.Unmarshal(bytes, &body)
 	if err != nil {
 		t.Error(err)

--- a/helpers.go
+++ b/helpers.go
@@ -14,8 +14,10 @@ import (
 )
 
 func getFilters(c echo.Context) ([]util.Filter, error) {
-	var filters []util.Filter
-	var ok bool
+	var (
+		filters []util.Filter
+		ok      bool
+	)
 
 	filterVal := c.Get("filters")
 	if filters, ok = filterVal.([]util.Filter); !ok {
@@ -26,8 +28,10 @@ func getFilters(c echo.Context) ([]util.Filter, error) {
 }
 
 func getLimitAndOffset(c echo.Context) (int, int, error) {
-	var limit, offset int
-	var ok bool
+	var (
+		limit, offset int
+		ok            bool
+	)
 
 	limitVal := c.Get("limit")
 	if limit, ok = limitVal.(int); !ok {
@@ -64,6 +68,7 @@ func setEventStreamResource(c echo.Context, model m.Event) {
 
 	// get the event type that just happened based on the http request
 	event := ""
+
 	switch c.Request().Method {
 	case http.MethodPost:
 		event = ".create"

--- a/internal/testutils/database/database.go
+++ b/internal/testutils/database/database.go
@@ -26,7 +26,6 @@ func ConnectToTestDB(dbSchema string) {
 			TablePrefix: dbSchema + ".",
 		},
 	})
-
 	if err != nil {
 		log.Fatalf("db does not exist - create the database '%s' first with '-createdb'. Error: %s", testDbName, err)
 	}
@@ -39,6 +38,7 @@ func ConnectToTestDB(dbSchema string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	rawDB.SetMaxOpenConns(20)
 
 	// Set the dao.DB in case any tests want to use it
@@ -74,6 +74,7 @@ func CreateFixtures(schema string) {
 // successful.
 func CreateTestDB() {
 	fmt.Printf("Creating database '%s'...", testDbName)
+
 	db, err := gorm.Open(postgres.Open(testDbString("postgres")), &gorm.Config{})
 	if err != nil {
 		log.Fatalf("Error opening the database connection: %s", err)
@@ -99,15 +100,14 @@ func DropSchema(dbSchema string) {
 	if result.Error != nil {
 		log.Fatalf("Error in drop schema %s %s: ", dbSchema, result.Error.Error())
 	}
-
 }
 
 // MigrateSchema migrates all the models.
 func MigrateSchema() {
 	// Perform the migrations and store the error for a proper return.
 	migrateTool := gormigrate.New(dao.DB, gormigrate.DefaultOptions, migrations.MigrationsCollection)
-	err := migrateTool.Migrate()
 
+	err := migrateTool.Migrate()
 	if err != nil {
 		log.Fatalf(`error migrating the schema: %s`, err)
 	}

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -44,6 +44,7 @@ func GetSourcesWithAppType(appTypeId int64) []model.Source {
 
 	// Find sources for source IDs
 	var sources []model.Source
+
 	for id := range sourceIds {
 		for _, src := range fixtures.TestSourceData {
 			if id == src.ID {
@@ -58,6 +59,7 @@ func GetSourcesWithAppType(appTypeId int64) []model.Source {
 
 func AssertLinks(t *testing.T, path string, links util.Links, limit int, offset int) {
 	expectedFirstLink := fmt.Sprintf("%s?limit=%d&offset=%d", path, limit, offset)
+
 	expectedLastLink := fmt.Sprintf("%s?limit=%d&offset=%d", path, limit, limit+offset)
 	if links.First != expectedFirstLink {
 		t.Error("first link is not correct for " + path)
@@ -71,6 +73,7 @@ func AssertLinks(t *testing.T, path string, links util.Links, limit int, offset 
 func IdentityHeaderForUser(testUserId string) *identity.XRHID {
 	accountNumber := fixtures.TestTenantData[0].ExternalTenant
 	orgID := fixtures.TestTenantData[0].OrgID
+
 	return &identity.XRHID{Identity: identity.Identity{OrgID: orgID, AccountNumber: accountNumber, User: identity.User{UserID: testUserId}}}
 }
 

--- a/internal/testutils/mocks/mock_dao_application.go
+++ b/internal/testutils/mocks/mock_dao_application.go
@@ -85,6 +85,7 @@ func (mockAppDao *MockApplicationDao) Delete(id *int64) (*m.Application, error) 
 			return &app, nil
 		}
 	}
+
 	return nil, util.NewErrNotFound("application")
 }
 
@@ -100,6 +101,7 @@ func (mockAppDao *MockApplicationDao) User() *int64 {
 
 func (mockAppDao *MockApplicationDao) DeleteCascade(applicationId int64) ([]m.ApplicationAuthentication, *m.Application, error) {
 	var application *m.Application
+
 	for _, app := range fixtures.TestApplicationData {
 		if app.ID == applicationId {
 			application = &app

--- a/internal/testutils/mocks/mock_dao_application_type.go
+++ b/internal/testutils/mocks/mock_dao_application_type.go
@@ -47,16 +47,19 @@ func (mockAppTypeDao *MockApplicationTypeDao) SubCollectionList(primaryCollectio
 	switch object := primaryCollection.(type) {
 	case m.Source:
 		var sourceExists bool
+
 		for _, src := range fixtures.TestSourceData {
 			if src.ID == object.ID {
 				sourceExists = true
 			}
 		}
+
 		if !sourceExists {
 			return nil, 0, util.NewErrNotFound("source")
 		}
 
 		appTypes := make(map[int64]int)
+
 		for _, app := range fixtures.TestApplicationData {
 			if app.SourceID == object.ID {
 				appTypes[app.ApplicationTypeID]++
@@ -76,6 +79,7 @@ func (mockAppTypeDao *MockApplicationTypeDao) SubCollectionList(primaryCollectio
 	}
 
 	count := int64(len(appTypesOut))
+
 	return appTypesOut, count, nil
 }
 

--- a/internal/testutils/mocks/mock_dao_authentication.go
+++ b/internal/testutils/mocks/mock_dao_authentication.go
@@ -64,16 +64,19 @@ func (mockAuthDao MockAuthenticationDao) ListForSource(sourceID int64, _, _ int,
 
 func (mockAuthDao MockAuthenticationDao) ListForApplication(appId int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
 	var appExists bool
+
 	for _, app := range fixtures.TestApplicationData {
 		if app.ID == appId {
 			appExists = true
 		}
 	}
+
 	if !appExists {
 		return nil, 0, util.NewErrNotFound("application")
 	}
 
 	var out []m.Authentication
+
 	for _, auth := range fixtures.TestAuthenticationData {
 		if auth.ResourceType == "Application" && auth.ResourceID == appId {
 			out = append(out, auth)
@@ -84,13 +87,16 @@ func (mockAuthDao MockAuthenticationDao) ListForApplication(appId int64, _, _ in
 }
 
 func (mockAuthDao MockAuthenticationDao) ListForApplicationAuthentication(appAuthID int64, _, _ int, _ []util.Filter) ([]m.Authentication, int64, error) {
-	var appAuthExists bool
-	var authID int64
+	var (
+		appAuthExists bool
+		authID        int64
+	)
 
 	for _, appAuth := range fixtures.TestApplicationAuthenticationData {
 		if appAuth.ID == appAuthID {
 			authID = appAuth.AuthenticationID
 			appAuthExists = true
+
 			break
 		}
 	}
@@ -147,6 +153,7 @@ func (mockAuthDao MockAuthenticationDao) Update(auth *m.Authentication) error {
 	if auth.ID == fixtures.TestAuthenticationData[0].ID {
 		return nil
 	}
+
 	return util.NewErrNotFound("authentication")
 }
 
@@ -164,6 +171,7 @@ func (mockAuthDao MockAuthenticationDao) Delete(id string) (*m.Authentication, e
 			}
 		}
 	}
+
 	return nil, util.NewErrNotFound("authentication")
 }
 
@@ -194,6 +202,7 @@ func (mockAuthDao MockAuthenticationDao) BulkCreate(_ *m.Authentication) error {
 
 func (mockAuthDao MockAuthenticationDao) ListIdsForResource(resourceType string, resourceIds []int64) ([]m.Authentication, error) {
 	var authsList []m.Authentication
+
 	for _, auth := range fixtures.TestAuthenticationData {
 		for _, rid := range resourceIds {
 			if auth.ResourceType == resourceType && auth.ResourceID == rid {

--- a/internal/testutils/mocks/mock_dao_endpoint.go
+++ b/internal/testutils/mocks/mock_dao_endpoint.go
@@ -14,14 +14,18 @@ type MockEndpointDao struct {
 
 func (mockEndpointDao *MockEndpointDao) SubCollectionList(primaryCollection interface{}, _, _ int, _ []util.Filter) ([]m.Endpoint, int64, error) {
 	// Return not found err when the source doesn't exist
-	var sourceExist bool
-	var sourceId int64
+	var (
+		sourceExist bool
+		sourceId    int64
+	)
+
 	switch object := primaryCollection.(type) {
 	case m.Source:
 		for _, source := range fixtures.TestSourceData {
 			if object.ID == source.ID {
 				sourceExist = true
 				sourceId = object.ID
+
 				break
 			}
 		}
@@ -35,6 +39,7 @@ func (mockEndpointDao *MockEndpointDao) SubCollectionList(primaryCollection inte
 
 	// Get list of endpoints for existing source
 	var endpointsOut []m.Endpoint
+
 	for _, e := range mockEndpointDao.Endpoints {
 		if e.SourceID == sourceId {
 			endpointsOut = append(endpointsOut, e)
@@ -79,6 +84,7 @@ func (mockEndpointDao *MockEndpointDao) Delete(id *int64) (*m.Endpoint, error) {
 			return &e, nil
 		}
 	}
+
 	return nil, util.NewErrNotFound("endpoint")
 }
 

--- a/internal/testutils/mocks/mock_dao_meta_data.go
+++ b/internal/testutils/mocks/mock_dao_meta_data.go
@@ -29,6 +29,7 @@ func (mockMetaDataDao *MockMetaDataDao) SubCollectionList(primaryCollection inte
 			return nil, 0, fmt.Errorf("unexpected primary collection type")
 		}
 	}
+
 	count := int64(len(appMetaDataList))
 	if count == 0 {
 		return nil, count, util.NewErrNotFound("metadata")

--- a/internal/testutils/mocks/mock_dao_rhc_connection.go
+++ b/internal/testutils/mocks/mock_dao_rhc_connection.go
@@ -37,6 +37,7 @@ func (mockRhcConnectionDao *MockRhcConnectionDao) GetById(id *int64) (*m.RhcConn
 func (mockRhcConnectionDao *MockRhcConnectionDao) Create(rhcConnection *m.RhcConnection) (*m.RhcConnection, error) {
 	// Check if in fixtures is a source with given source id
 	var sourceExists bool
+
 	for _, src := range fixtures.TestSourceData {
 		if src.ID == rhcConnection.Sources[0].ID {
 			sourceExists = true
@@ -49,6 +50,7 @@ func (mockRhcConnectionDao *MockRhcConnectionDao) Create(rhcConnection *m.RhcCon
 
 	// Check if in fixtures exists same relation
 	var relationExists bool
+
 	for _, s := range fixtures.TestSourceRhcConnectionData {
 		if s.SourceId == rhcConnection.Sources[0].ID {
 			for _, r := range fixtures.TestRhcConnectionData {

--- a/internal/testutils/mocks/mock_dao_source.go
+++ b/internal/testutils/mocks/mock_dao_source.go
@@ -20,6 +20,7 @@ func (mockSourceDao *MockSourceDao) SubCollectionList(primaryCollection interfac
 	switch object := primaryCollection.(type) {
 	case m.SourceType:
 		var sourceTypeExists bool
+
 		for _, sourceType := range fixtures.TestSourceTypeData {
 			if sourceType.Id == object.Id {
 				sourceTypeExists = true
@@ -40,6 +41,7 @@ func (mockSourceDao *MockSourceDao) SubCollectionList(primaryCollection interfac
 
 	case m.ApplicationType:
 		var appTypeExists bool
+
 		for _, appType := range fixtures.TestApplicationTypeData {
 			if appType.Id == object.Id {
 				appTypeExists = true
@@ -59,6 +61,7 @@ func (mockSourceDao *MockSourceDao) SubCollectionList(primaryCollection interfac
 	}
 
 	count := int64(len(sources))
+
 	return sources, count, nil
 }
 
@@ -99,6 +102,7 @@ func (mockSourceDao *MockSourceDao) Delete(id *int64) (*m.Source, error) {
 			return &source, nil
 		}
 	}
+
 	return nil, util.NewErrNotFound("source")
 }
 
@@ -150,6 +154,7 @@ func (mockSourceDao *MockSourceDao) ListForRhcConnection(_ *int64, _, _ int, _ [
 
 func (mockSourceDao *MockSourceDao) DeleteCascade(id int64) ([]m.ApplicationAuthentication, []m.Application, []m.Endpoint, []m.RhcConnection, *m.Source, error) {
 	var source *m.Source
+
 	for _, src := range fixtures.TestSourceData {
 		if src.ID == id {
 			source = &src

--- a/internal/testutils/mocks/mock_notification_producer.go
+++ b/internal/testutils/mocks/mock_notification_producer.go
@@ -17,5 +17,6 @@ func (producer *MockAvailabilityStatusNotificationProducer) EmitAvailabilityStat
 	producer.EmailNotificationInfo = emailNotificationInfo
 	producer.AccountNumber = id.AccountNumber
 	producer.OrgId = id.OrgID
+
 	return nil
 }

--- a/internal/testutils/mocks/mock_sender.go
+++ b/internal/testutils/mocks/mock_sender.go
@@ -12,5 +12,6 @@ func (m *MockSender) RaiseEvent(_ string, b []byte, headers []kafka.Header) erro
 	m.Headers = headers
 	m.Body = string(b)
 	m.Hit++
+
 	return nil
 }

--- a/internal/testutils/mocks/mock_vault.go
+++ b/internal/testutils/mocks/mock_vault.go
@@ -22,6 +22,7 @@ func (m *MockVault) Read(path string) (*api.Secret, error) {
 			return createSecretOutput(auth), nil
 		}
 	}
+
 	return nil, nil
 }
 
@@ -51,6 +52,7 @@ func (m *MockVault) Delete(path string) (*api.Secret, error) {
 
 		return secret, nil
 	}
+
 	return nil, util.NewErrNotFound("authentication")
 }
 
@@ -62,6 +64,7 @@ func getVaultPathsFromFixtures() []interface{} {
 		path := fmt.Sprintf("%s_%d_%s", auth.ResourceType, auth.TenantID, auth.ID)
 		vaultPaths = append(vaultPaths, path)
 	}
+
 	return vaultPaths
 }
 
@@ -92,5 +95,6 @@ func createSecretOutput(auth m.Authentication) *api.Secret {
 	}
 
 	secret.Data["metadata"] = fixtures.TestAuthenticationVaultMetaData
+
 	return secret
 }

--- a/internal/testutils/templates/bad_request_template.go
+++ b/internal/testutils/templates/bad_request_template.go
@@ -15,6 +15,7 @@ func BadRequestTest(t *testing.T, rec *httptest.ResponseRecorder) {
 	}
 
 	var out util.ErrorDocument
+
 	err := json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -28,6 +29,7 @@ func BadRequestTest(t *testing.T, rec *httptest.ResponseRecorder) {
 		if !strings.HasPrefix(src.Detail, "bad request") {
 			t.Errorf("Wrong error message: expected prefix 'bad request' in '%s'", src.Detail)
 		}
+
 		if src.Status != "400" {
 			t.Errorf("Wrong error status: expected 400, got %s", src.Status)
 		}

--- a/internal/testutils/templates/empty_subcollection_list.go
+++ b/internal/testutils/templates/empty_subcollection_list.go
@@ -16,6 +16,7 @@ func EmptySubcollectionListTest(t *testing.T, c echo.Context, rec *httptest.Resp
 	}
 
 	var out util.Collection
+
 	err := json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")

--- a/internal/testutils/templates/not_found_template.go
+++ b/internal/testutils/templates/not_found_template.go
@@ -15,6 +15,7 @@ func NotFoundTest(t *testing.T, rec *httptest.ResponseRecorder) {
 	}
 
 	var out util.ErrorDocument
+
 	err := json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -28,6 +29,7 @@ func NotFoundTest(t *testing.T, rec *httptest.ResponseRecorder) {
 		if !strings.HasSuffix(src.Detail, "not found") {
 			t.Errorf("Wrong error message: expected suffix 'not found' in '%s'", src.Detail)
 		}
+
 		if src.Status != "404" {
 			t.Errorf("Wrong error status: expected 404, got %s", src.Status)
 		}

--- a/internal_handlers.go
+++ b/internal_handlers.go
@@ -54,8 +54,8 @@ func InternalSourceList(c echo.Context) error {
 
 	// The DAO doesn't need a tenant set, since the queries won't be filtered by that tenant
 	sourcesDB := dao.GetSourceDao(nil)
-	sources, count, err := sourcesDB.ListInternal(limit, offset, filters, skipEmptySources)
 
+	sources, count, err := sourcesDB.ListInternal(limit, offset, filters, skipEmptySources)
 	if err != nil {
 		return err
 	}

--- a/internal_handlers_test.go
+++ b/internal_handlers_test.go
@@ -39,6 +39,7 @@ func TestSourceListInternal(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshalling output")
@@ -84,19 +85,24 @@ func TestSourceListInternal(t *testing.T) {
 		}
 
 		sourceInFixtures := false
+
 		for _, source := range fixtures.TestSourceData {
 			if source.ID == responseSourceId {
 				if source.AvailabilityStatus != responseAvailabilityStatus {
 					t.Errorf("Availability statuses don't match. Want %s, got %s", source.AvailabilityStatus, responseAvailabilityStatus)
 				}
+
 				sourceInFixtures = true
+
 				break
 			}
 		}
+
 		if !sourceInFixtures {
 			t.Errorf("Source ID %d not found in fixtures", responseSourceId)
 		}
 	}
+
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
@@ -126,6 +132,7 @@ func TestSourceListInternalSkipEmptySources(t *testing.T) {
 		}
 
 		var out util.Collection
+
 		err = json.Unmarshal(recorder.Body.Bytes(), &out)
 		if err != nil {
 			t.Error("Failed unmarshalling output")
@@ -138,6 +145,7 @@ func TestSourceListInternalSkipEmptySources(t *testing.T) {
 
 		// Assert that the source with the Cost Management applications is or isn't present in the results.
 		var found = false
+
 		for _, src := range out.Data {
 			s, ok := src.(map[string]interface{})
 			if !ok {
@@ -176,7 +184,9 @@ func TestSourceListInternalSkipEmptySources(t *testing.T) {
 	}
 
 	applicationDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
-	if err := applicationDao.Create(application); err != nil {
+
+	err := applicationDao.Create(application)
+	if err != nil {
 		t.Errorf("unable to create Cost Management application: %s", err)
 	}
 
@@ -199,7 +209,9 @@ func TestSourceListInternalSkipEmptySources(t *testing.T) {
 	}
 
 	rhcConnectionDao := dao.GetRhcConnectionDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
-	if _, err := rhcConnectionDao.Create(rhcConnection); err != nil {
+
+	_, err = rhcConnectionDao.Create(rhcConnection)
+	if err != nil {
 		t.Errorf("unable to create the RHC Connection: %s", err)
 	}
 
@@ -231,6 +243,7 @@ func TestSourceListInternalBadRequestInvalidFilter(t *testing.T) {
 	)
 
 	badRequestInternalSourceList := ErrorHandlingContext(InternalSourceList)
+
 	err := badRequestInternalSourceList(c)
 	if err != nil {
 		t.Error(err)
@@ -248,6 +261,7 @@ func TestInternalSecretGet(t *testing.T) {
 	testUserId := "testUser"
 
 	userDao := dao.GetUserDao(&tenantIDForSecret)
+
 	user, err := userDao.FindOrCreate(testUserId)
 	if err != nil {
 		t.Error(err)
@@ -259,6 +273,7 @@ func TestInternalSecretGet(t *testing.T) {
 	}
 
 	var userID *int64
+
 	for _, userScoped := range []bool{false, true} {
 		if userScoped {
 			userID = &user.Id
@@ -300,6 +315,7 @@ func TestInternalSecretGet(t *testing.T) {
 		}
 
 		var outSecret m.SecretResponse
+
 		err = json.Unmarshal(rec.Body.Bytes(), &outSecret)
 		if err != nil {
 			t.Error("Failed unmarshaling output")
@@ -310,6 +326,7 @@ func TestInternalSecretGet(t *testing.T) {
 		}
 
 		secretDao := dao.GetSecretDao(&dao.RequestParams{TenantID: &tenantIDForSecret, UserID: userID})
+
 		secret, err = secretDao.GetById(&secret.DbID)
 		if err != nil {
 			t.Error("secret not found")

--- a/jobs/async_destroy.go
+++ b/jobs/async_destroy.go
@@ -58,5 +58,6 @@ func (ad AsyncDestroyJob) ToJSON() []byte {
 	if err != nil {
 		panic(err)
 	}
+
 	return bytes
 }

--- a/jobs/client.go
+++ b/jobs/client.go
@@ -27,6 +27,7 @@ func (jr *JobRequest) Parse() error {
 	switch jr.JobName {
 	case "SuperkeyDestroyJob":
 		sdj := SuperkeyDestroyJob{}
+
 		err := json.Unmarshal([]byte(jr.JobRaw), &sdj)
 		if err != nil {
 			return err
@@ -35,6 +36,7 @@ func (jr *JobRequest) Parse() error {
 		jr.Job = &sdj
 	case "AsyncDestroyJob":
 		adj := AsyncDestroyJob{}
+
 		err := json.Unmarshal(jr.JobRaw, &adj)
 		if err != nil {
 			return err

--- a/jobs/superkey.go
+++ b/jobs/superkey.go
@@ -65,6 +65,7 @@ func (sk SuperkeyDestroyJob) sendForSource(id int64) error {
 	}
 
 	errors := make([]error, 0)
+
 	for i := range apps {
 		err := sk.sendForApplication(apps[i].ID)
 		if err != nil {
@@ -114,5 +115,6 @@ func (sk SuperkeyDestroyJob) ToJSON() []byte {
 	if err != nil {
 		panic(err)
 	}
+
 	return bytes
 }

--- a/jobs/worker.go
+++ b/jobs/worker.go
@@ -64,8 +64,8 @@ func Run(shutdown chan struct{}) {
 	go healthCheck.healthChecker()
 
 	<-shutdown
-	shutdown <- struct{}{}
 
+	shutdown <- struct{}{}
 }
 
 // Run a Job with a delay but in the background so it does _not_ block the
@@ -91,11 +91,13 @@ func RunJob(j Job) {
 // `Enqueue` if you want to run the job immediately.
 func RunJobNow(j Job) {
 	l.Log.Infof("Running Job %v with %v", j.Name(), j.Arguments())
+
 	err := j.Run()
 	if err != nil {
 		l.Log.Warnf("Error running job [ %v ], args [ %v ] : [ %v ]", j.Name(), j.Arguments(), err)
 		return
 	}
+
 	l.Log.Infof("Finished Job %v with %v", j.Name(), j.Arguments())
 }
 
@@ -119,6 +121,7 @@ func (hc *BackgroundWorkerHealthChecker) healthChecker() {
 		if hc.timeStamp.Before(time.Now().Add(-30 * time.Second)) {
 			return c.String(http.StatusInternalServerError, "Failed to hit redis for more than 30 seconds.")
 		}
+
 		return c.String(http.StatusOK, "OK")
 	})
 

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -156,7 +156,6 @@ func Produce(writer *Writer, message *Message) error {
 
 	if !message.isEmpty() {
 		err := writer.WriteMessages(context.Background(), kafka.Message(*message))
-
 		if err != nil {
 			headersMap := make(map[string]string)
 			for _, h := range message.Headers {

--- a/kafka/sasl.go
+++ b/kafka/sasl.go
@@ -84,6 +84,7 @@ func CreateTLSConfig(caContents *string) *tls.Config {
 	}
 
 	TlsConfig = tlsConfig
+
 	return TlsConfig
 }
 
@@ -111,6 +112,7 @@ func CreateSaslMechanism(saslConfig *clowder.KafkaSASLConfig) (sasl.Mechanism, e
 	}
 
 	var algorithm scram.Algorithm
+
 	switch strings.ToLower(*saslConfig.SaslMechanism) {
 	case saslPlain:
 		return plain.Mechanism{Username: *saslConfig.Username, Password: *saslConfig.Password}, nil
@@ -128,6 +130,7 @@ func CreateSaslMechanism(saslConfig *clowder.KafkaSASLConfig) (sasl.Mechanism, e
 	}
 
 	SaslMechanism = mechanism
+
 	return SaslMechanism, nil
 }
 
@@ -138,5 +141,6 @@ func CreateTransport(sasl sasl.Mechanism, tls *tls.Config) *kafka.Transport {
 	}
 
 	Transport = &kafka.Transport{SASL: sasl, TLS: tls}
+
 	return Transport
 }

--- a/kafka/sasl_test.go
+++ b/kafka/sasl_test.go
@@ -48,8 +48,8 @@ func TestCreateDialerEmptySasl(t *testing.T) {
 	_, err := CreateDialer(&emptySaslConfig)
 
 	want := "could not create a dialer for Kafka: the passed configuration is missing the Sasl settings"
-	got := err
 
+	got := err
 	if want != got.Error() {
 		t.Errorf(`unexpected error received when creating a dialer. Want "%s", got "%s"`, want, got)
 	}
@@ -101,6 +101,7 @@ func TestCreateTlsConfigEmptyCaContents(t *testing.T) {
 
 		{
 			var want uint16 = tls.VersionTLS12
+
 			got := tlsConfig.MinVersion
 
 			if want != got {
@@ -110,6 +111,7 @@ func TestCreateTlsConfigEmptyCaContents(t *testing.T) {
 
 		{
 			var want *x509.CertPool
+
 			got := tlsConfig.RootCAs
 
 			if want != got {
@@ -158,6 +160,7 @@ A7sKPPcw7+uvTPyLNhBzPvOk
 
 	{
 		var want uint16 = tls.VersionTLS12
+
 		got := tlsConfig.MinVersion
 
 		if want != got {
@@ -214,6 +217,7 @@ func TestCreatSaslMechanismEmptySaslMechanism(t *testing.T) {
 	saslConfig := createKafkaSaslConfigurationFixture()
 
 	want := "could not create a Sasl mechanism for Kafka: the Sasl mechanism is empty"
+
 	for _, tv := range testValues {
 		saslConfig.SaslMechanism = tv
 
@@ -277,6 +281,7 @@ func TestCreateSaslPlainMechanism(t *testing.T) {
 	}
 
 	want := plainMech.Name()
+
 	got := mechanism.Name()
 	if want != got {
 		t.Errorf(`unexpected Sasl mechanism created. Want "%s", got "%s"`, want, got)
@@ -298,6 +303,7 @@ func TestCreateSaslSha512Mechanism(t *testing.T) {
 	}
 
 	want := scram.SHA256.Name()
+
 	got := mechanism.Name()
 	if want != got {
 		t.Errorf(`unexpected Sasl mechanism created. Want "%s", got "%s"`, want, got)
@@ -319,6 +325,7 @@ func TestCreateSaslScramSha512Mechanism(t *testing.T) {
 	}
 
 	want := scram.SHA512.Name()
+
 	got := mechanism.Name()
 	if want != got {
 		t.Errorf(`unexpected Sasl mechanism created. Want "%s", got "%s"`, want, got)
@@ -336,6 +343,7 @@ func TestCreateSaslInvalidMechanism(t *testing.T) {
 	_, err := CreateSaslMechanism(saslConfig)
 
 	want := `unable to configure Sasl mechanism "whatever" for Kafka`
+
 	got := err.Error()
 	if want != got {
 		t.Errorf(`unexpected error when providing an invalid Sasl mechanism. Want "%s", got "%s"`, want, got)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -70,6 +70,7 @@ func cloudWatchLogrusHook(config *appconf.SourcesApiConfig) *lc.Hook {
 	if key != "" && secret != "" {
 		cred := credentials.NewStaticCredentials(key, secret, "")
 		awsconf := aws.NewConfig().WithRegion(region).WithCredentials(cred)
+
 		hook, err := lc.NewBatchingHook(group, stream, awsconf, 10*time.Second)
 		if err != nil {
 			Log.Fatal(err)
@@ -109,6 +110,7 @@ func stringContainAnySubString(stringToSearch string, subStrings []string) bool 
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -119,6 +121,7 @@ func stringContainAnySubString(stringToSearch string, subStrings []string) bool 
 */
 func functionNameFromPath(functionWithPath string) string {
 	functionPathParts := strings.Split(functionWithPath, "/")
+
 	partsLength := len(functionPathParts)
 	if partsLength == 0 {
 		return ""

--- a/main_test.go
+++ b/main_test.go
@@ -102,6 +102,7 @@ func SortByStringValueOnKey(field string, data []interface{}) {
 	sort.SliceStable(data, func(i, j int) bool {
 		dataI := data[i].(map[string]interface{})
 		dataJ := data[j].(map[string]interface{})
+
 		return dataI[field].(string) < dataJ[field].(string)
 	})
 }

--- a/marketplace/main_test.go
+++ b/marketplace/main_test.go
@@ -20,6 +20,7 @@ func TestMain(t *testing.M) {
 
 	// Start Miniredis
 	miniredis = miniredisV2.NewMiniRedis()
+
 	err := miniredis.StartAddr("localhost:45884")
 	if err != nil {
 		log.Fatalf("Could not initialize Minidredis: %s", err)
@@ -33,6 +34,7 @@ func TestMain(t *testing.M) {
 	if err != nil {
 		log.Fatalf(`error setting the "ENCRYPTION_KEY" environment variable: %s`, err)
 	}
+
 	util.InitializeEncryption()
 
 	result := t.Run()

--- a/marketplace/marketplace_token.go
+++ b/marketplace/marketplace_token.go
@@ -38,7 +38,9 @@ func (mtc *MarketplaceTokenCacher) FetchToken() (*BearerToken, error) {
 	}
 
 	token := &BearerToken{}
-	if err = json.Unmarshal([]byte(cachedToken), &token); err != nil {
+
+	err = json.Unmarshal([]byte(cachedToken), &token)
+	if err != nil {
 		logger.Log.Errorf(`[tenant_id: %d] unexpected error when unmarshalling the marketplace token: %s`, mtc.TenantID, err)
 
 		return nil, errors.New("could not process the marketplace token")
@@ -68,7 +70,6 @@ func (mtc *MarketplaceTokenCacher) CacheToken(token *BearerToken) error {
 		token,
 		redisExpiration,
 	).Err()
-
 	if err != nil {
 		logger.Log.Errorf(`[tenant_id: %d] unexpected error when trying to set the marketplace token on Redis: %s`, mtc.TenantID, err)
 

--- a/marketplace/marketplace_token_provider.go
+++ b/marketplace/marketplace_token_provider.go
@@ -35,7 +35,6 @@ func (mtp *MarketplaceTokenProvider) RequestToken() (*BearerToken, error) {
 		config.Get().MarketplaceHost+"/api-security/om-auth/cloud/token",
 		strings.NewReader(data.Encode()),
 	)
-
 	if err != nil {
 		logging.Log.Errorf(`error setting up the marketplace token request: %s`, err)
 

--- a/marketplace/marketplace_token_provider_test.go
+++ b/marketplace/marketplace_token_provider_test.go
@@ -20,6 +20,7 @@ func TestNotReachingMarketplace(t *testing.T) {
 	_, err := marketplaceTokenProvider.RequestToken()
 
 	want := "could not reach the marketplace"
+
 	got := err.Error()
 	if want != got {
 		t.Errorf(`unexpected error: want "%s", got "%s"`, want, got)
@@ -46,6 +47,7 @@ func TestInvalidStatusCodeReturnsError(t *testing.T) {
 	_, err := marketplaceTokenProvider.RequestToken()
 
 	want := "unexpected response received from the marketplace"
+
 	got := err.Error()
 	if want != got {
 		t.Errorf(`unexpected error: want "%s", got "%s"`, want, err)

--- a/marketplace/marketplace_token_test.go
+++ b/marketplace/marketplace_token_test.go
@@ -35,8 +35,8 @@ func TestGetTokenBadTenant(t *testing.T) {
 	)
 
 	tokenCacher.TenantID = 12345
-	_, err := tokenCacher.FetchToken()
 
+	_, err := tokenCacher.FetchToken()
 	if err != redis.Nil {
 		t.Errorf(`want error of type "redis.Nil", got "%s"`, reflect.TypeOf(err))
 	}
@@ -55,6 +55,7 @@ func TestGetToken(t *testing.T) {
 
 	// Set a token on the redis cache, to then try fo fetch it
 	token := setUpFakeToken()
+
 	marshalledToken, err := json.Marshal(token)
 	if err != nil {
 		t.Errorf("no error expected, got %s", err)

--- a/marketplace/token_test.go
+++ b/marketplace/token_test.go
@@ -41,7 +41,6 @@ func TestInvalidJsonPassed(t *testing.T) {
 	fakeMarketplaceResponse := http.Response{Body: readCloser}
 
 	_, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
-
 	if err == nil {
 		t.Errorf("want error, got none")
 	}
@@ -57,7 +56,6 @@ func TestInvalidStructurePassed(t *testing.T) {
 	fakeMarketplaceResponse := http.Response{Body: readCloser}
 
 	_, err := DecodeMarketplaceTokenFromResponse(&fakeMarketplaceResponse)
-
 	if err == nil {
 		t.Errorf("want error, got none")
 	}

--- a/marketplace/utils.go
+++ b/marketplace/utils.go
@@ -56,8 +56,8 @@ func SetMarketplaceTokenAuthExtraField(tenantId int64, auth *model.Authenticatio
 
 	// First try to fetch the token from the cache
 	marketplaceTokenCacher = GetMarketplaceTokenCacher(&tenantId)
-	token, err := marketplaceTokenCacher.FetchToken()
 
+	token, err := marketplaceTokenCacher.FetchToken()
 	if err != nil {
 		// If the error isn't "redis.Nil" something went wrong with Redis.
 		if err != redis.Nil {

--- a/marketplace/utils_test.go
+++ b/marketplace/utils_test.go
@@ -132,6 +132,7 @@ func TestNotMarketplaceAuthNotProcessed(t *testing.T) {
 	}
 
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err != nil {
 		t.Errorf("want no errors, got %s", err)
@@ -164,6 +165,7 @@ func TestAuthFromVaultMarketplaceCacheHit(t *testing.T) {
 
 	// Call the function under test
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
@@ -178,6 +180,7 @@ func TestAuthFromVaultMarketplaceCacheHit(t *testing.T) {
 
 	{
 		want := *expectedToken.Token
+
 		got := *token.Token
 		if want != got {
 			t.Errorf(`invalid token string. Want "%s", got "%s"`, want, got)
@@ -186,6 +189,7 @@ func TestAuthFromVaultMarketplaceCacheHit(t *testing.T) {
 
 	{
 		want := *expectedToken.Expiration
+
 		got := *token.Expiration
 		if want != got {
 			t.Errorf(`invalid token expiration. Want "%d", got "%d"`, want, got)
@@ -225,6 +229,7 @@ func TestAuthFromVaultMarketplaceProviderEmptyPassword(t *testing.T) {
 
 	// Call the function under test
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err == nil {
 		t.Errorf("want err, got nil")
@@ -264,6 +269,7 @@ func TestAuthFromVaultMarketplaceProviderSuccess(t *testing.T) {
 
 	// Call the function under test
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
@@ -306,6 +312,7 @@ func TestAuthFromVaultMarketplaceProviderSuccessCacheFailure(t *testing.T) {
 
 	// Call the function under test
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
@@ -342,6 +349,7 @@ func TestAuthFromVaultMarketplaceProviderFailure(t *testing.T) {
 	}
 
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err == nil {
 		t.Error("want error, got nil")
@@ -381,6 +389,7 @@ func TestAuthFromDbExtraNoContent(t *testing.T) {
 
 	// Call the function under test
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
@@ -432,6 +441,7 @@ func TestAuthFromDbExtraNullContent(t *testing.T) {
 
 	// Call the function under test
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err != nil {
 		t.Errorf("want no error, got %s", err)
@@ -486,6 +496,7 @@ func TestAuthFromDbExtraPreviousContent(t *testing.T) {
 
 	// Call the function under test
 	tenantId := int64(5)
+
 	err = SetMarketplaceTokenAuthExtraField(tenantId, auth)
 	if err != nil {
 		t.Errorf("want no error, got %s", err)

--- a/meta_data_handlers.go
+++ b/meta_data_handlers.go
@@ -39,7 +39,6 @@ func MetaDataList(c echo.Context) error {
 	)
 
 	metaDatas, count, err = metaDataDB.List(limit, offset, filters)
-
 	if err != nil {
 		return err
 	}
@@ -79,7 +78,6 @@ func ApplicationTypeListMetaData(c echo.Context) error {
 	)
 
 	metaDatas, count, err = metaDataDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
-
 	if err != nil {
 		return err
 	}
@@ -106,7 +104,6 @@ func MetaDataGet(c echo.Context) error {
 	c.Logger().Infof("Getting MetaData ID %v", id)
 
 	app, err := metaDataDB.GetById(&id)
-
 	if err != nil {
 		return err
 	}

--- a/meta_data_handlers_test.go
+++ b/meta_data_handlers_test.go
@@ -38,6 +38,7 @@ func TestApplicationTypeMetaDataSubcollectionList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -95,6 +96,7 @@ func TestApplicationTypeMetaDataSubcollectionListNotFound(t *testing.T) {
 	c.SetParamValues("3908503985")
 
 	notFoundApplicationTypeListMetaData := ErrorHandlingContext(ApplicationTypeListMetaData)
+
 	err := notFoundApplicationTypeListMetaData(c)
 	if err != nil {
 		t.Error(err)
@@ -120,6 +122,7 @@ func TestApplicationTypeMetaDataSubcollectionListBadRequestInvalidSyntax(t *test
 	c.SetParamValues("xxx")
 
 	badRequestApplicationTypeListMetaData := ErrorHandlingContext(ApplicationTypeListMetaData)
+
 	err := badRequestApplicationTypeListMetaData(c)
 	if err != nil {
 		t.Error(err)
@@ -149,6 +152,7 @@ func TestApplicationTypeMetaDataSubcollectionListBadRequestInvalidFilter(t *test
 	c.SetParamValues("1")
 
 	badRequestApplicationTypeListMetaData := ErrorHandlingContext(ApplicationTypeListMetaData)
+
 	err := badRequestApplicationTypeListMetaData(c)
 	if err != nil {
 		t.Error(err)
@@ -179,6 +183,7 @@ func TestMetaDataList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -223,6 +228,7 @@ func TestMetaDataListBadRequestInvalidFilter(t *testing.T) {
 	)
 
 	badRequestMetaDataList := ErrorHandlingContext(MetaDataList)
+
 	err := badRequestMetaDataList(c)
 	if err != nil {
 		t.Error(err)
@@ -252,6 +258,7 @@ func TestMetaDataGet(t *testing.T) {
 	}
 
 	var outMetaData m.MetaDataResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &outMetaData)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -270,6 +277,7 @@ func TestMetaDataGetNotFound(t *testing.T) {
 	c.SetParamValues("13984739874")
 
 	notFoundMetaDataGet := ErrorHandlingContext(MetaDataGet)
+
 	err := notFoundMetaDataGet(c)
 	if err != nil {
 		t.Error(err)
@@ -290,6 +298,7 @@ func TestMetaDataGetBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestMetaDataGet := ErrorHandlingContext(MetaDataGet)
+
 	err := badRequestMetaDataGet(c)
 	if err != nil {
 		t.Error(err)

--- a/middleware/error_handling.go
+++ b/middleware/error_handling.go
@@ -13,8 +13,10 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		err := next(c)
 		if err != nil {
-			var statusCode int
-			var message interface{}
+			var (
+				statusCode int
+				message    interface{}
+			)
 
 			switch err.(type) {
 			case util.ErrNotFound:
@@ -25,6 +27,7 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 				message = util.NewErrorDoc(err.Error(), "400")
 			default:
 				c.Logger().Error(err)
+
 				uuid, ok := c.Get(h.InsightsRequestID).(string)
 				if !ok {
 					uuid = ""
@@ -33,6 +36,7 @@ func HandleErrors(next echo.HandlerFunc) echo.HandlerFunc {
 				statusCode = http.StatusInternalServerError
 				message = util.ErrorDocWithRequestId(fmt.Sprintf("Internal Server Error: %v", err.Error()), "500", uuid)
 			}
+
 			return c.JSON(statusCode, message)
 		}
 

--- a/middleware/error_handling_test.go
+++ b/middleware/error_handling_test.go
@@ -20,8 +20,8 @@ func TestError(t *testing.T) {
 	)
 
 	explosion := HandleErrors(func(echo.Context) error { return fmt.Errorf("boom!") })
-	err := explosion(c)
 
+	err := explosion(c)
 	if err != nil {
 		t.Error("caught an error when there should not have been one")
 	}
@@ -46,8 +46,8 @@ func TestNoError(t *testing.T) {
 	)
 
 	goodRequest := HandleErrors(func(echo.Context) error { return nil })
-	err := goodRequest(c)
 
+	err := goodRequest(c)
 	if err != nil {
 		t.Error("caught an error when there should not have been one")
 	}
@@ -55,5 +55,4 @@ func TestNoError(t *testing.T) {
 	if rec.Code != 200 {
 		t.Errorf("%v was returned instead of %v", rec.Code, 200)
 	}
-
 }

--- a/middleware/event_stream_test.go
+++ b/middleware/event_stream_test.go
@@ -36,6 +36,7 @@ func TestRaiseEvent(t *testing.T) {
 	f := raiseMiddleware(func(c echo.Context) error {
 		c.Set("event_type", "Thing.create")
 		c.Set("resource", &fakeEvent{raised: true})
+
 		return c.NoContent(http.StatusNoContent)
 	})
 
@@ -67,6 +68,7 @@ func TestRaiseEventWithHeaders(t *testing.T) {
 	f := raiseMiddleware(func(c echo.Context) error {
 		c.Set("event_type", "Thing.create")
 		c.Set("resource", &fakeEvent{raised: true})
+
 		return c.NoContent(http.StatusNoContent)
 	})
 
@@ -106,6 +108,7 @@ func TestRaiseEventBody(t *testing.T) {
 	f := raiseMiddleware(func(c echo.Context) error {
 		c.Set("event_type", "Thing.create")
 		c.Set("resource", &fakeEvent{raised: true})
+
 		return c.NoContent(http.StatusNoContent)
 	})
 

--- a/middleware/filtering.go
+++ b/middleware/filtering.go
@@ -22,6 +22,7 @@ func SortAndFilter(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		c.Set("filters", filters)
+
 		return next(c)
 	}
 }
@@ -32,6 +33,7 @@ func parseFilter(c echo.Context) ([]util.Filter, error) {
 		if strings.HasPrefix(key, "filter") {
 			matches := util.FilterRegex.FindAllStringSubmatch(key, -1)
 			filter := util.Filter{}
+
 			if len(matches) < 2 {
 				return nil, fmt.Errorf("filter")
 			}

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -207,7 +207,6 @@ func TestParseFilteringBadFilter(t *testing.T) {
 	c := e.NewContext(req, nil)
 
 	filters, err := parseFilter(c)
-
 	if err == nil {
 		t.Error("got no error when there should have been one")
 	}

--- a/middleware/headers.go
+++ b/middleware/headers.go
@@ -55,6 +55,7 @@ func ParseHeaders(next echo.HandlerFunc) echo.HandlerFunc {
 		// received, generate an identity struct from the given "OrgId" and "EBS account number". If the "x-rh-identity"
 		// header is present, simply decode it and use the decided identity.
 		var id *identity.XRHID
+
 		xRhIdentityRaw := c.Request().Header.Get(h.XRHID)
 		if xRhIdentityRaw == "" {
 			generatedIdentity := util.GeneratedXRhIdentity(c.Request().Header.Get(h.AccountNumber), c.Request().Header.Get(h.OrgID))

--- a/middleware/main_test.go
+++ b/middleware/main_test.go
@@ -25,6 +25,7 @@ func TestMain(t *testing.M) {
 	xrhid = string(base64.StdEncoding.EncodeToString(rawId))
 
 	logger.InitLogger(conf)
+
 	e = echo.New()
 	code := t.Run()
 	os.Exit(code)

--- a/middleware/notifier.go
+++ b/middleware/notifier.go
@@ -16,6 +16,7 @@ func Notifier(next echo.HandlerFunc) echo.HandlerFunc {
 		if err != nil {
 			return err
 		}
+
 		emailNotificationInfo, ok := c.Get("emailNotificationInfo").(*m.EmailNotificationInfo)
 		if emailNotificationInfo == nil || !ok {
 			return fmt.Errorf("unable to find emailNotificationInfo instance in middleware")

--- a/middleware/pagination_test.go
+++ b/middleware/pagination_test.go
@@ -73,6 +73,7 @@ func TestParsePaginationBadRequestInvalidLimit(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	badRequestParsePaginationIntoContext := HandleErrors(parsePaginationIntoContext)
+
 	err := badRequestParsePaginationIntoContext(c)
 	if err != nil {
 		t.Error("something went very wrong - error parsing pagination.")
@@ -81,6 +82,7 @@ func TestParsePaginationBadRequestInvalidLimit(t *testing.T) {
 	templates.BadRequestTest(t, rec)
 
 	var resp util.ErrorDocument
+
 	err = json.Unmarshal(rec.Body.Bytes(), &resp)
 	if err != nil {
 		t.Error("Error unmarshaling response, malformed error document")
@@ -97,6 +99,7 @@ func TestParsePaginationBadRequestInvalidOffset(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	badRequestParsePaginationIntoContext := HandleErrors(parsePaginationIntoContext)
+
 	err := badRequestParsePaginationIntoContext(c)
 	if err != nil {
 		t.Error("something went very wrong - error parsing pagination.")
@@ -105,6 +108,7 @@ func TestParsePaginationBadRequestInvalidOffset(t *testing.T) {
 	templates.BadRequestTest(t, rec)
 
 	var resp util.ErrorDocument
+
 	err = json.Unmarshal(rec.Body.Bytes(), &resp)
 	if err != nil {
 		t.Error("Error unmarshaling response, malformed error document")

--- a/middleware/tenancy.go
+++ b/middleware/tenancy.go
@@ -36,6 +36,7 @@ func Tenancy(next echo.HandlerFunc) echo.HandlerFunc {
 		c.Logger().Debugf("[org_id: %s][account_number: %s] Looking up Tenant ID", id.Identity.OrgID, id.Identity.AccountNumber)
 
 		tenantDao := dao.GetTenantDao()
+
 		tenant, err := tenantDao.GetOrCreateTenant(&id.Identity)
 		if err != nil {
 			c.Logger().Errorf("[identity struct: %v] unable to get or create the tenant: %w", err)

--- a/middleware/tenancy_test.go
+++ b/middleware/tenancy_test.go
@@ -71,6 +71,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 		// Prepare the middlewares and execute them.
 		handlers := ParseHeaders(Tenancy(func(context echo.Context) error { return nil }))
+
 		err := handlers(c)
 		if err != nil {
 			t.Errorf(`unexpected error when running the "ParseHeaders" and "Tenancy" middlewares: %s`, err)
@@ -84,6 +85,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 			{
 				want := orgId
+
 				got := id.Identity.OrgID
 				if want != got {
 					t.Errorf(`the identity struct does not have the OrgId value from the database. Want "%s", got "%s"`, want, got)
@@ -92,6 +94,7 @@ func TestTenancySetsAllTenancyVariables(t *testing.T) {
 
 			{
 				want := accountNumber
+
 				got := id.Identity.AccountNumber
 				if want != got {
 					t.Errorf(`the identity struct does not have the AccountNUmber value from the database. Want "%s", got "%s"`, want, got)

--- a/middleware/user_test.go
+++ b/middleware/user_test.go
@@ -19,6 +19,7 @@ var catchUserOrElse204 = UserCatcher(func(c echo.Context) error {
 
 func TestUserCreationFromXRHID(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantID := int64(1)
 	testUserID := "55555"
 	identity := testutils.IdentityHeaderForUser(testUserID)
@@ -46,6 +47,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 	}
 
 	var user m.User
+
 	result := dao.DB.Find(&user, "user_id = ? AND tenant_id = ?", testUserID, tenantID)
 	if result.Error != nil {
 		t.Error(err)
@@ -64,6 +66,7 @@ func TestUserCreationFromXRHID(t *testing.T) {
 
 func TestUserCreationFromPSK(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantID := int64(1)
 	testUserID := "55555"
 
@@ -90,6 +93,7 @@ func TestUserCreationFromPSK(t *testing.T) {
 	}
 
 	var user m.User
+
 	result := dao.DB.Find(&user, "user_id = ? AND tenant_id = ?", testUserID, tenantID)
 	if result.Error != nil {
 		t.Error(err)

--- a/model/application_authentication.go
+++ b/model/application_authentication.go
@@ -49,6 +49,7 @@ func (aa *ApplicationAuthentication) ToResponse() *ApplicationAuthenticationResp
 	id := strconv.FormatInt(aa.ID, 10)
 	appId := strconv.FormatInt(aa.ApplicationID, 10)
 	authId := ""
+
 	if aa.VaultPath != "" && config.IsVaultOn() {
 		parts := strings.Split(aa.VaultPath, "/")
 		authId = parts[len(parts)-1]

--- a/model/application_type.go
+++ b/model/application_type.go
@@ -72,5 +72,6 @@ func (at *ApplicationType) UserResourceOwnership() bool {
 	if at.ResourceOwnership == nil {
 		return false
 	}
+
 	return *at.ResourceOwnership == UserOwnership
 }

--- a/model/authentication_http.go
+++ b/model/authentication_http.go
@@ -62,12 +62,15 @@ func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest)
 	if update.Name != nil {
 		auth.Name = update.Name
 	}
+
 	if update.AuthType != nil {
 		auth.AuthType = *update.AuthType
 	}
+
 	if update.Username != nil {
 		auth.Username = update.Username
 	}
+
 	if update.Password != nil {
 		err := auth.SetPassword(update.Password)
 		if err != nil {
@@ -85,6 +88,7 @@ func (auth *Authentication) UpdateFromRequest(update *AuthenticationEditRequest)
 	if update.AvailabilityStatus != nil {
 		auth.AvailabilityStatus = update.AvailabilityStatus
 	}
+
 	if update.AvailabilityStatusError != nil {
 		auth.AvailabilityStatusError = update.AvailabilityStatusError
 	}

--- a/model/events.go
+++ b/model/events.go
@@ -22,6 +22,7 @@ type bulkMessage struct {
 
 type updatingAttributes struct {
 	bulkMessage
+
 	Updated map[string]interface{} `json:"updated"`
 }
 

--- a/model/main_test.go
+++ b/model/main_test.go
@@ -9,5 +9,6 @@ import (
 
 func TestMain(t *testing.M) {
 	_ = parser.ParseFlags()
+
 	os.Exit(t.Run())
 }

--- a/model/relation_object.go
+++ b/model/relation_object.go
@@ -41,6 +41,7 @@ func (relationObject *RelationObject) tagsFromRelationDefinedAs(model interface{
 	statement := reflect.TypeOf(relationObject.baseObject)
 	field, _ := statement.FieldByName(relationName)
 	tag := field.Tag.Get("gorm")
+
 	return schema.ParseTagSetting(tag, ";")
 }
 
@@ -56,6 +57,7 @@ func (relationObject *RelationObject) HasMany(model interface{}, query *gorm.DB)
 
 func (relationObject *RelationObject) SelectStatementFor(query *gorm.DB, model interface{}) string {
 	statement := &gorm.Statement{DB: query}
+
 	err := statement.Parse(model)
 	if err != nil {
 		fmt.Println(fmt.Errorf("failed to parse statement: %v", err))
@@ -75,6 +77,7 @@ func (relationObject *RelationObject) HasManyThrough(query *gorm.DB, model inter
 
 	subCollectionModel := strcase.ToSnake(reflect.TypeOf(model).Elem().Name())
 	query.Model(model)
+
 	expression := []clause.Expression{clause.Eq{
 		Column: clause.Column{Table: clause.CurrentTable, Name: "id"},
 		Value:  clause.Column{Table: throughTable, Name: subCollectionModel + "_id"},
@@ -142,6 +145,7 @@ func (relationObject *RelationObject) checkIfPrimaryRecordExists(query *gorm.DB)
 
 func NewRelationObject(objectModel interface{}, currentTenantID int64, query *gorm.DB) (RelationObject, error) {
 	object := RelationObject{baseObject: objectModel, CurrentTenantID: currentTenantID}
+
 	err := object.setRelationObjectID()
 	if err != nil {
 		return object, err

--- a/model/secret_store_util.go
+++ b/model/secret_store_util.go
@@ -59,6 +59,7 @@ func (auth *Authentication) GetPassword() (*string, error) {
 		}
 
 		decrypted, err := util.Decrypt(*auth.Password)
+
 		return &decrypted, err
 
 	case config.VaultStore:
@@ -81,6 +82,7 @@ func (auth *Authentication) SetExtra(extra map[string]interface{}) error {
 	switch config.Get().SecretStore {
 	case config.DatabaseStore, config.SecretsManagerStore:
 		var err error
+
 		auth.ExtraDb, err = json.Marshal(extra)
 		if err != nil {
 			return err
@@ -101,8 +103,10 @@ func (auth *Authentication) SetExtra(extra map[string]interface{}) error {
 func (auth *Authentication) SetExtraField(key string, value interface{}) error {
 	switch config.Get().SecretStore {
 	case config.DatabaseStore, config.SecretsManagerStore:
-		var err error
-		var extra = make(map[string]interface{})
+		var (
+			err   error
+			extra = make(map[string]interface{})
+		)
 
 		if auth.ExtraDb != nil && string(auth.ExtraDb) != `null` {
 			err := json.Unmarshal(auth.ExtraDb, &extra)
@@ -113,6 +117,7 @@ func (auth *Authentication) SetExtraField(key string, value interface{}) error {
 
 		extra[key] = value
 		auth.ExtraDb, err = json.Marshal(extra)
+
 		return err
 
 	case config.VaultStore:
@@ -143,6 +148,7 @@ func (auth *Authentication) SetPassword(pass *string) error {
 		}
 
 		auth.Password = &encrypted
+
 		return nil
 
 	case config.VaultStore:

--- a/model/source_http.go
+++ b/model/source_http.go
@@ -79,15 +79,19 @@ func (src *Source) UpdateFromRequest(update *SourceEditRequest) {
 	if update.Name != nil {
 		src.Name = *update.Name
 	}
+
 	if update.Version != nil {
 		src.Version = update.Version
 	}
+
 	if update.Imported != nil {
 		src.Imported = update.Imported
 	}
+
 	if update.SourceRef != nil {
 		src.SourceRef = update.SourceRef
 	}
+
 	if update.AvailabilityStatus != nil {
 		src.AvailabilityStatus = *update.AvailabilityStatus
 	}

--- a/openapi_handlers_test.go
+++ b/openapi_handlers_test.go
@@ -18,6 +18,7 @@ func TestOpenApiReturn(t *testing.T) {
 	}
 
 	rawFile := make(map[string]interface{})
+
 	err = json.Unmarshal(raw, &rawFile)
 	if err != nil {
 		t.Errorf("Failed to marshal json: %v", err)
@@ -45,6 +46,7 @@ func TestOpenApiReturn(t *testing.T) {
 	}
 
 	out := make(map[string]interface{})
+
 	err = json.Unmarshal(output, &out)
 	if err != nil {
 		t.Error(err)

--- a/rhc_connection_handlers.go
+++ b/rhc_connection_handlers.go
@@ -75,11 +75,13 @@ func RhcConnectionGetById(c echo.Context) error {
 
 func RhcConnectionCreate(c echo.Context) error {
 	input := &model.RhcConnectionCreateRequest{}
-	if err := c.Bind(input); err != nil {
+
+	err := c.Bind(input)
+	if err != nil {
 		return err
 	}
 
-	err := service.ValidateRhcConnectionRequest(input)
+	err = service.ValidateRhcConnectionRequest(input)
 	if err != nil {
 		return util.NewErrBadRequest(fmt.Sprintf("Validation failed: %v", err))
 	}
@@ -114,7 +116,9 @@ func RhcConnectionEdit(c echo.Context) error {
 	}
 
 	input := &model.RhcConnectionEditRequest{}
-	if err := c.Bind(input); err != nil {
+
+	err = c.Bind(input)
+	if err != nil {
 		return err
 	}
 
@@ -129,6 +133,7 @@ func RhcConnectionEdit(c echo.Context) error {
 	}
 
 	dbRhcConnection.UpdateFromRequest(input)
+
 	err = rhcConnectionDao.Update(dbRhcConnection)
 	if err != nil {
 		return err

--- a/rhc_connection_handlers_test.go
+++ b/rhc_connection_handlers_test.go
@@ -42,6 +42,7 @@ func TestRhcConnectionList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshalling output")
@@ -56,6 +57,7 @@ func TestRhcConnectionList(t *testing.T) {
 	}
 
 	var wantCount int
+
 	for _, rhc := range fixtures.TestRhcConnectionData {
 		for _, srcRhc := range fixtures.TestSourceRhcConnectionData {
 			if srcRhc.RhcConnectionId == rhc.ID && srcRhc.TenantId == tenantId {
@@ -81,6 +83,7 @@ func TestRhcConnectionList(t *testing.T) {
 				if srcRhc.TenantId != tenantId {
 					t.Errorf("wrong tenant id in returned object, expected %d, got %d", tenantId, srcRhc.TenantId)
 				}
+
 				break
 			}
 		}
@@ -159,6 +162,7 @@ func TestRhcConnectionListInvalidFilter(t *testing.T) {
 	)
 
 	badRequestRhcConnectionList := ErrorHandlingContext(RhcConnectionList)
+
 	err := badRequestRhcConnectionList(c)
 	if err != nil {
 		t.Error(err)
@@ -193,6 +197,7 @@ func TestRhcConnectionGetById(t *testing.T) {
 	}
 
 	var outRhcConnectionResponse model.RhcConnectionResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &outRhcConnectionResponse)
 	if err != nil {
 		t.Error("Failed unmarshalling output")
@@ -203,6 +208,7 @@ func TestRhcConnectionGetById(t *testing.T) {
 	}
 
 	var outRhcId int64
+
 	outRhcId, err = strconv.ParseInt(*outRhcConnectionResponse.Id, 10, 64)
 	if err != nil {
 		t.Error(err)
@@ -214,6 +220,7 @@ func TestRhcConnectionGetById(t *testing.T) {
 			if srcRhc.TenantId != tenantId {
 				t.Errorf("wrong tenant id, expected %d, got %d", tenantId, srcRhc.TenantId)
 			}
+
 			break
 		}
 	}
@@ -228,6 +235,7 @@ func TestRhcConnectionGetByIdMissingIdParam(t *testing.T) {
 	)
 
 	badRequestRhcConnectionGetById := ErrorHandlingContext(RhcConnectionGetById)
+
 	err := badRequestRhcConnectionGetById(c)
 	if err != nil {
 		t.Error(err)
@@ -248,6 +256,7 @@ func TestRhcConnectionGetByIdInvalidParam(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestRhcConnectionGetById := ErrorHandlingContext(RhcConnectionGetById)
+
 	err := badRequestRhcConnectionGetById(c)
 	if err != nil {
 		t.Error(err)
@@ -260,6 +269,7 @@ func TestRhcConnectionGetByIdInvalidParam(t *testing.T) {
 // existing rhc connection but when tenant is not owner of rhc connection
 func TestRhcConnectionGetByIdInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 	rhcId := int64(1)
 
@@ -276,6 +286,7 @@ func TestRhcConnectionGetByIdInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", rhcId))
 
 	notFoundRhcConnectionGetByUuid := ErrorHandlingContext(RhcConnectionGetById)
+
 	err := notFoundRhcConnectionGetByUuid(c)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -288,6 +299,7 @@ func TestRhcConnectionGetByIdInvalidTenant(t *testing.T) {
 // not existing tenant
 func TestRhcConnectionGetByIdTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	rhcId := int64(1)
 
@@ -304,6 +316,7 @@ func TestRhcConnectionGetByIdTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", rhcId))
 
 	notFoundRhcConnectionGetByUuid := ErrorHandlingContext(RhcConnectionGetById)
+
 	err := notFoundRhcConnectionGetByUuid(c)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -328,6 +341,7 @@ func TestRhcConnectionGetByIdNotFound(t *testing.T) {
 	c.SetParamValues(nonExistingId)
 
 	notFoundRhcConnectionGetByUuid := ErrorHandlingContext(RhcConnectionGetById)
+
 	err := notFoundRhcConnectionGetByUuid(c)
 	if err != nil {
 		t.Errorf(`want nil error, got "%s"`, err)
@@ -373,6 +387,7 @@ func TestRhcConnectionCreate(t *testing.T) {
 // not existing tenant
 func TestRhcConnectionCreateTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 
 	requestBody := model.RhcConnectionCreateRequest{
@@ -398,6 +413,7 @@ func TestRhcConnectionCreateTenantNotExists(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundRhcConnectionCreate := ErrorHandlingContext(RhcConnectionCreate)
+
 	err = notFoundRhcConnectionCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -410,6 +426,7 @@ func TestRhcConnectionCreateTenantNotExists(t *testing.T) {
 // existing tenant who doesn't own the source
 func TestRhcConnectionCreateTenantNotOwnsSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 
 	requestBody := model.RhcConnectionCreateRequest{
@@ -435,6 +452,7 @@ func TestRhcConnectionCreateTenantNotOwnsSource(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundRhcConnectionCreate := ErrorHandlingContext(RhcConnectionCreate)
+
 	err = notFoundRhcConnectionCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -465,6 +483,7 @@ func TestRhcConnectionCreateInvalidInput(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestRhcConnectionCreate := ErrorHandlingContext(RhcConnectionCreate)
+
 	err = badRequestRhcConnectionCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -497,6 +516,7 @@ func TestRhcConnectionCreateNotExistingSource(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	sourceNotFoundRhcConnectionCreate := ErrorHandlingContext(RhcConnectionCreate)
+
 	err = sourceNotFoundRhcConnectionCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -529,6 +549,7 @@ func TestRhcConnectionCreateRelationExists(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestRhcConnectionCreate := ErrorHandlingContext(RhcConnectionCreate)
+
 	err = badRequestRhcConnectionCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -578,6 +599,7 @@ func TestRhcConnectionEdit(t *testing.T) {
 			if srcRhc.TenantId != tenantId {
 				t.Errorf("wrong tenant id, expected %d, got %d", tenantId, srcRhc.TenantId)
 			}
+
 			break
 		}
 	}
@@ -587,6 +609,7 @@ func TestRhcConnectionEdit(t *testing.T) {
 // edit existing not owned rhc connection
 func TestRhcConnectionEditInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	rhcId := fixtures.TestRhcConnectionData[2].ID
 	requestBody := model.RhcConnectionEditRequest{
@@ -613,6 +636,7 @@ func TestRhcConnectionEditInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", rhcId))
 
 	notFoundRhcConnectionEdit := ErrorHandlingContext(RhcConnectionEdit)
+
 	err = notFoundRhcConnectionEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -638,6 +662,7 @@ func TestRhcConnectionEditInvalidParam(t *testing.T) {
 	c.SetParamValues(invalidId)
 
 	badRequestRhcConnectionEdit := ErrorHandlingContext(RhcConnectionEdit)
+
 	err := badRequestRhcConnectionEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -672,8 +697,8 @@ func TestRhcConnectionEditNotFound(t *testing.T) {
 	c.SetParamValues(invalidId)
 
 	notFoundRhcConnectionEdit := ErrorHandlingContext(RhcConnectionEdit)
-	err = notFoundRhcConnectionEdit(c)
 
+	err = notFoundRhcConnectionEdit(c)
 	if err != nil {
 		t.Error(err)
 	}
@@ -726,6 +751,7 @@ func TestRhcConnectionDeleteInvalidParam(t *testing.T) {
 	c.SetParamValues(invalidId)
 
 	badRequestRhcConnectionDelete := ErrorHandlingContext(RhcConnectionDelete)
+
 	err := badRequestRhcConnectionDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -747,6 +773,7 @@ func TestRhcConnectionDeleteMissingParam(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestRhcConnectionDelete := ErrorHandlingContext(RhcConnectionDelete)
+
 	err := badRequestRhcConnectionDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -759,6 +786,7 @@ func TestRhcConnectionDeleteMissingParam(t *testing.T) {
 // when tenant tries to delete not owned rhc connection
 func TestRhcConnectionDeleteInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	rhcId := fixtures.TestRhcConnectionData[2].ID
 
@@ -776,6 +804,7 @@ func TestRhcConnectionDeleteInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", rhcId))
 
 	notFoundRhcConnectionDelete := ErrorHandlingContext(RhcConnectionDelete)
+
 	err := notFoundRhcConnectionDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -788,6 +817,7 @@ func TestRhcConnectionDeleteInvalidTenant(t *testing.T) {
 // when tenant doesn't exist
 func TestRhcConnectionDeleteTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(98304983)
 	rhcId := fixtures.TestRhcConnectionData[2].ID
 
@@ -805,6 +835,7 @@ func TestRhcConnectionDeleteTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", rhcId))
 
 	notFoundRhcConnectionDelete := ErrorHandlingContext(RhcConnectionDelete)
+
 	err := notFoundRhcConnectionDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -830,6 +861,7 @@ func TestRhcConnectionDeleteNotFound(t *testing.T) {
 	c.SetParamValues(nonExistingId)
 
 	notFoundRhcConnectionDelete := ErrorHandlingContext(RhcConnectionDelete)
+
 	err := notFoundRhcConnectionDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -867,6 +899,7 @@ func TestRhcConnectionGetRelatedSources(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshalling output")
@@ -928,6 +961,7 @@ func TestRhcConnectionGetRelatedSourcesInvalidFilter(t *testing.T) {
 	c.SetParamValues(rhcConnectionId)
 
 	badRequestRhcConnectionSourcesList := ErrorHandlingContext(RhcConnectionSourcesList)
+
 	err := badRequestRhcConnectionSourcesList(c)
 	if err != nil {
 		t.Error(err)
@@ -955,6 +989,7 @@ func TestRhcConnectionGetRelatedSourcesInvalidParam(t *testing.T) {
 	c.SetParamValues(rhcConnectionId)
 
 	badRequestRhcConnectionSourcesList := ErrorHandlingContext(RhcConnectionSourcesList)
+
 	err := badRequestRhcConnectionSourcesList(c)
 	if err != nil {
 		t.Error(err)
@@ -982,6 +1017,7 @@ func TestRhcConnectionGetRelatedSourcesNotFound(t *testing.T) {
 	c.SetParamValues(rhcConnectionId)
 
 	notFoundRhcConnectionSourcesList := ErrorHandlingContext(RhcConnectionSourcesList)
+
 	err := notFoundRhcConnectionSourcesList(c)
 	if err != nil {
 		t.Error(err)
@@ -994,6 +1030,7 @@ func TestRhcConnectionGetRelatedSourcesNotFound(t *testing.T) {
 // when tenant tries to list sources for not owned rhc connection
 func TestRhcConnectionGetRelatedSourcesInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 	rhcConnectionId := int64(1)
 
@@ -1013,6 +1050,7 @@ func TestRhcConnectionGetRelatedSourcesInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", rhcConnectionId))
 
 	notFoundRhcConnectionSourcesList := ErrorHandlingContext(RhcConnectionSourcesList)
+
 	err := notFoundRhcConnectionSourcesList(c)
 	if err != nil {
 		t.Error(err)
@@ -1025,6 +1063,7 @@ func TestRhcConnectionGetRelatedSourcesInvalidTenant(t *testing.T) {
 // when tenant doesn't exist
 func TestRhcConnectionGetRelatedSourcesTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	rhcConnectionId := int64(1)
 
@@ -1044,6 +1083,7 @@ func TestRhcConnectionGetRelatedSourcesTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", rhcConnectionId))
 
 	notFoundRhcConnectionSourcesList := ErrorHandlingContext(RhcConnectionSourcesList)
+
 	err := notFoundRhcConnectionSourcesList(c)
 	if err != nil {
 		t.Error(err)

--- a/routes.go
+++ b/routes.go
@@ -29,13 +29,17 @@ func setupRoutes(e *echo.Echo) {
 	// Set up the middlewares.
 	permissionCheckMiddleware := middleware.PermissionCheck(config.Get().BypassRbac, config.Get().AuthorizedPsks, rbacClient)
 
-	var listMiddleware = []echo.MiddlewareFunc{middleware.SortAndFilter, middleware.Pagination}
-	var tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.LoggerFields, middleware.UserCatcher}
+	var (
+		listMiddleware    = []echo.MiddlewareFunc{middleware.SortAndFilter, middleware.Pagination}
+		tenancyMiddleware = []echo.MiddlewareFunc{middleware.Tenancy, middleware.LoggerFields, middleware.UserCatcher}
+	)
 
-	var tenancyWithListMiddleware = append(tenancyMiddleware, listMiddleware...)
-	var permissionMiddlewareWithoutEvents = append(tenancyMiddleware, permissionCheckMiddleware)
-	var permissionMiddleware = append(permissionMiddlewareWithoutEvents, middleware.RaiseEvent)
-	var permissionWithListMiddleware = append(listMiddleware, permissionCheckMiddleware)
+	var (
+		tenancyWithListMiddleware         = append(tenancyMiddleware, listMiddleware...)
+		permissionMiddlewareWithoutEvents = append(tenancyMiddleware, permissionCheckMiddleware)
+		permissionMiddleware              = append(permissionMiddlewareWithoutEvents, middleware.RaiseEvent)
+		permissionWithListMiddleware      = append(listMiddleware, permissionCheckMiddleware)
+	)
 
 	apiVersions := []string{"v1.0", "v2.0", "v3.0", "v3.1", "v1", "v2", "v3"}
 	for _, version := range apiVersions {

--- a/secret_handlers.go
+++ b/secret_handlers.go
@@ -28,6 +28,7 @@ func SecretCreate(c echo.Context) error {
 	}
 
 	createRequest := m.SecretCreateRequest{}
+
 	err = c.Bind(&createRequest)
 	if err != nil {
 		return err
@@ -126,6 +127,7 @@ func SecretEdit(c echo.Context) error {
 	}
 
 	updateRequest := &m.SecretEditRequest{}
+
 	err = c.Bind(updateRequest)
 	if err != nil {
 		return err

--- a/secret_handlers_test.go
+++ b/secret_handlers_test.go
@@ -40,6 +40,7 @@ func TestSecretCreateNameExistInCurrentTenant(t *testing.T) {
 	secretExtra := map[string]interface{}{"extra": map[string]interface{}{"extra": "params"}}
 
 	secretCreateRequest := secretFromParams(name, authType, userName, password, secretExtra, false)
+
 	_, rec, err := createSecretRequest(t, secretCreateRequest, &tenantId)
 	if err != nil {
 		t.Error(err)
@@ -48,7 +49,6 @@ func TestSecretCreateNameExistInCurrentTenant(t *testing.T) {
 	secret := parseSecretResponse(t, rec)
 
 	_, _, err = createSecretRequest(t, secretCreateRequest, &tenantId)
-
 	if err != nil && err.Error() != "bad request: secret name "+name+" exists in current tenant" {
 		t.Error(err)
 	}
@@ -72,7 +72,6 @@ func TestSecretCreateEmptyName(t *testing.T) {
 	secretCreateRequest := secretFromParams(name, authType, userName, password, secretExtra, false)
 
 	_, _, err := createSecretRequest(t, secretCreateRequest, &tenantId)
-
 	if err.Error() != "bad request: secret name have to be populated" {
 		t.Error(err)
 	}
@@ -90,6 +89,7 @@ func TestSecretCreate(t *testing.T) {
 	userName := "test-name"
 	password := "123456"
 	secretExtra := map[string]interface{}{"extra": map[string]interface{}{"extra": "params"}}
+
 	var userID *int64
 
 	for _, userScoped := range []bool{false, true} {
@@ -155,6 +155,7 @@ func int64Matcher(t *testing.T, nameResource string, firstValue int64, secondVal
 func parseSecretResponse(t *testing.T, rec *httptest.ResponseRecorder) *m.AuthenticationResponse {
 	secret := &m.AuthenticationResponse{}
 	raw, _ := io.ReadAll(rec.Body)
+
 	err := json.Unmarshal(raw, &secret)
 	if err != nil {
 		t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -165,6 +166,7 @@ func parseSecretResponse(t *testing.T, rec *httptest.ResponseRecorder) *m.Authen
 
 func fetchSecretFromDB(t *testing.T, secretIDValue string, requestParams *dao.RequestParams) *m.Authentication {
 	secretDao := dao.GetSecretDao(requestParams)
+
 	secretID, err := util.InterfaceToInt64(secretIDValue)
 	if err != nil {
 		t.Error(err)
@@ -222,7 +224,9 @@ func cleanSecretByID(t *testing.T, secretIDValue string, requestParams *dao.Requ
 	if err != nil {
 		t.Error(err)
 	}
+
 	secretDao := dao.GetSecretDao(requestParams)
+
 	err = secretDao.Delete(&secretID)
 	if err != nil {
 		t.Error(err)
@@ -233,6 +237,7 @@ func TestSecretList(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	tenantId := int64(1)
+
 	secret1, err := dao.CreateSecretByName("Secret 1", &tenantId, nil)
 	if err != nil {
 		t.Error(err)
@@ -265,6 +270,7 @@ func TestSecretList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -292,9 +298,11 @@ func TestSecretList(t *testing.T) {
 	}
 
 	var foundIDs []int64
+
 	for _, secret := range out.Data {
 		secretMap := secret.(map[string]interface{})
 		secretID := secretMap["id"].(string)
+
 		outID, err := strconv.ParseInt(secretID, 10, 64)
 		if err != nil {
 			t.Errorf(`The ID of the payload could not be converted to int64: %s`, err)
@@ -315,12 +323,14 @@ func TestSecretList(t *testing.T) {
 	if err != nil {
 		t.Error(nil)
 	}
+
 	cleanSecretByID(t, secret1ID, &dao.RequestParams{TenantID: &tenantId})
 
 	secret2ID, err := util.InterfaceToString(secret2.DbID)
 	if err != nil {
 		t.Error(nil)
 	}
+
 	cleanSecretByID(t, secret2ID, &dao.RequestParams{TenantID: &tenantId})
 }
 
@@ -328,6 +338,7 @@ func TestSecretListWithFilter(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	tenantId := int64(1)
+
 	secret1, err := dao.CreateSecretByName("Secret 1", &tenantId, nil)
 	if err != nil {
 		t.Error(err)
@@ -362,6 +373,7 @@ func TestSecretListWithFilter(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -389,9 +401,11 @@ func TestSecretListWithFilter(t *testing.T) {
 	}
 
 	var foundIDs []int64
+
 	for _, secret := range out.Data {
 		secretMap := secret.(map[string]interface{})
 		secretID := secretMap["id"].(string)
+
 		outID, err := strconv.ParseInt(secretID, 10, 64)
 		if err != nil {
 			t.Errorf(`The ID of the payload could not be converted to int64: %s`, err)
@@ -412,12 +426,14 @@ func TestSecretListWithFilter(t *testing.T) {
 	if err != nil {
 		t.Error(nil)
 	}
+
 	cleanSecretByID(t, secret1ID, &dao.RequestParams{TenantID: &tenantId})
 
 	secret2ID, err := util.InterfaceToString(secret2.DbID)
 	if err != nil {
 		t.Error(nil)
 	}
+
 	cleanSecretByID(t, secret2ID, &dao.RequestParams{TenantID: &tenantId})
 }
 
@@ -462,6 +478,7 @@ func TestSecretTenantNotExist(t *testing.T) {
 
 func TestSecretListBadRequestInvalidFilter(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 
 	c, rec := request.CreateTestContext(
@@ -479,6 +496,7 @@ func TestSecretListBadRequestInvalidFilter(t *testing.T) {
 	)
 
 	badRequestSecretList := ErrorHandlingContext(SecretList)
+
 	err := badRequestSecretList(c)
 	if err != nil {
 		t.Error(err)
@@ -489,16 +507,19 @@ func TestSecretListBadRequestInvalidFilter(t *testing.T) {
 
 func TestSecretGet(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantIDForSecret := int64(1)
 	testUserId := "testUser"
 
 	userDao := dao.GetUserDao(&tenantIDForSecret)
+
 	user, err := userDao.FindOrCreate(testUserId)
 	if err != nil {
 		t.Error(err)
 	}
 
 	var userID *int64
+
 	for _, userScoped := range []bool{false, true} {
 		if userScoped {
 			userID = &user.Id
@@ -540,6 +561,7 @@ func TestSecretGet(t *testing.T) {
 		}
 
 		var outSecret m.SecretResponse
+
 		err = json.Unmarshal(rec.Body.Bytes(), &outSecret)
 		if err != nil {
 			t.Error("Failed unmarshaling output")
@@ -550,6 +572,7 @@ func TestSecretGet(t *testing.T) {
 		}
 
 		secretDao := dao.GetSecretDao(&dao.RequestParams{TenantID: &tenantIDForSecret, UserID: userID})
+
 		secret, err = secretDao.GetById(&secret.DbID)
 		if err != nil {
 			t.Error("secret not found")
@@ -592,6 +615,7 @@ func TestSecretGetTenantNotExist(t *testing.T) {
 	c.SetParamValues(secretID)
 
 	notFoundSecretGet := ErrorHandlingContext(SecretGet)
+
 	err = notFoundSecretGet(c)
 	if err != nil {
 		t.Error(err)
@@ -601,6 +625,7 @@ func TestSecretGetTenantNotExist(t *testing.T) {
 	if err != nil {
 		t.Error(nil)
 	}
+
 	cleanSecretByID(t, secretID, &dao.RequestParams{TenantID: &tenantIDForSecret})
 
 	templates.NotFoundTest(t, rec)
@@ -624,6 +649,7 @@ func TestSecretGetNotFound(t *testing.T) {
 	c.SetParamValues(id)
 
 	notFoundSecretGet := ErrorHandlingContext(SecretGet)
+
 	err := notFoundSecretGet(c)
 	if err != nil {
 		t.Error(err)
@@ -641,6 +667,7 @@ func TestSecretEdit(t *testing.T) {
 	testUserId := "testUser"
 
 	userDao := dao.GetUserDao(&tenantIDForSecret)
+
 	user, err := userDao.FindOrCreate(testUserId)
 	if err != nil {
 		t.Error(err)
@@ -662,6 +689,7 @@ func TestSecretEdit(t *testing.T) {
 	}
 
 	var userID *int64
+
 	for _, userScoped := range []bool{false, true} {
 		if userScoped {
 			userID = &user.Id
@@ -705,6 +733,7 @@ func TestSecretEdit(t *testing.T) {
 		}
 
 		var outSecret m.SecretResponse
+
 		err = json.Unmarshal(rec.Body.Bytes(), &outSecret)
 		if err != nil {
 			t.Error("Failed unmarshaling output")
@@ -715,6 +744,7 @@ func TestSecretEdit(t *testing.T) {
 		}
 
 		secretDao := dao.GetSecretDao(&dao.RequestParams{TenantID: &tenantIDForSecret, UserID: userID})
+
 		secret, err = secretDao.GetById(&secret.DbID)
 		if err != nil {
 			t.Error("secret not found")
@@ -749,8 +779,10 @@ func TestSecretEdit(t *testing.T) {
 
 func TestSecretEditInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	tenantOther := int64(1)
+
 	secret, err := dao.CreateSecretByName("Secret 1", &tenantOther, nil)
 	if err != nil {
 		t.Error(err)
@@ -784,6 +816,7 @@ func TestSecretEditInvalidTenant(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundSecretEdit := ErrorHandlingContext(SecretEdit)
+
 	err = notFoundSecretEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -822,6 +855,7 @@ func TestSecretEditNotFound(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundSecretEdit := ErrorHandlingContext(SecretEdit)
+
 	err = notFoundSecretEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -834,6 +868,7 @@ func TestSecretEditBadRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 
 	tenantId := int64(1)
+
 	secret, err := dao.CreateSecretByName("Secret 1", &tenantId, nil)
 	if err != nil {
 		t.Error(err)
@@ -868,6 +903,7 @@ func TestSecretEditBadRequest(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestSecretEdit := ErrorHandlingContext(SecretEdit)
+
 	err = badRequestSecretEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -885,12 +921,14 @@ func TestSecretDelete(t *testing.T) {
 	testUserId := "testUser"
 
 	userDao := dao.GetUserDao(&tenantIDForSecret)
+
 	user, err := userDao.FindOrCreate(testUserId)
 	if err != nil {
 		t.Error(err)
 	}
 
 	var userID *int64
+
 	for _, userScoped := range []bool{false, true} {
 		if userScoped {
 			userID = &user.Id
@@ -934,6 +972,7 @@ func TestSecretDelete(t *testing.T) {
 		}
 
 		secretDao := dao.GetSecretDao(&dao.RequestParams{TenantID: &tenantIDForSecret, UserID: userID})
+
 		_, err = secretDao.GetById(&secret.DbID)
 		if !errors.As(err, &util.ErrNotFound{}) {
 			t.Error("'secret not found' expected")
@@ -943,8 +982,10 @@ func TestSecretDelete(t *testing.T) {
 
 func TestSecretDeleteInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	tenantOther := int64(1)
+
 	secret, err := dao.CreateSecretByName("Secret 1", &tenantOther, nil)
 	if err != nil {
 		t.Error(err)
@@ -969,6 +1010,7 @@ func TestSecretDeleteInvalidTenant(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundSecretEdit := ErrorHandlingContext(SecretDelete)
+
 	err = notFoundSecretEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -999,6 +1041,7 @@ func TestSecretDeleteNotFound(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundSecretEdit := ErrorHandlingContext(SecretDelete)
+
 	err := notFoundSecretEdit(c)
 	if err != nil {
 		t.Error(err)

--- a/service/application_authentication_validation.go
+++ b/service/application_authentication_validation.go
@@ -10,12 +10,14 @@ func ValidateApplicationAuthenticationCreateRequest(appAuth *m.ApplicationAuthen
 	if err != nil {
 		return err
 	}
+
 	appAuth.ApplicationID = appId
 
 	authId, err := util.InterfaceToInt64(appAuth.AuthenticationIDRaw)
 	if err != nil {
 		return err
 	}
+
 	appAuth.AuthenticationID = authId
 
 	return nil

--- a/service/application_validation.go
+++ b/service/application_validation.go
@@ -34,6 +34,7 @@ func ValidateApplicationCreateRequest(requestParams *dao.RequestParams, appReq *
 	if err != nil {
 		return fmt.Errorf("invalid application type id %v", appReq.ApplicationTypeIDRaw)
 	}
+
 	appReq.ApplicationTypeID = appTypeID
 
 	sourceID, err := util.InterfaceToInt64(appReq.SourceIDRaw)
@@ -43,6 +44,7 @@ func ValidateApplicationCreateRequest(requestParams *dao.RequestParams, appReq *
 
 	// Check if sourceID exists
 	sourceDao := dao.GetSourceDao(requestParams)
+
 	sourceExists, err := sourceDao.Exists(sourceID)
 	if err != nil {
 		return err

--- a/service/application_validation_test.go
+++ b/service/application_validation_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestValidApplicationRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: true}
 
 	req := m.ApplicationCreateRequest{
@@ -40,6 +41,7 @@ func TestValidApplicationRequest(t *testing.T) {
 
 func TestInvalidApplicationTypeForSource(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	AppTypeDao = &mocks.MockApplicationTypeDao{Compatible: false}
 
 	req := m.ApplicationCreateRequest{
@@ -94,7 +96,6 @@ func TestEditNilAvailabilityStatus(t *testing.T) {
 	}
 
 	err := ValidateApplicationEditRequest(&editRequest)
-
 	if err != nil {
 		t.Errorf(`unexpected error when validating an empty availability status for an application edit: %s`, err)
 	}
@@ -112,6 +113,7 @@ func TestEditInvalidAvailabilityStatuses(t *testing.T) {
 	}
 
 	want := `availability status invalid. Must be one of "available", "in_progress", "partially_available" or "unavailable"`
+
 	for _, tv := range testValues {
 		editRequest := m.ApplicationEditRequest{
 			AvailabilityStatus: tv,
@@ -141,7 +143,6 @@ func TestEditValidAvailabilityStatuses(t *testing.T) {
 		}
 
 		err := ValidateApplicationEditRequest(&editRequest)
-
 		if err != nil {
 			t.Errorf(`unexpected error when validating a valid availability status "%s" for an application edit: %s`, *tv, err)
 		}
@@ -160,8 +161,8 @@ func TestEditInvalidAvailabilityStatusPaused(t *testing.T) {
 	}
 
 	want := `invalid availability status. Must be one of "available", "in_progress", "partially_available" or "unavailable"`
-	for _, tv := range testValues {
 
+	for _, tv := range testValues {
 		editRequest := m.ResourceEditPausedRequest{
 			AvailabilityStatus: tv,
 		}
@@ -192,8 +193,8 @@ func TestEditValidAvailabilityStatusPaused(t *testing.T) {
 		}
 
 		app := m.Application{}
-		err := app.UpdateFromRequestPaused(&editRequest)
 
+		err := app.UpdateFromRequestPaused(&editRequest)
 		if err != nil {
 			t.Errorf(`unexpected error when validating a valid availability status "%s" for a paused application edit: %s`, *tv, err)
 		}

--- a/service/authentication_validation.go
+++ b/service/authentication_validation.go
@@ -16,6 +16,7 @@ func ValidateAuthenticationCreationRequest(auth *model.AuthenticationCreateReque
 	if auth.ResourceType == "" {
 		return fmt.Errorf("resource_type is required")
 	}
+
 	if auth.ResourceIDRaw == nil {
 		return fmt.Errorf("resource_id is required")
 	}
@@ -24,6 +25,7 @@ func ValidateAuthenticationCreationRequest(auth *model.AuthenticationCreateReque
 	if err != nil {
 		return fmt.Errorf("resource_id must be a valid integer or string")
 	}
+
 	auth.ResourceID = rid
 
 	if !util.SliceContainsString(validAuthenticationResources, strings.ToLower(auth.ResourceType)) {
@@ -33,7 +35,8 @@ func ValidateAuthenticationCreationRequest(auth *model.AuthenticationCreateReque
 	// capitalize it so it's always the same format.
 	auth.ResourceType = util.Capitalize(auth.ResourceType)
 
-	if err = ValidateAzureSubscriptionId(auth); err != nil {
+	err = ValidateAzureSubscriptionId(auth)
+	if err != nil {
 		return fmt.Errorf("subscription ID is invalid: %w", err)
 	}
 
@@ -64,11 +67,12 @@ func ValidateAzureSubscriptionId(auth *model.AuthenticationCreateRequest) error 
 		if trimmed == "" {
 			return errors.New("username must not be blank or empty for Azure Source Types")
 		}
-		if _, err := uuid.Parse(trimmed); err != nil {
+
+		_, err := uuid.Parse(trimmed)
+		if err != nil {
 			return fmt.Errorf("the username must be a valid UUID for Azure Source Types")
 		}
 	}
 
 	return nil
-
 }

--- a/service/authentication_validation_test.go
+++ b/service/authentication_validation_test.go
@@ -105,6 +105,7 @@ func TestAuthEditInvalidAvailabilityStatuses(t *testing.T) {
 	}
 
 	want := `availability status invalid. Must be one of "available", "in_progress", "partially_available" or "unavailable"`
+
 	for _, tv := range testValues {
 		editRequest := model.AuthenticationEditRequest{
 			AvailabilityStatus: tv,
@@ -134,7 +135,6 @@ func TestAuthEditValidAvailabilityStatuses(t *testing.T) {
 		}
 
 		err := ValidateAuthenticationEditRequest(&editRequest)
-
 		if err != nil {
 			t.Errorf(`unexpected error when validating a valid availability status "%s" for an application edit: %s`, *tv, err)
 		}
@@ -148,11 +148,11 @@ func TestValidateAuthenticationCreateRequest_invalidUUID(t *testing.T) {
 		AuthType: "lighthouse_subscription_id",
 		Username: &invalidUsername,
 	}
+
 	err := ValidateAzureSubscriptionId(auth)
 	if err == nil {
 		t.Errorf("expected error for invalid UUID, but got nil")
 	}
-
 }
 
 // TestValidateAuthenticationCreateRequest_ValidUUID tests that an valid UUID should pass
@@ -162,9 +162,9 @@ func TestValidateAuthenticationCreateRequest_ValidUUID(t *testing.T) {
 		AuthType: "lighthouse_subscription_id",
 		Username: &validUsername,
 	}
+
 	err := ValidateAzureSubscriptionId(auth)
 	if err != nil {
 		t.Errorf("Expected no error for valid UUID, but got %s", err)
 	}
-
 }

--- a/service/availability_check_test.go
+++ b/service/availability_check_test.go
@@ -73,6 +73,7 @@ func TestRhcConnectionAvailability(t *testing.T) {
 
 func TestAllAvailability(t *testing.T) {
 	var acr = &dummyChecker{}
+
 	src := &m.Source{
 		// 2 applications on this source.
 		Applications: []m.Application{{}, {}, {}},

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -19,14 +19,19 @@ func TestParseEndpointsTestRegression(t *testing.T) {
 
 	// Prepare all the fixtures to simulate a valid Bulk Create request.
 	var endpointFixture = fixtures.TestEndpointData[0]
+
 	endpointFixture.Role = util.StringRef("endpoint-role")
 	endpointFixture.ReceptorNode = util.StringRef("endpoint-receptor-node")
+
 	var verifySsl = true
+
 	endpointFixture.VerifySsl = &verifySsl
 	endpointFixture.CertificateAuthority = util.StringRef("endpoint-ca")
 
-	var sourceFixture = fixtures.TestSourceData[0]
-	var tenantFixture = fixtures.TestTenantData[0]
+	var (
+		sourceFixture = fixtures.TestSourceData[0]
+		tenantFixture = fixtures.TestTenantData[0]
+	)
 
 	var reqEndpoints = []model.BulkCreateEndpoint{
 		{
@@ -45,6 +50,7 @@ func TestParseEndpointsTestRegression(t *testing.T) {
 			},
 		},
 	}
+
 	bulkCreateOutput := model.BulkCreateOutput{
 		Sources: []model.Source{sourceFixture},
 	}
@@ -142,6 +148,7 @@ func TestParseSourcesWithSourceTypeId(t *testing.T) {
 	// Prepare test data
 	sourceTypeFixture := fixtures.TestSourceTypeData[0]
 	sourceName := "Source for TestParseSources()"
+
 	var reqSources = []model.BulkCreateSource{
 		{
 			SourceCreateRequest: model.SourceCreateRequest{
@@ -156,6 +163,7 @@ func TestParseSourcesWithSourceTypeId(t *testing.T) {
 
 	// Parse the sources
 	var err error
+
 	sources, err := parseSources(reqSources, &tenant, &userResource)
 	if err != nil {
 		t.Errorf(`unexpected error when parsing the sources from bulk create: %s`, err)
@@ -197,6 +205,7 @@ func TestParseSourcesWithSourceTypeName(t *testing.T) {
 	// Prepare test data
 	sourceTypeFixture := fixtures.TestSourceTypeData[1]
 	sourceName := "Source for TestParseSources()"
+
 	var reqSources = []model.BulkCreateSource{
 		{
 			SourceCreateRequest: model.SourceCreateRequest{
@@ -211,6 +220,7 @@ func TestParseSourcesWithSourceTypeName(t *testing.T) {
 
 	// Parse the sources
 	var err error
+
 	sources, err := parseSources(reqSources, &tenant, &userResource)
 	if err != nil {
 		t.Errorf(`unexpected error when parsing the sources from bulk create: %s`, err)
@@ -252,6 +262,7 @@ func TestParseSourcesBadRequestInvalidSourceTypeId(t *testing.T) {
 	// Prepare test data
 	sourceTypeId := "wrong id"
 	sourceName := "Source for TestParseSources()"
+
 	var reqSources = []model.BulkCreateSource{
 		{
 			SourceCreateRequest: model.SourceCreateRequest{
@@ -266,6 +277,7 @@ func TestParseSourcesBadRequestInvalidSourceTypeId(t *testing.T) {
 
 	// Parse the sources and check the results
 	var err error
+
 	sources, err := parseSources(reqSources, &tenant, &userResource)
 	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("expected bad request error, got <%s>", err)
@@ -284,6 +296,7 @@ func TestParseSourcesNotFoundInvalidSourceTypeId(t *testing.T) {
 	// Prepare test data
 	sourceTypeId := "1000"
 	sourceName := "Source for TestParseSources()"
+
 	var reqSources = []model.BulkCreateSource{
 		{
 			SourceCreateRequest: model.SourceCreateRequest{
@@ -298,6 +311,7 @@ func TestParseSourcesNotFoundInvalidSourceTypeId(t *testing.T) {
 
 	// Parse the sources and check the results
 	var err error
+
 	sources, err := parseSources(reqSources, &tenant, &userResource)
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("expected not found error, got <%s>", err)
@@ -316,6 +330,7 @@ func TestParseSourcesBadRequestInvalidSourceTypeName(t *testing.T) {
 	// Prepare test data
 	sourceTypeName := "invalid name"
 	sourceName := "Source for TestParseSources()"
+
 	var reqSources = []model.BulkCreateSource{
 		{
 			SourceCreateRequest: model.SourceCreateRequest{
@@ -330,6 +345,7 @@ func TestParseSourcesBadRequestInvalidSourceTypeName(t *testing.T) {
 
 	// Parse the sources and check the results
 	var err error
+
 	sources, err := parseSources(reqSources, &tenant, &userResource)
 	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("expected bad request error, got <%s>", err)
@@ -347,6 +363,7 @@ func TestParseSourcesBadRequestMissingSourceType(t *testing.T) {
 
 	// Prepare test data
 	sourceName := "Source for TestParseSources()"
+
 	var reqSources = []model.BulkCreateSource{
 		{
 			SourceCreateRequest: model.SourceCreateRequest{
@@ -360,6 +377,7 @@ func TestParseSourcesBadRequestMissingSourceType(t *testing.T) {
 
 	// Parse the sources and check the results
 	var err error
+
 	sources, err := parseSources(reqSources, &tenant, &userResource)
 	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("expected bad request error, got <%s>", err)
@@ -377,6 +395,7 @@ func TestParseSourcesBadRequestValidationFails(t *testing.T) {
 
 	// Prepare test data
 	sourceTypeName := "google"
+
 	var reqSources = []model.BulkCreateSource{
 		{
 			SourceCreateRequest: model.SourceCreateRequest{
@@ -391,6 +410,7 @@ func TestParseSourcesBadRequestValidationFails(t *testing.T) {
 
 	// Parse the sources and check the results
 	var err error
+
 	sources, err := parseSources(reqSources, &tenant, &userResource)
 	if !errors.As(err, &util.ErrBadRequest{}) {
 		t.Errorf("expected bad request error, got <%s>", err)
@@ -410,6 +430,7 @@ func TestParseSourcesWithSourceOwnership(t *testing.T) {
 	sourceTypeName := "bitbucket"
 	applicationTypeName := "app-studio"
 	sourceName := "Source for TestParseSources()"
+
 	var reqSources = []model.BulkCreateSource{
 		{
 			SourceCreateRequest: model.SourceCreateRequest{

--- a/service/endpoint_validation_test.go
+++ b/service/endpoint_validation_test.go
@@ -184,7 +184,6 @@ func TestSchemeGetsDefaulted(t *testing.T) {
 	ecr.Scheme = nil
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
-
 	if err != nil {
 		t.Errorf("want no errors, got %s", err)
 	}
@@ -197,7 +196,6 @@ func TestSchemeGetsDefaulted(t *testing.T) {
 	ecr.Scheme = &invalidScheme
 
 	err = ValidateEndpointCreateRequest(endpointDao, &ecr)
-
 	if err != nil {
 		t.Errorf("want no errors, got %s", err)
 	}
@@ -281,6 +279,7 @@ func TestInvalidHosts(t *testing.T) {
 	ecr := setUpEndpointCreateRequest()
 
 	want := "the provided host is not valid"
+
 	for _, tt := range testValues {
 		ecr.Host = tt
 
@@ -331,6 +330,7 @@ func TestDefaultingPortWhenMissingOrLessThanZero(t *testing.T) {
 
 	for _, tt := range testValues {
 		ecr.Port = tt.value
+
 		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
 		if err != nil {
 			t.Errorf("want no error, got %s", err)
@@ -351,7 +351,6 @@ func TestPortLargeValue(t *testing.T) {
 	ecr.Port = &largePort
 
 	err := ValidateEndpointCreateRequest(endpointDao, &ecr)
-
 	if err == nil {
 		t.Error("want error, got none")
 	}
@@ -395,11 +394,11 @@ func TestEmptyCertificateAuthority(t *testing.T) {
 	}
 
 	want := "the certificate authority cannot be empty"
+
 	for _, tt := range testValues {
 		ecr.CertificateAuthority = tt.value
 
 		err := ValidateEndpointCreateRequest(endpointDao, &ecr)
-
 		if err.Error() != want {
 			t.Errorf("want '%s', got '%s'", want, err)
 		}
@@ -441,7 +440,6 @@ func TestDefaultAvailabilityStatus(t *testing.T) {
 	if want != got {
 		t.Errorf(`unexpected default value for an endpoint when the availability status comes empty. Want "%s", got "%s"`, want, got)
 	}
-
 }
 
 // TestInvalidAvailabilityStatuses tests if an error is returned when passing invalid availability statuses.
@@ -452,6 +450,7 @@ func TestInvalidAvailabilityStatuses(t *testing.T) {
 
 	invalidValues := []string{"hello", "world", "almost", "passes", "validation"}
 	want := "invalid availability status"
+
 	for _, tt := range invalidValues {
 		ecr.AvailabilityStatus = tt
 
@@ -532,7 +531,6 @@ func TestEditSchemeGetsDefaulted(t *testing.T) {
 	editRequest.Scheme = nil
 
 	err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
-
 	if err != nil {
 		t.Errorf("unexpected error when validating a nil scheme for an endpoint edit: %s", err)
 	}
@@ -545,7 +543,6 @@ func TestEditSchemeGetsDefaulted(t *testing.T) {
 	editRequest.Scheme = &invalidScheme
 
 	err = ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
-
 	if err != nil {
 		t.Errorf("unexpected error when editing an endpoint and giving it an invalid scheme: %s", err)
 	}
@@ -631,6 +628,7 @@ func TestEditInvalidHosts(t *testing.T) {
 	editRequest, sourceId := setUpEndpointEditRequest()
 
 	want := "the provided host is not valid"
+
 	for _, tt := range testValues {
 		editRequest.Host = &tt
 
@@ -681,6 +679,7 @@ func TestEditDefaultingPortWhenMissingOrLessThanZero(t *testing.T) {
 
 	for _, tt := range testValues {
 		editRequest.Port = tt.value
+
 		err := ValidateEndpointEditRequest(endpointDao, sourceId, &editRequest)
 		if err != nil {
 			t.Errorf("unexpected error when editing an endpoint and giving it invalid port values: %s", err)
@@ -745,6 +744,7 @@ func TestEditEmptyCertificateAuthority(t *testing.T) {
 	}
 
 	want := "the certificate authority cannot be empty"
+
 	for _, tt := range testValues {
 		editRequest.CertificateAuthority = tt.value
 
@@ -784,6 +784,7 @@ func TestEditEndpointInvalidAvailabilityStatuses(t *testing.T) {
 
 	invalidValues := []string{"hello", "world", "almost", "passes", "validation"}
 	want := "invalid availability status"
+
 	for _, tt := range invalidValues {
 		editRequest.AvailabilityStatus = &tt
 
@@ -810,8 +811,8 @@ func TestEditEndpointInvalidAvailabilityStatusPaused(t *testing.T) {
 	}
 
 	want := `invalid availability status. Must be either "available" or "unavailable"`
-	for _, tv := range testValues {
 
+	for _, tv := range testValues {
 		editRequest := model.ResourceEditPausedRequest{
 			AvailabilityStatus: tv,
 		}
@@ -840,8 +841,8 @@ func TestEditEndpointValidAvailabilityStatusPaused(t *testing.T) {
 		}
 
 		endpoint := model.Endpoint{}
-		err := endpoint.UpdateFromRequestPaused(&editRequest)
 
+		err := endpoint.UpdateFromRequestPaused(&editRequest)
 		if err != nil {
 			t.Errorf(`unexpected error when validating a valid availability status "%s" for a paused endpoint edit: %s`, *tv, err)
 		}

--- a/service/events.go
+++ b/service/events.go
@@ -23,6 +23,7 @@ func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) 
 	}
 
 	headers = append(headers, kafka.Header{Key: "event_type", Value: []byte(eventType)})
+
 	err = Producer().RaiseEvent(eventType, msg, headers)
 	if err != nil {
 		return fmt.Errorf("failed to raise event to kafka: %v", err)
@@ -37,10 +38,14 @@ func RaiseEvent(eventType string, resource model.Event, headers []kafka.Header) 
 //  3. x-rh-sources-org-id -- always passed if present, and used for generation.
 func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	headers := make([]kafka.Header, 0)
-	var account, orgId, xrhid string
-	var ok bool
+
+	var (
+		account, orgId, xrhid string
+		ok                    bool
+	)
 
 	// pulling the specified account if it exists
+
 	if c.Get(h.AccountNumber) != nil {
 		account, ok = c.Get(h.AccountNumber).(string)
 		if !ok {
@@ -73,6 +78,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 			if account == "" {
 				account = id.Identity.AccountNumber
 			}
+
 			if orgId == "" {
 				orgId = id.Identity.OrgID
 			}
@@ -85,6 +91,7 @@ func ForwadableHeaders(c echo.Context) ([]kafka.Header, error) {
 	if account != "" {
 		headers = append(headers, kafka.Header{Key: h.AccountNumber, Value: []byte(account)})
 	}
+
 	if orgId != "" {
 		headers = append(headers, kafka.Header{Key: h.OrgID, Value: []byte(orgId)})
 	}

--- a/service/events_test.go
+++ b/service/events_test.go
@@ -60,6 +60,7 @@ func TestForwadableHeadersAccountNumber(t *testing.T) {
 		xRhIdHeader := headers[1]
 		{
 			want := h.XRHID
+
 			got := xRhIdHeader.Key
 			if want != got {
 				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
@@ -128,6 +129,7 @@ func TestForwadableHeadersOrgId(t *testing.T) {
 		xRhIdHeader := headers[1]
 		{
 			want := h.XRHID
+
 			got := xRhIdHeader.Key
 			if want != got {
 				t.Errorf(`incorrect Kafka header generated. Want "%s", got "%s"`, want, got)
@@ -334,5 +336,4 @@ func TestForwadableHeadersPskOrgId(t *testing.T) {
 			}
 		}
 	}
-
 }

--- a/service/feature_flags.go
+++ b/service/feature_flags.go
@@ -38,6 +38,7 @@ func (l FeatureFlagListener) OnWarning(warning error) {
 
 func (l FeatureFlagListener) OnReady() {
 	ready = true
+
 	logging.Log.Info("connection to unleash instance is ready")
 }
 

--- a/service/main_test.go
+++ b/service/main_test.go
@@ -36,6 +36,7 @@ func TestMain(t *testing.M) {
 		sourceDao = dao.GetSourceDao(requestParams)
 
 		database.CreateFixtures("service")
+
 		err := dao.PopulateStaticTypeCache()
 		if err != nil {
 			panic("failed to populate static type cache")

--- a/service/notifications.go
+++ b/service/notifications.go
@@ -87,6 +87,7 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(i
 	defer kafka.CloseWriter(writer, "emit availability status notification")
 
 	notificationMessageGuid := uuid.New().String()
+
 	loggerWithGuid := l.Log.WithField("notification-guid", notificationMessageGuid)
 	if sourceIdentification != "" {
 		loggerWithGuid = loggerWithGuid.WithField("notification-source-id", sourceIdentification)
@@ -117,6 +118,7 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(i
 	event := notificationEvent{Metadata: notificationMetadata{}, Payload: string(payload)}
 
 	msg := &kafka.Message{}
+
 	err = msg.AddValueAsJSON(&notificationMessage{
 		ID:          notificationMessageGuid,
 		Version:     notificationMessageVersion,
@@ -130,16 +132,17 @@ func (producer *AvailabilityStatusNotifier) EmitAvailabilityStatusNotification(i
 		Context:     string(context),
 		Recipients:  []notificationRecipients{},
 	})
-
 	if err != nil {
 		loggerWithGuid.Warnf("Failed to add struct value as json to kafka message: %v", err)
 		return err
 	}
 
-	if err := kafka.Produce(writer, msg); err != nil {
+	err = kafka.Produce(writer, msg)
+	if err != nil {
 		err := fmt.Errorf("failed to produce Kafka message to emit notification: %v, error: %s", statusEventType, err)
 
 		loggerWithGuid.Warn(err)
+
 		return err
 	}
 

--- a/service/secret_validation.go
+++ b/service/secret_validation.go
@@ -17,5 +17,6 @@ func ValidateSecretCreationRequest(requestParams *dao.RequestParams, auth model.
 			return fmt.Errorf("secret name %s exists in current tenant", *auth.Name)
 		}
 	}
+
 	return nil
 }

--- a/service/source_validation.go
+++ b/service/source_validation.go
@@ -18,7 +18,6 @@ var validWorkflowStatuses = []string{model.AccountAuth, model.ManualConfig}
 // values. In the specific case of the UUID, if an empty or nil one is provided, a new random UUID is generated and
 // appended to the request.
 func ValidateSourceCreationRequest(sourceDao dao.SourceDao, req *model.SourceCreateRequest) error {
-
 	if req.Name == nil || *req.Name == "" {
 		return fmt.Errorf("name cannot be empty")
 	}
@@ -89,5 +88,6 @@ func ValidateSourceEditRequest(dao dao.SourceDao, editRequest *model.SourceEditR
 			return errors.New(`availability status invalid. Must be one of "available", "in_progress", "partially_available" or "unavailable"`)
 		}
 	}
+
 	return nil
 }

--- a/service/source_validation_test.go
+++ b/service/source_validation_test.go
@@ -30,7 +30,6 @@ func setUp() model.SourceCreateRequest {
 		AvailabilityStatus:  model.Available,
 		SourceTypeIDRaw:     &sourceTypeId,
 	}
-
 }
 
 // setUpSourceEditRequest returns a freshly created and valid SourceEditRequest.
@@ -87,11 +86,11 @@ func TestInvalidDuplicatedNameInTenant(t *testing.T) {
 	sourceName := "Source350"
 	sourceUid := "abcde-fghijk"
 	newSource := model.Source{ID: 350, Name: sourceName, SourceTypeID: 1, TenantID: 1, Uid: &sourceUid}
+
 	err := dao.DB.
 		Debug().
 		Create(&newSource).
 		Error
-
 	if err != nil {
 		t.Errorf(`could not create the source fixture for the test: %s`, err)
 	}
@@ -100,7 +99,6 @@ func TestInvalidDuplicatedNameInTenant(t *testing.T) {
 	request.Name = &sourceName
 
 	err = ValidateSourceCreationRequest(sourceDao, &request)
-
 	if err == nil {
 		t.Errorf("Error expected, got none")
 	}
@@ -141,8 +139,8 @@ func TestAppCreationWorkflowValues(t *testing.T) {
 
 	for _, validValue := range validValues {
 		request.AppCreationWorkflow = validValue
-		err := ValidateSourceCreationRequest(sourceDao, &request)
 
+		err := ValidateSourceCreationRequest(sourceDao, &request)
 		if err != nil {
 			t.Errorf("No errors expected, got \"%s\"", err)
 		}
@@ -158,8 +156,8 @@ func TestAppCreationWorkflowValues(t *testing.T) {
 
 	for _, invalidValue := range invalidValues {
 		request.AppCreationWorkflow = invalidValue
-		err := ValidateSourceCreationRequest(sourceDao, &request)
 
+		err := ValidateSourceCreationRequest(sourceDao, &request)
 		if err != nil {
 			t.Errorf("No errors expected, got %s", err)
 		}
@@ -195,6 +193,7 @@ func TestAvailabilityStatusValues(t *testing.T) {
 	// Test that the default value is set on the request when no availability status is provided.
 
 	request.AvailabilityStatus = ""
+
 	err := ValidateSourceCreationRequest(sourceDao, &request)
 	if err != nil {
 		t.Errorf("unexpected error received when setting a default value for the availability status of a source: %s", err)
@@ -230,9 +229,11 @@ func TestAvailabilityStatusValues(t *testing.T) {
 func TestSourceTypeIdLowerOne(t *testing.T) {
 	request := setUp()
 
-	var pointerNegativeInt int64 = -10
-	var pointerNegativeFloat float64 = -1921
-	var pointerNegativeString = "-12345"
+	var (
+		pointerNegativeInt    int64   = -10
+		pointerNegativeFloat  float64 = -1921
+		pointerNegativeString         = "-12345"
+	)
 
 	lowerZero := []struct {
 		value interface{}
@@ -253,7 +254,6 @@ func TestSourceTypeIdLowerOne(t *testing.T) {
 		request.SourceTypeIDRaw = tt.value
 
 		err := ValidateSourceCreationRequest(sourceDao, &request)
-
 		if err == nil {
 			t.Errorf("Error expected, got none")
 		}
@@ -282,8 +282,8 @@ func TestInvalidSourceTypeIdFormat(t *testing.T) {
 
 	for _, tt := range invalidTypes {
 		request.SourceTypeIDRaw = tt.value
-		err := ValidateSourceCreationRequest(sourceDao, &request)
 
+		err := ValidateSourceCreationRequest(sourceDao, &request)
 		if err == nil {
 			t.Errorf("Error expected, got none")
 		}
@@ -301,7 +301,6 @@ func TestSourceTypeIdIsNil(t *testing.T) {
 	}
 
 	err := ValidateSourceCreationRequest(sourceDao, &request)
-
 	if err == nil {
 		t.Errorf("Error expected, got none")
 	}
@@ -319,11 +318,11 @@ func TestEditSourceNameRequest(t *testing.T) {
 	sourceName := "Source350"
 	sourceUid := "abcde-fghijk"
 	newSource := model.Source{ID: 350, Name: sourceName, SourceTypeID: 1, TenantID: 1, Uid: &sourceUid}
+
 	err := dao.DB.
 		Debug().
 		Create(&newSource).
 		Error
-
 	if err != nil {
 		t.Errorf(`could not create the source fixture for the test: %s`, err)
 	}
@@ -332,7 +331,6 @@ func TestEditSourceNameRequest(t *testing.T) {
 	request.Name = &sourceName
 
 	err = ValidateSourceEditRequest(sourceDao, &request)
-
 	if err == nil {
 		t.Errorf("Error expected, got none")
 	}
@@ -353,6 +351,7 @@ func TestEditSourceInvalidName(t *testing.T) {
 	err := ValidateSourceEditRequest(sourceDao, &request)
 
 	want := "name cannot be empty"
+
 	got := err.Error()
 	if want != got {
 		t.Errorf(`unexpected error when editing a source and giving it an empty name. Want "%s", got "%s"`, want, got)
@@ -371,6 +370,7 @@ func TestEditSourceInvalidAvailabilityStatuses(t *testing.T) {
 	}
 
 	want := `availability status invalid. Must be one of "available", "in_progress", "partially_available" or "unavailable"`
+
 	for _, tv := range testValues {
 		editRequest := setUpSourceEditRequest()
 		editRequest.AvailabilityStatus = tv
@@ -398,7 +398,6 @@ func TestEditSourceValidAvailabilityStatuses(t *testing.T) {
 		editRequest.AvailabilityStatus = tv
 
 		err := ValidateSourceEditRequest(sourceDao, &editRequest)
-
 		if err != nil {
 			t.Errorf(`unexpected error when validating a valid availability status "%s" for a source edit: %s`, *tv, err)
 		}
@@ -416,8 +415,8 @@ func TestEditSourceInvalidAvailabilityStatusPaused(t *testing.T) {
 	}
 
 	want := `invalid availability status. Must be one of "available", "in_progress", "partially_available" or "unavailable"`
-	for _, tv := range testValues {
 
+	for _, tv := range testValues {
 		editRequest := model.SourcePausedEditRequest{
 			AvailabilityStatus: tv,
 		}
@@ -448,8 +447,8 @@ func TestEditSourceValidAvailabilityStatusPaused(t *testing.T) {
 		}
 
 		source := model.Source{}
-		err := source.UpdateFromRequestPaused(&editRequest)
 
+		err := source.UpdateFromRequestPaused(&editRequest)
 		if err != nil {
 			t.Errorf(`unexpected error when validating a valid availability status "%s" for a paused endpoint edit: %s`, *tv, err)
 		}

--- a/service/subresource_destroyer.go
+++ b/service/subresource_destroyer.go
@@ -45,6 +45,7 @@ func DeleteCascade(tenantId *int64, userId *int64, resourceType string, resource
 	switch resourceType {
 	case "Source":
 		sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: tenantId, UserID: userId})
+
 		applicationAuthentications, applications, endpoints, rhcConnections, source, err := sourceDao.DeleteCascade(resourceId)
 		if err != nil {
 			return fmt.Errorf(`could not completely delete the source: %s`, err)
@@ -65,6 +66,7 @@ func DeleteCascade(tenantId *int64, userId *int64, resourceType string, resource
 			var appIds []int64
 			for _, app := range applications {
 				appIds = append(appIds, app.ID)
+
 				err := RaiseEvent("Application.destroy", &app, headers)
 				if err != nil {
 					logging.Log.Errorf(`Event "Application.destroy" could not be raised for application %v: %s`, app.ToEvent(), err)
@@ -75,6 +77,7 @@ func DeleteCascade(tenantId *int64, userId *int64, resourceType string, resource
 			var endpointIds []int64
 			for _, endpoint := range endpoints {
 				endpointIds = append(endpointIds, endpoint.ID)
+
 				err := RaiseEvent("Endpoint.destroy", &endpoint, headers)
 				if err != nil {
 					logging.Log.Errorf(`Event "Endpoint.destroy" could not be raised for endpoint %v: %s`, endpoint.ToEvent(), err)
@@ -119,6 +122,7 @@ func DeleteCascade(tenantId *int64, userId *int64, resourceType string, resource
 
 	case "Application":
 		applicationsDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: tenantId, UserID: userId})
+
 		applicationAuthentications, application, err := applicationsDao.DeleteCascade(resourceId)
 		if err != nil {
 			return fmt.Errorf(`could not completely delete the application: %s`, err)
@@ -146,11 +150,13 @@ func DeleteCascade(tenantId *int64, userId *int64, resourceType string, resource
 			}
 
 			authentications = append(authentications, auths...)
+
 			lock.Unlock()
 		}()
 	case "Endpoint":
 		// Delete the endpoint.
 		endpointDao := dao.GetEndpointDao(tenantId)
+
 		endpoint, err := endpointDao.Delete(&resourceId)
 		if err != nil {
 			return fmt.Errorf(`could not delete the endpoint: %s`, err)
@@ -170,6 +176,7 @@ func DeleteCascade(tenantId *int64, userId *int64, resourceType string, resource
 			}
 
 			authentications = append(authentications, auths...)
+
 			lock.Unlock()
 		}()
 	}

--- a/service/superkey.go
+++ b/service/superkey.go
@@ -58,6 +58,7 @@ func SendSuperKeyCreateRequest(application *m.Application, headers []kafka.Heade
 	}
 
 	m := kafka.Message{}
+
 	err = m.AddValueAsJSON(&req)
 	if err != nil {
 		return err
@@ -93,6 +94,7 @@ func SendSuperKeyDeleteRequest(application *m.Application, headers []kafka.Heade
 	if err != nil {
 		return err
 	}
+
 	if skData == nil {
 		l.Log.Warnf("SuperKey Data was nil - cleaning up incomplete superkey")
 		return nil
@@ -110,6 +112,7 @@ func SendSuperKeyDeleteRequest(application *m.Application, headers []kafka.Heade
 	}
 
 	m := kafka.Message{}
+
 	err = m.AddValueAsJSON(&req)
 	if err != nil {
 		return err

--- a/service/superkey_helpers.go
+++ b/service/superkey_helpers.go
@@ -32,6 +32,7 @@ func loadApplication(application *m.Application) (*m.Application, error) {
 func getApplicationSuperkeyMetaData(application *m.Application) ([]superkey.Step, error) {
 	// fetch the metadata from the db (no tenancy required)
 	mDB := dao.GetMetaDataDao()
+
 	metadata, err := mDB.GetSuperKeySteps(application.ApplicationTypeID)
 	if err != nil {
 		return nil, err
@@ -42,6 +43,7 @@ func getApplicationSuperkeyMetaData(application *m.Application) ([]superkey.Step
 	// parse the data brought back from the db into the superkey "step" struct
 	for i, step := range metadata {
 		substitutions := make(map[string]string)
+
 		err := json.Unmarshal(step.Substitutions, &substitutions)
 		if err != nil {
 			return nil, err
@@ -66,18 +68,22 @@ func getExtraValues(application *m.Application, provider string) (map[string]str
 	case "amazon":
 		// fetch the account number for replacing in the iam payloads
 		mDB := dao.GetMetaDataDao()
+
 		acct, err := mDB.GetSuperKeyAccountNumber(application.ApplicationTypeID)
 		if err != nil {
 			return nil, err
 		}
+
 		extra["account"] = acct
 
 		// fetch the result_type for the application_type
 		atDB := dao.GetApplicationTypeDao(nil)
+
 		authType, err := atDB.GetSuperKeyResultType(application.ApplicationTypeID, provider)
 		if err != nil {
 			return nil, err
 		}
+
 		extra["result_type"] = authType
 		externalID := uuid.New().String()
 		extra["external_id"] = externalID
@@ -124,6 +130,7 @@ func parseSuperKeyData(data datatypes.JSON) (*superKeyData, error) {
 	}
 
 	superkeyData := make(map[string]interface{})
+
 	err := json.Unmarshal(data, &superkeyData)
 	if err != nil {
 		return nil, err
@@ -140,15 +147,18 @@ func parseSuperKeyData(data datatypes.JSON) (*superKeyData, error) {
 	}
 
 	var stepsCompleted map[string]map[string]string
+
 	rawSteps := superkeyData["steps"]
 	l.Log.Debugf("rawSteps: %v", rawSteps)
 
 	if rawSteps != nil {
 		b, _ := json.Marshal(&rawSteps)
+
 		err := json.Unmarshal(b, &stepsCompleted)
 		if err != nil {
 			l.Log.Warnf("Failed to unmarshal completed steps into map: %v", err)
 		}
+
 		l.Log.Debugf("Found stepsCompleted: %v", stepsCompleted)
 	}
 

--- a/service/update_resource.go
+++ b/service/update_resource.go
@@ -14,6 +14,7 @@ func UpdateSourceFromApplicationAvailabilityStatus(application *m.Application, p
 	if previousStatus != application.AvailabilityStatus {
 		source := &m.Source{}
 		source.ID = application.SourceID
+
 		source.AvailabilityStatus = application.AvailabilityStatus
 		if application.LastCheckedAt != nil && !application.LastCheckedAt.IsZero() {
 			source.LastCheckedAt = application.LastCheckedAt
@@ -24,6 +25,7 @@ func UpdateSourceFromApplicationAvailabilityStatus(application *m.Application, p
 		}
 
 		sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: &application.TenantID})
+
 		err := sourceDao.Update(source)
 		if err != nil {
 			l.Log.Errorf("unable to load source: %v", err.Error())

--- a/source_handlers.go
+++ b/source_handlers.go
@@ -86,7 +86,6 @@ func SourceGet(c echo.Context) error {
 	c.Logger().Infof("Getting Source Id %v", id)
 
 	s, err := sourcesDB.GetById(&id)
-
 	if err != nil {
 		return err
 	}
@@ -101,7 +100,9 @@ func SourceCreate(c echo.Context) error {
 	}
 
 	input := &m.SourceCreateRequest{}
-	if err := c.Bind(input); err != nil {
+
+	err = c.Bind(input)
+	if err != nil {
 		return err
 	}
 
@@ -127,6 +128,7 @@ func SourceCreate(c echo.Context) error {
 	}
 
 	setEventStreamResource(c, source)
+
 	return c.JSON(http.StatusCreated, source.ToResponse())
 }
 
@@ -152,21 +154,26 @@ func SourceEdit(c echo.Context) error {
 	// If "PausedAt" contains a date it means that the source was paused back then.
 	if s.PausedAt != nil {
 		input := &m.SourcePausedEditRequest{}
-		if err := c.Bind(input); err != nil {
+
+		err := c.Bind(input)
+		if err != nil {
 			return err
 		}
 
-		err := s.UpdateFromRequestPaused(input)
+		err = s.UpdateFromRequestPaused(input)
 		if err != nil {
 			return util.NewErrBadRequest(err)
 		}
 	} else {
 		input := &m.SourceEditRequest{}
-		if err := c.Bind(input); err != nil {
+
+		err := c.Bind(input)
+		if err != nil {
 			return err
 		}
 
-		if err := service.ValidateSourceEditRequest(sourcesDB, input); err != nil {
+		err = service.ValidateSourceEditRequest(sourcesDB, input)
+		if err != nil {
 			return util.NewErrBadRequest(err)
 		}
 
@@ -180,6 +187,7 @@ func SourceEdit(c echo.Context) error {
 
 	setNotificationForAvailabilityStatus(c, previousStatus, s)
 	setEventStreamResource(c, s)
+
 	return c.JSON(http.StatusOK, s.ToResponse())
 }
 
@@ -195,10 +203,10 @@ func SourceDelete(c echo.Context) (err error) {
 	}
 
 	s, err := sourcesDB.GetById(&id)
-
 	if err != nil {
 		return err
 	}
+
 	if c.Get("cert-auth") != nil {
 		satelliteId := dao.Static.GetSourceTypeId("satellite")
 		if s.SourceTypeID != satelliteId {
@@ -240,6 +248,7 @@ func SourceListAuthentications(c echo.Context) error {
 	}
 
 	tenantId := authDao.Tenant()
+
 	out := make([]interface{}, count)
 	for i := 0; i < int(count); i++ {
 		// Set the marketplace token —if the auth is of the marketplace type— for the authentication.
@@ -281,7 +290,6 @@ func SourceTypeListSource(c echo.Context) error {
 	}
 
 	sources, count, err = sourcesDB.SubCollectionList(m.SourceType{Id: id}, limit, offset, filters)
-
 	if err != nil {
 		return err
 	}
@@ -323,7 +331,6 @@ func ApplicationTypeListSource(c echo.Context) error {
 	}
 
 	sources, count, err = sourcesDB.SubCollectionList(m.ApplicationType{Id: id}, limit, offset, filters)
-
 	if err != nil {
 		return err
 	}
@@ -342,6 +349,7 @@ func SourceCheckAvailability(c echo.Context) error {
 	// override the context with a non-terminating context, setting the logger
 	// field so we still get the nice log messages
 	ctx := context.WithValue(context.Background(), logger.EchoLogger{}, c.Get("logger"))
+
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 

--- a/source_handlers_test.go
+++ b/source_handlers_test.go
@@ -64,6 +64,7 @@ func TestSourceListAuthentications(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -78,6 +79,7 @@ func TestSourceListAuthentications(t *testing.T) {
 	}
 
 	var wantCount int
+
 	for _, a := range fixtures.TestAuthenticationData {
 		if a.SourceID == sourceId && a.TenantID == tenantId {
 			wantCount++
@@ -122,10 +124,10 @@ func TestSourceListAuthentications(t *testing.T) {
 				}
 			}
 		}
-
 	}
 
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
+
 	conf.SecretStore = originalSecretStore
 }
 
@@ -162,6 +164,7 @@ func TestSourceListAuthenticationsEmptyList(t *testing.T) {
 // for not existing tenant
 func TestSourceListAuthenticationsTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
@@ -181,6 +184,7 @@ func TestSourceListAuthenticationsTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceListAuthentications := ErrorHandlingContext(SourceListAuthentications)
+
 	err := notFoundSourceListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -193,6 +197,7 @@ func TestSourceListAuthenticationsTenantNotExists(t *testing.T) {
 // valid tenant and source that not belongs to this tenant
 func TestSourceListAuthenticationsInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	sourceId := int64(2)
 	tenantId := int64(2)
 
@@ -212,6 +217,7 @@ func TestSourceListAuthenticationsInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceListAuthentications := ErrorHandlingContext(SourceListAuthentications)
+
 	err := notFoundSourceListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -237,6 +243,7 @@ func TestSourceListAuthenticationsNotFound(t *testing.T) {
 	c.SetParamValues("30983098439")
 
 	notFoundSourceListAuthentications := ErrorHandlingContext(SourceListAuthentications)
+
 	err := notFoundSourceListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -262,6 +269,7 @@ func TestSourceListAuthenticationsBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestSourceListAuthentications := ErrorHandlingContext(SourceListAuthentications)
+
 	err := badRequestSourceListAuthentications(c)
 	if err != nil {
 		t.Error(err)
@@ -299,6 +307,7 @@ func TestSourceTypeSourceSubcollectionList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -315,6 +324,7 @@ func TestSourceTypeSourceSubcollectionList(t *testing.T) {
 	// How many sources with given source type is in fixtures
 	// (adding new fixtures will not affect the test)
 	var wantSourcesCount int
+
 	for _, i := range fixtures.TestSourceData {
 		if i.SourceTypeID == sourceTypeId && i.TenantID == tenantId {
 			wantSourcesCount++
@@ -418,6 +428,7 @@ func TestSourceTypeSourceSubcollectionListNotFound(t *testing.T) {
 	c.SetParamValues("80398409384")
 
 	notFoundSourceTypeListSource := ErrorHandlingContext(SourceTypeListSource)
+
 	err := notFoundSourceTypeListSource(c)
 	if err != nil {
 		t.Error(err)
@@ -443,6 +454,7 @@ func TestSourceTypeSourceSubcollectionListBadRequestInvalidSyntax(t *testing.T) 
 	c.SetParamValues("xxx")
 
 	badRequestSourceTypeListSource := ErrorHandlingContext(SourceTypeListSource)
+
 	err := badRequestSourceTypeListSource(c)
 	if err != nil {
 		t.Error(err)
@@ -472,6 +484,7 @@ func TestSourceTypeSourceSubcollectionListBadRequestInvalidFilter(t *testing.T) 
 	c.SetParamValues("1")
 
 	badRequestSourceTypeListSource := ErrorHandlingContext(SourceTypeListSource)
+
 	err := badRequestSourceTypeListSource(c)
 	if err != nil {
 		t.Error(err)
@@ -510,6 +523,7 @@ func TestApplicationTypeListSourceSubcollectionList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -623,6 +637,7 @@ func TestApplicationTypeListSourceSubcollectionListNotFound(t *testing.T) {
 	c.SetParamValues("398748974")
 
 	notFoundApplicationTypeListSource := ErrorHandlingContext(ApplicationTypeListSource)
+
 	err := notFoundApplicationTypeListSource(c)
 	if err != nil {
 		t.Error(err)
@@ -648,6 +663,7 @@ func TestApplicationTypeListSourceSubcollectionListBadRequestInvalidSyntax(t *te
 	c.SetParamValues("xxx")
 
 	badRequestApplicationTypeListSource := ErrorHandlingContext(ApplicationTypeListSource)
+
 	err := badRequestApplicationTypeListSource(c)
 	if err != nil {
 		t.Error(err)
@@ -677,6 +693,7 @@ func TestApplicationTypeListSourceSubcollectionListBadRequestInvalidFilter(t *te
 	c.SetParamValues("1")
 
 	badRequestApplicationTypeListSource := ErrorHandlingContext(ApplicationTypeListSource)
+
 	err := badRequestApplicationTypeListSource(c)
 	if err != nil {
 		t.Error(err)
@@ -708,6 +725,7 @@ func TestSourceList(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -722,6 +740,7 @@ func TestSourceList(t *testing.T) {
 	}
 
 	var wantSourcesCount int
+
 	for _, s := range fixtures.TestSourceData {
 		if s.TenantID == tenantId {
 			wantSourcesCount++
@@ -839,6 +858,7 @@ func TestSourceListSatellite(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -884,6 +904,7 @@ func TestSourceListBadRequestInvalidFilter(t *testing.T) {
 			"tenantID": int64(1),
 		})
 	badRequestSourceList := ErrorHandlingContext(SourceList)
+
 	err := badRequestSourceList(c)
 	if err != nil {
 		t.Error(err)
@@ -918,6 +939,7 @@ func TestSourceGet(t *testing.T) {
 	}
 
 	var outSrc m.SourceResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &outSrc)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -943,6 +965,7 @@ func TestSourceGet(t *testing.T) {
 			if src.TenantID != tenantId {
 				t.Errorf("wrong tenant id, expected %d, got %d", tenantId, src.TenantID)
 			}
+
 			break
 		}
 	}
@@ -952,6 +975,7 @@ func TestSourceGet(t *testing.T) {
 // existing source id but with tenant that is now owner of this source
 func TestSourceGetInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(3)
 	sourceId := int64(1)
 
@@ -968,6 +992,7 @@ func TestSourceGetInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceGet := ErrorHandlingContext(SourceGet)
+
 	err := notFoundSourceGet(c)
 	if err != nil {
 		t.Error(err)
@@ -980,6 +1005,7 @@ func TestSourceGetInvalidTenant(t *testing.T) {
 // not existing tenant
 func TestSourceGetTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
@@ -996,6 +1022,7 @@ func TestSourceGetTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceGet := ErrorHandlingContext(SourceGet)
+
 	err := notFoundSourceGet(c)
 	if err != nil {
 		t.Error(err)
@@ -1018,6 +1045,7 @@ func TestSourceGetNotFound(t *testing.T) {
 	c.SetParamValues("9872034520975")
 
 	notFoundSourceGet := ErrorHandlingContext(SourceGet)
+
 	err := notFoundSourceGet(c)
 	if err != nil {
 		t.Error(err)
@@ -1040,6 +1068,7 @@ func TestSourceGetBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestSourceGet := ErrorHandlingContext(SourceGet)
+
 	err := badRequestSourceGet(c)
 	if err != nil {
 		t.Error(err)
@@ -1071,6 +1100,7 @@ func TestSourceCreateBadRequest(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestSourceCreate := ErrorHandlingContext(SourceCreate)
+
 	err = badRequestSourceCreate(c)
 	if err != nil {
 		t.Error(err)
@@ -1087,6 +1117,7 @@ func TestSourceCreate(t *testing.T) {
 	version := "10.5"
 	imported := "true"
 	sourceRef := "Source reference #5"
+
 	var sourceTypeId int64 = 1
 
 	requestBody := m.SourceCreateRequest{
@@ -1126,6 +1157,7 @@ func TestSourceCreate(t *testing.T) {
 
 	src := m.SourceResponse{}
 	raw, _ := io.ReadAll(rec.Body)
+
 	err = json.Unmarshal(raw, &src)
 	if err != nil {
 		t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -1137,6 +1169,7 @@ func TestSourceCreate(t *testing.T) {
 
 	id, _ := strconv.ParseInt(src.ID, 10, 64)
 	SourceDao, _ := getSourceDao(c)
+
 	_, err = SourceDao.Delete(&id)
 	if err != nil {
 		t.Errorf("Failed to delete source id %v", id)
@@ -1173,6 +1206,7 @@ func TestSourceEdit(t *testing.T) {
 	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
+
 	err := sourceEditHandlerWithNotifier(c)
 	if err != nil {
 		t.Error(err)
@@ -1184,6 +1218,7 @@ func TestSourceEdit(t *testing.T) {
 
 	src := m.SourceResponse{}
 	raw, _ := io.ReadAll(rec.Body)
+
 	err = json.Unmarshal(raw, &src)
 	if err != nil {
 		t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -1222,6 +1257,7 @@ func TestSourceEdit(t *testing.T) {
 // edit existing not owned source
 func TestSourceEditInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	sourceId := int64(1)
 
@@ -1247,6 +1283,7 @@ func TestSourceEditInvalidTenant(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundSourceEdit := ErrorHandlingContext(SourceEdit)
+
 	err := notFoundSourceEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -1278,6 +1315,7 @@ func TestSourceEditNotFound(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundSourceEdit := ErrorHandlingContext(SourceEdit)
+
 	err := notFoundSourceEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -1309,6 +1347,7 @@ func TestSourceEditBadRequest(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestSourceEdit := ErrorHandlingContext(SourceEdit)
+
 	err := badRequestSourceEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -1340,6 +1379,7 @@ func TestSourceEditNameEmptyString(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	badRequestSourceEdit := ErrorHandlingContext(SourceEdit)
+
 	err := badRequestSourceEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -1376,6 +1416,7 @@ func TestSourceEditNoNameRequest(t *testing.T) {
 	c.Set(h.ParsedIdentity, &identity.XRHID{Identity: identity.Identity{AccountNumber: tenant.ExternalTenant}})
 
 	sourceEditHandlerWithNotifier := middleware.Notifier(SourceEdit)
+
 	err := sourceEditHandlerWithNotifier(c)
 	if err != nil {
 		t.Error(err)
@@ -1387,6 +1428,7 @@ func TestSourceEditNoNameRequest(t *testing.T) {
 
 	src := m.SourceResponse{}
 	raw, _ := io.ReadAll(rec.Body)
+
 	err = json.Unmarshal(raw, &src)
 	if err != nil {
 		t.Errorf("Failed to unmarshal application from response: %v", err)
@@ -1395,6 +1437,7 @@ func TestSourceEditNoNameRequest(t *testing.T) {
 	if *src.Name != source.Name {
 		t.Errorf("Unexpected source name: expected #'{source.Name}', got '#{*src.Name}'")
 	}
+
 	if *src.AvailabilityStatus != "in_progress" {
 		t.Errorf("Wrong availability status, wanted %v got %v", "in_progress", *src.AvailabilityStatus)
 	}
@@ -1609,6 +1652,7 @@ func TestSourceDelete(t *testing.T) {
 
 	// Check that relation "source - rhc connection" doesn't exist
 	var out []m.RhcConnection
+
 	out, _, _ = rhcConnectionDao.ListForSource(&src.ID, 100, 0, []util.Filter{})
 	for _, r := range out {
 		if r.ID == rhc.ID {
@@ -1629,6 +1673,7 @@ func TestSourceDelete(t *testing.T) {
 // delete existing but not owned source
 func TestSourceDeleteInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	sourceId := int64(1)
 
@@ -1645,6 +1690,7 @@ func TestSourceDeleteInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceDelete := ErrorHandlingContext(SourceDelete)
+
 	err := notFoundSourceDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -1667,6 +1713,7 @@ func TestSourceDeleteNotFound(t *testing.T) {
 	c.SetParamValues("9038049384")
 
 	notFoundSourceDelete := ErrorHandlingContext(SourceDelete)
+
 	err := notFoundSourceDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -1689,6 +1736,7 @@ func TestSourceDeleteBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestSourceDelete := ErrorHandlingContext(SourceDelete)
+
 	err := badRequestSourceDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -1735,11 +1783,14 @@ func TestAvailabilityStatusCheckSkipEmptySources(t *testing.T) {
 	)
 
 	// Set the environment variables so that the URL to which we need to send the request gets properly built.
-	if err := os.Setenv("COST_MANAGEMENT_AVAILABILITY_CHECK_URL", "invalidurl"); err != nil {
+	err := os.Setenv("COST_MANAGEMENT_AVAILABILITY_CHECK_URL", "invalidurl")
+	if err != nil {
 		t.Errorf("unable to set the URL for the Cost Management application: %err", err)
 	}
+
 	defer func() {
-		if err := os.Unsetenv("COST_MANAGEMENT_AVAILABILITY_CHECK_URL"); err != nil {
+		err := os.Unsetenv("COST_MANAGEMENT_AVAILABILITY_CHECK_URL")
+		if err != nil {
 			t.Errorf("unable to unset the URL for the Cost Management application: %err", err)
 		}
 	}()
@@ -1774,27 +1825,32 @@ func TestAvailabilityStatusCheckSkipEmptySources(t *testing.T) {
 	// added above. Then, we need to make sure to revert things for the rest of the tests.
 	if parser.RunningIntegrationTests {
 		sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: &fixtures.TestTenantData[0].Id})
-		if err := sourceDao.Create(&fixtureSource); err != nil {
+
+		err := sourceDao.Create(&fixtureSource)
+		if err != nil {
 			t.Errorf(`unable to create the source fixture in the database: %s`, err)
 		}
 
 		defer func() {
-			if _, err := sourceDao.Delete(&fixtureSource.ID); err != nil {
+			_, err := sourceDao.Delete(&fixtureSource.ID)
+			if err != nil {
 				t.Errorf(`unexpected behavior may occur in other tests due to being unable to delete the source fixture: %s`, err)
 			}
 		}()
 	} else {
 		previousMockSourceDao := mockSourceDao
+
 		defer func() {
 			mockSourceDao = previousMockSourceDao
 		}()
+
 		mockSourceDao = &mocks.MockSourceDao{Sources: customSourceFixtures, RelatedSources: fixtures.TestSourceData}
 	}
 
 	c.SetParamNames("source_id")
 	c.SetParamValues("12345")
 
-	err := SourceCheckAvailability(c)
+	err = SourceCheckAvailability(c)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1808,6 +1864,7 @@ func TestAvailabilityStatusCheckSkipEmptySources(t *testing.T) {
 // with a tenant who doesn't own the source
 func TestAvailabilityStatusCheckInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	sourceId := int64(1)
 
@@ -1824,6 +1881,7 @@ func TestAvailabilityStatusCheckInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceCheckAvailability := ErrorHandlingContext(SourceCheckAvailability)
+
 	err := notFoundSourceCheckAvailability(c)
 	if err != nil {
 		t.Error(err)
@@ -1846,6 +1904,7 @@ func TestAvailabilityStatusCheckNotFound(t *testing.T) {
 	c.SetParamValues("183209745")
 
 	notFoundSourceCheckAvailability := ErrorHandlingContext(SourceCheckAvailability)
+
 	err := notFoundSourceCheckAvailability(c)
 	if err != nil {
 		t.Error(err)
@@ -1868,6 +1927,7 @@ func TestAvailabilityStatusCheckBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestSourceCheckAvailability := ErrorHandlingContext(SourceCheckAvailability)
+
 	err := badRequestSourceCheckAvailability(c)
 	if err != nil {
 		t.Error(err)
@@ -1904,6 +1964,7 @@ func TestSourcesGetRelatedRhcConnections(t *testing.T) {
 	}
 
 	var out util.Collection
+
 	err = json.Unmarshal(rec.Body.Bytes(), &out)
 	if err != nil {
 		t.Error("Failed unmarshalling output")
@@ -1940,6 +2001,7 @@ func TestSourcesGetRelatedRhcConnections(t *testing.T) {
 // for source without rhc-connections
 func TestSourcesGetRelatedRhcConnectionsEmptyList(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 	sourceId := int64(4)
 
@@ -1970,6 +2032,7 @@ func TestSourcesGetRelatedRhcConnectionsEmptyList(t *testing.T) {
 // (with existing rhc-connections) but tenant is not owner of this source
 func TestSourcesGetRelatedRhcConnectionsInvalidTenant(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(2)
 	sourceId := int64(1)
 
@@ -1989,6 +2052,7 @@ func TestSourcesGetRelatedRhcConnectionsInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourcesRhcConnectionList := ErrorHandlingContext(SourcesRhcConnectionList)
+
 	err := notFoundSourcesRhcConnectionList(c)
 	if err != nil {
 		t.Error(err)
@@ -2014,6 +2078,7 @@ func TestSourcesGetRelatedRhcConnectionsNotFound(t *testing.T) {
 	c.SetParamValues("0394830498")
 
 	notFoundSourcesRhcConnectionList := ErrorHandlingContext(SourcesRhcConnectionList)
+
 	err := notFoundSourcesRhcConnectionList(c)
 	if err != nil {
 		t.Error(err)
@@ -2039,6 +2104,7 @@ func TestSourcesGetRelatedRhcConnectionsBadRequestInvalidSyntax(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestSourcesRhcConnectionList := ErrorHandlingContext(SourcesRhcConnectionList)
+
 	err := badRequestSourcesRhcConnectionList(c)
 	if err != nil {
 		t.Error(err)
@@ -2068,6 +2134,7 @@ func TestSourcesGetRelatedRhcConnectionsBadRequestInvalidFilter(t *testing.T) {
 	c.SetParamValues("1")
 
 	badRequestSourcesRhcConnectionList := ErrorHandlingContext(SourcesRhcConnectionList)
+
 	err := badRequestSourcesRhcConnectionList(c)
 	if err != nil {
 		t.Error(err)
@@ -2080,6 +2147,7 @@ func TestSourcesGetRelatedRhcConnectionsBadRequestInvalidFilter(t *testing.T) {
 // itself as paused, by modifying their "paused_at" column.
 func TestPauseSourceAndItsApplications(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 	sourceId := int64(1)
 
@@ -2107,6 +2175,7 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 	// Check that the source is paused
 	daoParams := dao.RequestParams{TenantID: &tenantId}
 	sourceDao := dao.GetSourceDao(&daoParams)
+
 	src, err := sourceDao.GetById(&sourceId)
 	if err != nil {
 		t.Error(err)
@@ -2123,14 +2192,17 @@ func TestPauseSourceAndItsApplications(t *testing.T) {
 
 	// Check that relation applications are paused and belongs to desired tenant
 	appDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
+
 	apps, _, err := appDao.SubCollectionList(m.Source{ID: sourceId}, 100, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
+
 	for _, a := range apps {
 		if a.PausedAt == nil {
 			t.Errorf("application with id = %d is not paused and the opposite is expected", a.ID)
 		}
+
 		if a.TenantID != tenantId {
 			t.Errorf("expected tenant %d, got %d", tenantId, a.TenantID)
 		}
@@ -2164,6 +2236,7 @@ func TestPauseSourceAndItsApplicationsInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourcePause := ErrorHandlingContext(SourcePause)
+
 	err := notFoundSourcePause(c)
 	if err != nil {
 		t.Error(err)
@@ -2176,6 +2249,7 @@ func TestPauseSourceAndItsApplicationsInvalidTenant(t *testing.T) {
 // for not existing tenant
 func TestPauseSourceAndItsApplicationsTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
@@ -2192,6 +2266,7 @@ func TestPauseSourceAndItsApplicationsTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourcePause := ErrorHandlingContext(SourcePause)
+
 	err := notFoundSourcePause(c)
 	if err != nil {
 		t.Error(err)
@@ -2214,6 +2289,7 @@ func TestPauseSourceAndItsApplicationsNotFound(t *testing.T) {
 	c.SetParamValues("809897868745")
 
 	notFoundSourcePause := ErrorHandlingContext(SourcePause)
+
 	err := notFoundSourcePause(c)
 	if err != nil {
 		t.Error(err)
@@ -2236,6 +2312,7 @@ func TestPauseSourceAndItsApplicationsBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	badRequestSourcePause := ErrorHandlingContext(SourcePause)
+
 	err := badRequestSourcePause(c)
 	if err != nil {
 		t.Error(err)
@@ -2248,12 +2325,14 @@ func TestPauseSourceAndItsApplicationsBadRequest(t *testing.T) {
 // itself as not paused, by setting their "paused_at" column as "NULL".
 func TestUnpauseSourceAndItsApplications(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := int64(1)
 	sourceId := int64(1)
 
 	// Test data preparation = pause the source and its apps
 	daoParams := dao.RequestParams{TenantID: &tenantId}
 	sourceDao := dao.GetSourceDao(&daoParams)
+
 	err := sourceDao.Pause(sourceId)
 	if err != nil {
 		t.Error(err)
@@ -2298,14 +2377,17 @@ func TestUnpauseSourceAndItsApplications(t *testing.T) {
 
 	// Check that related applications are not paused and belongs to the desired tenant
 	appDao := dao.GetApplicationDao(&dao.RequestParams{TenantID: &tenantId})
+
 	apps, _, err := appDao.SubCollectionList(m.Source{ID: sourceId}, 100, 0, nil)
 	if err != nil {
 		t.Error(err)
 	}
+
 	for _, a := range apps {
 		if a.PausedAt != nil {
 			t.Errorf("application with id = %d is paused and the opposite is expected", a.ID)
 		}
+
 		if a.TenantID != tenantId {
 			t.Errorf("expected tenant %d, got %d", tenantId, a.TenantID)
 		}
@@ -2333,6 +2415,7 @@ func TestUnpauseSourceAndItsApplicationsInvalidTenant(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceUnpause := ErrorHandlingContext(SourceUnpause)
+
 	err := notFoundSourceUnpause(c)
 	if err != nil {
 		t.Error(err)
@@ -2345,6 +2428,7 @@ func TestUnpauseSourceAndItsApplicationsInvalidTenant(t *testing.T) {
 // for not existing tenant
 func TestUnpauseSourceAndItsApplicationsTenantNotExists(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+
 	tenantId := fixtures.NotExistingTenantId
 	sourceId := int64(1)
 
@@ -2361,6 +2445,7 @@ func TestUnpauseSourceAndItsApplicationsTenantNotExists(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceUnpause := ErrorHandlingContext(SourceUnpause)
+
 	err := notFoundSourceUnpause(c)
 	if err != nil {
 		t.Error(err)
@@ -2386,6 +2471,7 @@ func TestUnpauseSourceAndItsApplicationsNotFound(t *testing.T) {
 	c.SetParamValues(fmt.Sprintf("%d", sourceId))
 
 	notFoundSourceUnpause := ErrorHandlingContext(SourceUnpause)
+
 	err := notFoundSourceUnpause(c)
 	if err != nil {
 		t.Error(err)
@@ -2411,6 +2497,7 @@ func TestUnpauseSourceAndItsApplicationsBadRequest(t *testing.T) {
 	c.SetParamValues(sourceId)
 
 	notFoundSourceUnpause := ErrorHandlingContext(SourceUnpause)
+
 	err := notFoundSourceUnpause(c)
 	if err != nil {
 		t.Error(err)
@@ -2454,8 +2541,11 @@ func TestSourcePauseRaiseEventCheck(t *testing.T) {
 	backupProducer := service.Producer
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: MockSender{}} }
 
-	var sourceRaiseEventCallCount int
-	var applicationRaiseEventCallCount int
+	var (
+		sourceRaiseEventCallCount      int
+		applicationRaiseEventCallCount int
+	)
+
 	raiseEventFunc = func(eventType string, payload []byte, headers []kafka.Header) error {
 		// Set up an error which will get returned. Probably will get overwritten if there are multiple errors, but
 		// we don't mind since we are logging every failure. Essentially, it just to satisfy the function signature.
@@ -2472,6 +2562,7 @@ func TestSourcePauseRaiseEventCheck(t *testing.T) {
 			applicationRaiseEventCallCount++
 		default:
 			t.Errorf(`incorrect event type when raising the event. Want "Source.pause" or "Application.pause", got "%s"`, eventType)
+
 			err = errors.New(`incorrect event type raised`)
 		}
 
@@ -2486,6 +2577,7 @@ func TestSourcePauseRaiseEventCheck(t *testing.T) {
 	{
 		// We are pausing a single source, therefore there should only have been 1 call to the "RaiseEvent" function.
 		want := 1
+
 		got := sourceRaiseEventCallCount
 		if want != got {
 			t.Errorf(`raise event was called an incorrect number of times for the source event. Want "%d", got "%d"`, want, got)
@@ -2496,6 +2588,7 @@ func TestSourcePauseRaiseEventCheck(t *testing.T) {
 		// The source has 2 related application in the fixtures, so the "RaiseEvent" function should have been called
 		// twice.
 		want := 2
+
 		got := applicationRaiseEventCallCount
 		if want != got {
 			t.Errorf(`raise event was called an incorrect number of times for the application event. Want "%d", got "%d"`, want, got)
@@ -2532,8 +2625,11 @@ func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
 	backupProducer := service.Producer
 	service.Producer = func() events.Sender { return events.EventStreamProducer{Sender: MockSender{}} }
 
-	var sourceRaiseEventCallCount int
-	var applicationRaiseEventCallCount int
+	var (
+		sourceRaiseEventCallCount      int
+		applicationRaiseEventCallCount int
+	)
+
 	raiseEventFunc = func(eventType string, payload []byte, headers []kafka.Header) error {
 		// Set up an error which will get returned. Probably will get overwritten if there are multiple errors, but
 		// we don't mind since we are logging every failure. Essentially, it just to satisfy the function signature.
@@ -2550,6 +2646,7 @@ func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
 			applicationRaiseEventCallCount++
 		default:
 			t.Errorf(`incorrect event type when raising the event. Want "Source.pause" or "Application.pause", got "%s"`, eventType)
+
 			err = errors.New(`incorrect event type raised`)
 		}
 
@@ -2564,6 +2661,7 @@ func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
 	{
 		// We are resuming a single source, therefore there should only have been 1 call to the "RaiseEvent" function.
 		want := 1
+
 		got := sourceRaiseEventCallCount
 		if want != got {
 			t.Errorf(`raise event was called an incorrect number of times for the source event. Want "%d", got "%d"`, want, got)
@@ -2574,6 +2672,7 @@ func TestSourceUnpauseRaiseEventCheck(t *testing.T) {
 		// The source has 2 related application in the fixtures, so the "RaiseEvent" function should have been called
 		// twice.
 		want := 2
+
 		got := applicationRaiseEventCallCount
 		if want != got {
 			t.Errorf(`raise event was called an incorrect number of times for the application event. Want "%d", got "%d"`, want, got)
@@ -2621,6 +2720,7 @@ func sourceEventTestHelper(t *testing.T, c echo.Context, expectedEventType strin
 
 	{
 		var h kafka.Header
+
 		for _, header := range headers {
 			if header.Key == "event_type" {
 				h = header
@@ -2629,6 +2729,7 @@ func sourceEventTestHelper(t *testing.T, c echo.Context, expectedEventType strin
 		}
 		// The header should contain the expected event type as well.
 		want := expectedEventType
+
 		got := string(h.Value)
 		if want != got {
 			t.Errorf(`incorrect header on raise event. Want "%s", got "%s"`, want, got)
@@ -2673,6 +2774,7 @@ func TestSourceEditPausedIntegration(t *testing.T) {
 	}
 
 	badRequestSourceEdit := ErrorHandlingContext(SourceEdit)
+
 	err = badRequestSourceEdit(c)
 	if err != nil {
 		t.Error(err)
@@ -2689,6 +2791,7 @@ func TestSourceEditPausedIntegration(t *testing.T) {
 	}
 
 	want := "name"
+
 	got := rec.Body.String()
 	if !strings.Contains(got, want) {
 		t.Errorf(`unexpected body returned. Want "%s" contained in what we got "%s"`, want, got)
@@ -2766,6 +2869,7 @@ func TestSourceDeleteWithOwnershipWhenUserIsNotAllowedToDelete(t *testing.T) {
 	otherUserIDWithoutOwnRecords := "other_user"
 	applicationTypeID := fixtures.TestApplicationTypeData[3].Id
 	sourceTypeID := fixtures.TestSourceTypeData[2].Id
+
 	recordsWithUserID, _, err := dao.CreateSourceWithSubResources(sourceTypeID, applicationTypeID, accountNumber, &userIDWithOwnRecords)
 	if err != nil {
 		t.Errorf("unable to create source: %v", err)
@@ -2795,6 +2899,7 @@ func TestSourceDeleteWithOwnershipWhenUserIsNotAllowedToDelete(t *testing.T) {
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	notFoundSourceDelete := ErrorHandlingContext(SourceDelete)
+
 	err = notFoundSourceDelete(c)
 	if err != nil {
 		t.Error(err)
@@ -2818,6 +2923,7 @@ func TestSuperKeyDestroyWithOwnershipWhenUserIsNotAllowedToDelete(t *testing.T) 
 
 	applicationTypeID := fixtures.TestApplicationTypeData[3].Id
 	sourceTypeID := fixtures.TestSourceTypeData[2].Id
+
 	recordsWithUserID, user, err := dao.CreateSourceWithSubResources(sourceTypeID, applicationTypeID, accountNumber, &userIDWithOwnRecords)
 	if err != nil {
 		t.Errorf("unable to create source: %v", err)
@@ -2828,6 +2934,7 @@ func TestSuperKeyDestroyWithOwnershipWhenUserIsNotAllowedToDelete(t *testing.T) 
 	tenantID := src.TenantID
 
 	sourceDao := dao.GetSourceDao(&dao.RequestParams{TenantID: &tenantID, UserID: &user.Id})
+
 	err = sourceDao.Update(&m.Source{ID: src.ID, AppCreationWorkflow: m.AccountAuth})
 	if err != nil {
 		t.Error(err)
@@ -2858,6 +2965,7 @@ func TestSuperKeyDestroyWithOwnershipWhenUserIsNotAllowedToDelete(t *testing.T) 
 	c.Request().Header.Add("Content-Type", "application/json;charset=utf-8")
 
 	superKeyDestroySource := middleware.SuperKeyDestroySource(SourceDelete)
+
 	err = superKeyDestroySource(c)
 	if !errors.As(err, &util.ErrNotFound{}) {
 		t.Errorf("improper error occurred for super key destroy source operation %v", err)
@@ -2878,6 +2986,7 @@ func TestSourceDeleteWithOwnership(t *testing.T) {
 
 	applicationTypeID := fixtures.TestApplicationTypeData[3].Id
 	sourceTypeID := fixtures.TestSourceTypeData[2].Id
+
 	recordsWithUserID, user, err := dao.CreateSourceWithSubResources(sourceTypeID, applicationTypeID, accountNumber, &userIDWithOwnRecords)
 	if err != nil {
 		t.Errorf("unable to create source: %v", err)
@@ -2931,5 +3040,6 @@ func checkAllSourcesBelongToTenant(tenantId int64, sources []interface{}) error 
 			}
 		}
 	}
+
 	return nil
 }

--- a/source_type_handlers.go
+++ b/source_type_handlers.go
@@ -14,13 +14,11 @@ var getSourceTypeDao func(c echo.Context) (dao.SourceTypeDao, error)
 
 func getSourceTypeDaoWithoutTenant(_ echo.Context) (dao.SourceTypeDao, error) {
 	// we do not need tenancy for source type.
-
 	return dao.GetSourceTypeDao(), nil
 }
 
 func SourceTypeList(c echo.Context) error {
 	sourceTypeDB, err := getSourceTypeDao(c)
-
 	if err != nil {
 		return err
 	}
@@ -62,7 +60,6 @@ func SourceTypeGet(c echo.Context) error {
 	}
 
 	sourceType, err := SourceTypeDB.GetById(&id)
-
 	if err != nil {
 		return err
 	}

--- a/source_type_handlers_test.go
+++ b/source_type_handlers_test.go
@@ -26,7 +26,6 @@ func TestSourceTypeList(t *testing.T) {
 	)
 
 	err := SourceTypeList(c)
-
 	if err != nil {
 		t.Error(err)
 	}
@@ -59,6 +58,7 @@ func TestSourceTypeList(t *testing.T) {
 		if !ok {
 			t.Error("model did not deserialize as a application type response")
 		}
+
 		if s["id"] == 1 && s["name"] != "amazon" {
 			t.Error("ghosts infected the return")
 		}
@@ -84,6 +84,7 @@ func TestSourceTypeListBadRequestInvalidFilter(t *testing.T) {
 	)
 
 	badRequestSourceTypeList := ErrorHandlingContext(SourceTypeList)
+
 	err := badRequestSourceTypeList(c)
 	if err != nil {
 		t.Error(err)
@@ -113,6 +114,7 @@ func TestSourceTypeGet(t *testing.T) {
 	}
 
 	var outSrc m.SourceResponse
+
 	err = json.Unmarshal(rec.Body.Bytes(), &outSrc)
 	if err != nil {
 		t.Error("Failed unmarshaling output")
@@ -135,6 +137,7 @@ func TestSourceTypeGetNotFound(t *testing.T) {
 	c.SetParamValues("3098539345")
 
 	notFoundSourceTypeGet := ErrorHandlingContext(SourceTypeGet)
+
 	err := notFoundSourceTypeGet(c)
 	if err != nil {
 		t.Error(err)
@@ -155,6 +158,7 @@ func TestSourceTypeGetBadRequest(t *testing.T) {
 	c.SetParamValues("xxx")
 
 	notFoundSourceTypeGet := ErrorHandlingContext(SourceTypeGet)
+
 	err := notFoundSourceTypeGet(c)
 	if err != nil {
 		t.Error(err)

--- a/statuslistener/main_test.go
+++ b/statuslistener/main_test.go
@@ -14,12 +14,14 @@ var runningIntegration = false
 
 func TestMain(t *testing.M) {
 	l.InitLogger(config)
+
 	flags := parser.ParseFlags()
 
 	if flags.CreateDb {
 		database.CreateTestDB()
 	} else if flags.Integration {
 		runningIntegration = true
+
 		database.ConnectAndMigrateDB("status_listener")
 		database.CreateFixtures("status_listener")
 	}

--- a/util/collection_response.go
+++ b/util/collection_response.go
@@ -26,6 +26,7 @@ type Links struct {
 
 func CollectionResponse(collection []interface{}, req *http.Request, count, limit, offset int) *Collection {
 	var first, last string
+
 	q := req.URL.Query()
 
 	// set the "first" link with same limit+offset (what they requested)

--- a/util/echo/binder_test.go
+++ b/util/echo/binder_test.go
@@ -22,6 +22,7 @@ func TestGoodPayload(t *testing.T) {
 		bytes.NewBufferString(`{"good_field": true}`),
 		nil,
 	)
+
 	err := c.Bind(&TestStruct{})
 	if err != nil {
 		t.Error(err)
@@ -40,7 +41,6 @@ func TestBadPayload(t *testing.T) {
 	if err == nil {
 		t.Error("No error was found when there should have been an extra field error")
 	}
-
 }
 
 func TestNilBody(t *testing.T) {
@@ -59,7 +59,6 @@ func TestNilBody(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "no body") {
 		t.Errorf("Expected that err message contains 'no body' but got '%s'", err)
 	}
-
 }
 
 func TestNoBody(t *testing.T) {
@@ -77,7 +76,6 @@ func TestNoBody(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "no body") {
 		t.Errorf("Expected that err message contains 'no body' but got '%s'", err)
 	}
-
 }
 
 // TestEmptyJsonBody tests that when a valid, empty JSON object is given, a "bad request" error is returned.

--- a/util/echo/echo_context_test.go
+++ b/util/echo/echo_context_test.go
@@ -84,6 +84,7 @@ func TestGetTenantFromEchoContextInvalidFormat(t *testing.T) {
 	)
 
 	want := "the tenant was provided in an invalid format"
+
 	_, err := GetTenantFromEchoContext(c)
 	if !strings.Contains(want, err.Error()) {
 		t.Errorf(`incorrect tenant pulled. Want "%s", got "%s"`, want, err)

--- a/util/echo/main_test.go
+++ b/util/echo/main_test.go
@@ -20,6 +20,7 @@ func CreateTestContext(method string, path string, body io.Reader, context map[s
 	echoInstance.Binder = &NoUnknownFieldsBinder{}
 	request := httptest.NewRequest(method, path, body)
 	recorder := httptest.NewRecorder()
+
 	echoContext := echoInstance.NewContext(request, recorder)
 	for k, v := range context {
 		echoContext.Set(k, v)

--- a/util/encryption.go
+++ b/util/encryption.go
@@ -26,6 +26,7 @@ func InitializeEncryption() {
 	key = os.Getenv("ENCRYPTION_KEY")
 	if key == "" {
 		var err error
+
 		key, err = setDefaultEncryptionKey()
 		if err != nil {
 			panic(err)
@@ -36,6 +37,7 @@ func InitializeEncryption() {
 	if err != nil {
 		panic(err)
 	}
+
 	key = string(decoded)
 	keyPresent = true
 }
@@ -47,7 +49,9 @@ func setDefaultEncryptionKey() (string, error) {
 		if !ok {
 			return "", fmt.Errorf("not possible to recover the information")
 		}
+
 		filepath := path.Join(path.Dir(filename), "encryption_key.dev")
+
 		_, err := os.Stat(filepath)
 		if os.IsNotExist(err) {
 			panic("encryption_key.dev file does not exist. Please import encryption_key.dev file and create symlink encryption_key.dev to encryption_key using [ln -s FILE LINK].")
@@ -56,14 +60,18 @@ func setDefaultEncryptionKey() (string, error) {
 			if bodyErr != nil {
 				return "", fmt.Errorf("unable to read file: %v", err)
 			}
+
 			key = string(body)
+
 			keyErr := os.Setenv("ENCRYPTION_KEY", string(body))
 			if keyErr != nil {
 				return "", fmt.Errorf("error in setting variable in environment: %v", keyErr)
 			}
+
 			return key, nil
 		}
 	}
+
 	panic("Unable to set up default encryption key")
 }
 
@@ -160,6 +168,7 @@ func padString(text string, blockSize int) string {
 
 	padLength := blockSize - len(text)%blockSize
 	padding := bytes.Repeat([]byte{byte(0)}, padLength)
+
 	return text + string(padding)
 }
 

--- a/util/encryption_test.go
+++ b/util/encryption_test.go
@@ -89,10 +89,11 @@ func TestSetDefaultEncryptionKey(t *testing.T) {
 	if setErr != nil {
 		t.Errorf("encryption key unable to set as empty string: %v", setErr)
 	}
+
 	InitializeEncryption()
+
 	encryptionKey := os.Getenv("ENCRYPTION_KEY")
 	if encryptionKey != "YWFhYWFhYWFhYWFhYWFhYQ" {
 		t.Errorf("Wrong encryption key! setDefaultEncryptionKey() did not work properly")
 	}
-
 }

--- a/util/error_document.go
+++ b/util/error_document.go
@@ -17,6 +17,7 @@ type ErrorDocument struct {
 func ErrorDocWithRequestId(message, status, uuid string) *ErrorDocument {
 	e := NewErrorDoc(message, status)
 	e.Errors[0].RequestId = uuid
+
 	return e
 }
 

--- a/util/identity_header.go
+++ b/util/identity_header.go
@@ -17,6 +17,7 @@ func GeneratedXRhIdentity(account, orgId string) string {
 			Type: "System",
 		},
 	}
+
 	bytes, err := json.Marshal(id)
 	if err != nil {
 		return ""

--- a/util/identity_header_test.go
+++ b/util/identity_header_test.go
@@ -17,6 +17,7 @@ func TestCreateIdentityHeader(t *testing.T) {
 	}
 
 	var identity identity.XRHID
+
 	err = json.Unmarshal(bytes, &identity)
 	if err != nil {
 		t.Errorf("failed to unmarshal generated x-rh-identity")

--- a/util/parser.go
+++ b/util/parser.go
@@ -18,6 +18,7 @@ func InterfaceToInt64(i interface{}) (int64, error) {
 		if value == nil {
 			return 0, fmt.Errorf("cannot parse a nil pointer to a float64")
 		}
+
 		return int64(*value), nil
 	case int64:
 		return value, nil
@@ -89,6 +90,7 @@ func DateTimePointerToRecordFormat(inputTime *time.Time) *string {
 	if inputTime == nil {
 		return nil
 	}
+
 	return StringValueOrNil(FormatTimeToString(*inputTime, RecordDateTimeFormat))
 }
 
@@ -100,6 +102,7 @@ func DateTimePointerToRFC3339(inputTime *time.Time) string {
 	if inputTime == nil {
 		return ""
 	}
+
 	return FormatTimeToString(*inputTime, time.RFC3339)
 }
 

--- a/util/parser_test.go
+++ b/util/parser_test.go
@@ -28,8 +28,8 @@ func TestValidConversionValues(t *testing.T) {
 	var i interface{}
 	for _, tt := range validTestValues {
 		i = tt.testedValue
-		value, err := InterfaceToInt64(i)
 
+		value, err := InterfaceToInt64(i)
 		if err != nil {
 			t.Errorf("Not expecting an error, got \"%s\"", err)
 		}
@@ -42,9 +42,11 @@ func TestValidConversionValues(t *testing.T) {
 
 // TestNilPointers tests that when passed nil pointers to the InterfaceToInt64 function, this returns an error.
 func TestNilPointers(t *testing.T) {
-	var nilFloatPointer *float64 = nil
-	var nilInt64Pointer *int64 = nil
-	var nilStringPointer *string = nil
+	var (
+		nilFloatPointer  *float64 = nil
+		nilInt64Pointer  *int64   = nil
+		nilStringPointer *string  = nil
+	)
 
 	nilPointers := []struct {
 		pointer interface{}
@@ -57,8 +59,8 @@ func TestNilPointers(t *testing.T) {
 	var i interface{}
 	for _, tt := range nilPointers {
 		i = tt.pointer
-		value, err := InterfaceToInt64(i)
 
+		value, err := InterfaceToInt64(i)
 		if err == nil {
 			t.Errorf("Expecting an error, got none")
 		}
@@ -88,6 +90,7 @@ func TestUnparseableString(t *testing.T) {
 	var i interface{}
 	for _, tt := range notValues {
 		i = tt.value
+
 		value, err := InterfaceToInt64(i)
 		if err == nil {
 			t.Errorf("Error expected, got none")
@@ -153,9 +156,12 @@ func TestGoodStringValues(t *testing.T) {
 }
 
 func TestNilStringValue(t *testing.T) {
-	var x *float64
-	var y *int64
-	var z *string
+	var (
+		x *float64
+		y *int64
+		z *string
+	)
+
 	types := []interface{}{x, y, z, nil}
 
 	for i := range types {

--- a/util/resource.go
+++ b/util/resource.go
@@ -22,6 +22,7 @@ func ParseStatusMessageToResource(resource *Resource, statusMessage types.Status
 
 	resourceID, err := InterfaceToInt64(statusMessage.ResourceID)
 	isErr := err != nil
+
 	resourceTypeWithStringID := SliceContainsString(resourceTypeWithStringIDs, statusMessage.ResourceType)
 	if isErr && !resourceTypeWithStringID {
 		return nil, fmt.Errorf("error in parsing resource: %v, error: %w", resource, err)
@@ -32,6 +33,7 @@ func ParseStatusMessageToResource(resource *Resource, statusMessage types.Status
 	}
 
 	resource.ResourceID = resourceID
+
 	return resource, nil
 }
 

--- a/util/slice_utils.go
+++ b/util/slice_utils.go
@@ -13,6 +13,7 @@ func SliceContainsString(slice []string, target string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/util/xrh_header.go
+++ b/util/xrh_header.go
@@ -13,6 +13,7 @@ import (
 
 func ParseXRHIDHeader(inputIdentity string) (*identity.XRHID, error) {
 	var XRHIdentity *identity.XRHID
+
 	decodedIdentity, err := base64.StdEncoding.DecodeString(inputIdentity)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding Identity: %v", err)

--- a/util/xrh_header_test.go
+++ b/util/xrh_header_test.go
@@ -63,7 +63,6 @@ func TestParseXRHIDHeader(t *testing.T) {
 			t.Errorf(`invalid account number returned. Want "%s", got "%s"`, want, got)
 		}
 	}
-
 }
 
 // TestParseXRHIDHeaderInvalidBase64String tests that an error is returned when the given string is not properly base64
@@ -114,6 +113,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 
 	{
 		want := accountNumber
+
 		got := id.AccountNumber
 		if want != got {
 			t.Errorf(`invalid account number extracted from identity. Want "%s", got "%s"`, want, got)
@@ -122,6 +122,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 
 	{
 		want := orgId
+
 		got := id.OrgID
 		if want != got {
 			t.Errorf(`invalid orgId extracted from identity. Want "%s", got "%s"`, want, got)
@@ -147,6 +148,7 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 
 	{
 		want := accountNumber
+
 		got := id.AccountNumber
 		if want != got {
 			t.Errorf(`invalid account number extracted from identity. Want "%s", got "%s"`, want, got)
@@ -155,10 +157,10 @@ func TestIdentityFromKafkaHeaders(t *testing.T) {
 
 	{
 		want := orgId
+
 		got := id.OrgID
 		if want != got {
 			t.Errorf(`invalid org id extracted from identity. Want "%s", got "%s"`, want, got)
 		}
 	}
-
 }


### PR DESCRIPTION
The GitHub action only complains about the linting errors that are introduced in the new patches, but not about the old ones.

This patch fixes all the linting errors from the codebase:

- Missing whitespaces.
- Removing the inline error checkings.

That way whenever the linter is run locally, no more old errors will be shown.