### PR TITLE
RHCLOUD-39282 | fix: the UI expects an empty array

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -66,6 +66,7 @@
   dependent_applications: []
   supported_source_types:
     - amazon
+  supported_authentication_types: []
 "/insights/platform/provisioning":
   display_name: Launch images
   dependent_applications: []


### PR DESCRIPTION
The "image builder" application type does not have any specific authentication types that we need to take care of, but unfortunately the UI is expecting an array of elements, so Sources not sending the key with an empty array at least is making the UI do weird things.

## Jira ticket
[[RHCLOUD-39282]](https://issues.redhat.com/browse/RHCLOUD-39282)