### PR TITLE
RHCLOUD-39282 | feature: enable "image builder" migration

### DIFF
--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -28,7 +28,7 @@ var MigrationsCollection = []*gormigrate.Migration{
 	RenameForeignKeysIndexes(),
 	RemoveProcessedDuplicatedTenants(),
 	AvailabilityStatusColumnsNotNullConstraintDefaultValue(),
-	//MigrateAwsProvisioningToImageBuilder(),
+	MigrateAwsProvisioningToImageBuilder(),
 }
 
 var ctx = context.Background()


### PR DESCRIPTION
Once the database has been seeded, it is safe to reenable the migration so that the data migration is performed.

## Jira ticket
[[RHCLOUD-39282]](https://issues.redhat.com/browse/RHCLOUD-39282)