### PR TITLE
RCHLOUD-39282 | fix: migration does not find the new "image builder" application

### DIFF
--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -28,7 +28,7 @@ var MigrationsCollection = []*gormigrate.Migration{
 	RenameForeignKeysIndexes(),
 	RemoveProcessedDuplicatedTenants(),
 	AvailabilityStatusColumnsNotNullConstraintDefaultValue(),
-	MigrateAwsProvisioningToImageBuilder(),
+	//MigrateAwsProvisioningToImageBuilder(),
 }
 
 var ctx = context.Background()


### PR DESCRIPTION
The migrations run before the seeding, so we need to comment the migration to let the seeding add the new application type.

## Jira ticket
[[RCHLOUD-39282]](https://issues.redhat.com/browse/RCHLOUD-39282)