### PR TITLE
RHCLOUD-37754 | fix: metrics are making Sources panic

### DIFF
--- a/metrics/metrics_prometheus_service.go
+++ b/metrics/metrics_prometheus_service.go
@@ -36,7 +36,8 @@ func NewPrometheusMetricsService() (MetricsService, error) {
 func (s *prometheusMetricsService) IncrementSourcesAvailabilityCheckRequestsCounter() {
 	s.availabilityCheckRequestsCounter.With(
 		prometheus.Labels{
-			"status": outcomeName[resultSuccess],
+			"status":       outcomeName[resultSuccess],
+			"error_origin": "",
 		},
 	).Inc()
 }


### PR DESCRIPTION
The Prometheus client requires us to set all the tags even if they're empty, as otherwise it throws an "inconsistent label cardinality" error.

## Jira ticket
[[RHCLOUD-37754]](https://issues.redhat.com/browse/RHCLOUD-37754)