### PR TITLE
RHCLOUD-39281 | feature: filter available application types

### DIFF
--- a/application_type_handlers_test.go
+++ b/application_type_handlers_test.go
@@ -4,8 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
+	"slices"
+	"strconv"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/request"
@@ -79,6 +83,110 @@ func TestSourceApplicationTypeSubcollectionList(t *testing.T) {
 
 		if s["id"] == "1" && s["display_name"] != "test app type" {
 			t.Error("ghosts infected the return")
+		}
+	}
+
+	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
+}
+
+// TestSourceApplicationTypeSubcollectionListDisabledAppTypes tests that the
+// handler under test does not return the disabled application types for a
+// given source.
+func TestSourceApplicationTypesSubcollectionListDisabledAppTypes(t *testing.T) {
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[0].Name}
+
+	tenantId := fixtures.TestTenantData[0].Id
+	sourceId := fixtures.TestSourceData[0].ID
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/sources/1/application_types",
+		nil,
+		map[string]interface{}{
+			"limit":    100,
+			"offset":   0,
+			"filters":  []util.Filter{},
+			"tenantID": tenantId,
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	// Call the handler under test.
+	err := SourceListApplicationTypes(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify that the status code is correct.
+	if rec.Code != http.StatusOK {
+		t.Errorf(`unepxected status code returned. Want "%d", got "%d"`, http.StatusOK, rec.Code)
+	}
+
+	// Unmarshal the response.
+	var out util.Collection
+
+	err = json.Unmarshal(rec.Body.Bytes(), &out)
+	if err != nil {
+		t.Errorf(`unexpected error when unmarshalling the response: %s`, err)
+	}
+
+	// Verify the limit key in the meta field.
+	if out.Meta.Limit != 100 {
+		t.Errorf(`unexpected limit value in the meta object. Want "100", got "%d"`, out.Meta.Limit)
+	}
+
+	// Verify the offset key in the meta field.
+	if out.Meta.Offset != 0 {
+		t.Errorf(`unexpected offset value in the meta object. Want "0", got "%d"`, out.Meta.Limit)
+	}
+
+	// Get the expected app types.
+	expectedAppTypes := []m.ApplicationType{}
+
+	for _, app := range fixtures.TestApplicationData {
+		if app.SourceID == sourceId {
+			for _, appType := range fixtures.TestApplicationTypeData {
+				if app.ApplicationTypeID == appType.Id && appType.Name != fixtures.TestApplicationTypeData[0].Name {
+					expectedAppTypes = append(expectedAppTypes, appType)
+				}
+			}
+		}
+	}
+
+	// Verify that the incoming data contains the expected number of
+	// application types.
+	if len(out.Data) != len(expectedAppTypes) {
+		t.Errorf(`unexpected number of application types fetched. Want "%d", got "%d"`, len(expectedAppTypes), len(out.Data))
+	}
+
+	// Verify we received the expected application types.
+	for _, expectedAppType := range expectedAppTypes {
+		atIndex := slices.IndexFunc(out.Data, func(appTypeRaw interface{}) bool {
+			appType, ok := appTypeRaw.(map[string]interface{})
+			if !ok {
+				t.Errorf(`unable to properly decode incoming application type: %v`, appTypeRaw)
+			}
+
+			appTypeIdStr, ok := appType["id"].(string)
+			if !ok {
+				t.Errorf(`the application type id is in an unexpected format. Want "string", got "%s"`, reflect.TypeOf(appType["id"]))
+			}
+
+			appTypeId, err := strconv.Atoi(appTypeIdStr)
+			if err != nil {
+				t.Errorf(`unable to convert application type ID to integer: %s`, err)
+			}
+
+			return int64(appTypeId) == expectedAppType.Id && appType["name"] == expectedAppType.Name
+		})
+
+		if atIndex == -1 {
+			t.Errorf(`unexpected application types fetched. Want "%v", got "%v"`, expectedAppTypes, out.Data)
 		}
 	}
 
@@ -316,6 +424,103 @@ func TestApplicationTypeList(t *testing.T) {
 	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
 }
 
+// TestApplicationTypesListDisabledAppTypes tests that the handler under test
+// returns a "404" response for a disabled application type.
+func TestApplicationTypesListDisabledAppTypes(t *testing.T) {
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[0].Name}
+
+	sourceId := fixtures.TestSourceData[0].ID
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types",
+		nil,
+		map[string]interface{}{
+			"limit":   100,
+			"offset":  0,
+			"filters": []util.Filter{},
+		},
+	)
+
+	c.SetParamNames("source_id")
+	c.SetParamValues(fmt.Sprintf("%d", sourceId))
+
+	// Call the handler under test.
+	err := ApplicationTypeList(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify that the status code is correct.
+	if rec.Code != http.StatusOK {
+		t.Errorf(`unepxected status code returned. Want "%d", got "%d"`, http.StatusOK, rec.Code)
+	}
+
+	// Unmarshal the response.
+	var out util.Collection
+
+	err = json.Unmarshal(rec.Body.Bytes(), &out)
+	if err != nil {
+		t.Errorf(`unexpected error when unmarshalling the response: %s`, err)
+	}
+
+	// Verify the limit key in the meta field.
+	if out.Meta.Limit != 100 {
+		t.Errorf(`unexpected limit value in the meta object. Want "100", got "%d"`, out.Meta.Limit)
+	}
+
+	// Verify the offset key in the meta field.
+	if out.Meta.Offset != 0 {
+		t.Errorf(`unexpected offset value in the meta object. Want "0", got "%d"`, out.Meta.Limit)
+	}
+
+	// Get the expected app types.
+	expectedAppTypes := []m.ApplicationType{}
+
+	for _, appType := range fixtures.TestApplicationTypeData {
+		if appType.Name != fixtures.TestApplicationTypeData[0].Name {
+			expectedAppTypes = append(expectedAppTypes, appType)
+		}
+	}
+
+	// Verify that the incoming data contains the expected number of
+	// application types.
+	if len(out.Data) != len(expectedAppTypes) {
+		t.Errorf(`unexpected number of application types fetched. Want "%d", got "%d"`, len(expectedAppTypes), len(out.Data))
+	}
+
+	// Verify we received the expected application types.
+	for _, expectedAppType := range expectedAppTypes {
+		atIndex := slices.IndexFunc(out.Data, func(appTypeRaw interface{}) bool {
+			appType, ok := appTypeRaw.(map[string]interface{})
+			if !ok {
+				t.Errorf(`unable to properly decode incoming application type: %v`, appTypeRaw)
+			}
+
+			appTypeIdStr, ok := appType["id"].(string)
+			if !ok {
+				t.Errorf(`the application type id is in an unexpected format. Want "string", got "%s"`, reflect.TypeOf(appType["id"]))
+			}
+
+			appTypeId, err := strconv.Atoi(appTypeIdStr)
+			if err != nil {
+				t.Errorf(`unable to convert application type ID to integer: %s`, err)
+			}
+
+			return int64(appTypeId) == expectedAppType.Id && appType["name"] == expectedAppType.Name
+		})
+
+		if atIndex == -1 {
+			t.Errorf(`unexpected application types fetched. Want "%v", got "%v"`, expectedAppTypes, out.Data)
+		}
+	}
+
+	testutils.AssertLinks(t, c.Request().RequestURI, out.Links, 100, 0)
+}
+
 // TestApplicationTypeListWithTenant tests that list of application types is returned
 // even when tenant is provided (the request usually doesn't need a tenant)
 func TestApplicationTypeListWithTenant(t *testing.T) {
@@ -397,6 +602,59 @@ func TestApplicationTypeGet(t *testing.T) {
 
 	if outAppType.DisplayName != "test app type" {
 		t.Error("ghosts infected the return")
+	}
+}
+
+func TestApplicationTypeGetDisabledApplication(t *testing.T) {
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[0].Name}
+
+	c, rec := request.CreateTestContext(
+		http.MethodGet,
+		"/api/sources/v3.1/application_types/1",
+		nil,
+		nil,
+	)
+
+	c.SetParamNames("id")
+	c.SetParamValues("1")
+
+	// Prepare the handler so that the errors get handled.
+	applicationTypeGetDisabledApp := ErrorHandlingContext(ApplicationTypeGet)
+
+	// Call the handler under test.
+	err := applicationTypeGetDisabledApp(c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Verify that the status code is correct.
+	if rec.Code != http.StatusNotFound {
+		t.Errorf(`unepxected status code returned. Want "%d", got "%d"`, http.StatusNotFound, rec.Code)
+	}
+
+	// Verify that the returned body has the expected error.
+	var out util.ErrorDocument
+
+	err = json.Unmarshal(rec.Body.Bytes(), &out)
+	if err != nil {
+		t.Errorf(`unable to unmarshal response: %s`, err)
+	}
+
+	if len(out.Errors) == 0 {
+		t.Errorf(`unmarshaled body does not contain any errors: %v`, out)
+	}
+
+	for _, src := range out.Errors {
+		if src.Detail != "application type not found" {
+			t.Errorf(`unexpected error in body's error detail. Want "not found", got "%s"`, src.Detail)
+		}
+
+		if src.Status != "404" {
+			t.Errorf(`unexpected status code in body's error detail. Want "404", got "%s"`, src.Status)
+		}
 	}
 }
 

--- a/dao/application_type_dao_test.go
+++ b/dao/application_type_dao_test.go
@@ -2,8 +2,11 @@ package dao
 
 import (
 	"errors"
+	"slices"
+	"strings"
 	"testing"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"
@@ -58,6 +61,60 @@ func TestApplicationTypeSubCollectionListOffsetAndLimit(t *testing.T) {
 	DropSchema("offset_limit")
 }
 
+// TestApplicationTypeSubscollectionDisabledApplicationTypes tests that when
+// fetching the associated application types for an entity, the disabled ones
+// are not returned.
+func TestApplicationTypeSubscollectionDisabledApplicationTypes(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_sub_disabled_app_types")
+
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[0].Name}
+
+	// Get the expected application types for the given source from the
+	// fixtures.
+	sourceId := fixtures.TestSourceData[0].ID
+
+	expectedAppTypes := []m.ApplicationType{}
+
+	for _, app := range fixtures.TestApplicationData {
+		if app.SourceID == sourceId {
+			for _, appType := range fixtures.TestApplicationTypeData {
+				if app.ApplicationTypeID == appType.Id && appType.Name != fixtures.TestApplicationTypeData[0].Name {
+					expectedAppTypes = append(expectedAppTypes, appType)
+				}
+			}
+		}
+	}
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+
+	appTypes, gotCount, err := appTypeDao.SubCollectionList(m.Source{ID: sourceId}, 100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`unexpected error when listing the application types: %s`, err)
+	}
+
+	// Verify that only the unfiltered application types have been fetched.
+	if int64(len(expectedAppTypes)) != gotCount {
+		t.Errorf(`incorrect count of application types, want "%d", got "%d"`, len(expectedAppTypes), gotCount)
+	}
+
+	for i, expectedAppType := range expectedAppTypes {
+		if expectedAppType.Id != appTypes[i].Id {
+			t.Errorf(`unexpected app type fetched from the database. Want "%v", got "%v`, expectedAppType, appTypes[i])
+		}
+
+		if expectedAppType.Name != appTypes[i].Name {
+			t.Errorf(`unexpected app type fetched from the database. Want "%v", got "%v`, expectedAppType, appTypes[i])
+		}
+	}
+
+	DropSchema("app_types_sub_disabled_app_types")
+}
+
 // TestApplicationTypeListOffsetAndLimit tests that List() in application type dao returns correct
 // count value and correct count of returned objects
 func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
@@ -96,6 +153,106 @@ func TestApplicationTypeListOffsetAndLimit(t *testing.T) {
 	DropSchema("offset_limit")
 }
 
+// TestApplicationTypeListDisabledApplicationTypes tests that when listing the
+// application types, the disabled ones are not returned.
+func TestApplicationTypeListDisabledApplicationTypes(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_list_disabled_app_types")
+
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[0].Name}
+
+	// Get all the expected application types.
+	expectedAppTypes := []m.ApplicationType{}
+
+	for _, appType := range fixtures.TestApplicationTypeData {
+		if appType.Name != config.Get().DisabledApplicationTypes[0] {
+			expectedAppTypes = append(expectedAppTypes, appType)
+		}
+	}
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+
+	appTypes, gotCount, err := appTypeDao.List(100, 0, []util.Filter{})
+	if err != nil {
+		t.Errorf(`unexpected error when listing the app types: %s`, err)
+	}
+
+	if int64(len(expectedAppTypes)) != gotCount {
+		t.Errorf(`incorrect count of app types, want "%d", got "%d"`, len(expectedAppTypes), gotCount)
+	}
+
+	// Verify that only the unfiltered application types have been fetched.
+	if int64(len(expectedAppTypes)) != gotCount {
+		t.Errorf(`incorrect count of application types, want "%d", got "%d"`, len(expectedAppTypes), gotCount)
+	}
+
+	for _, expectedAppType := range expectedAppTypes {
+		atIndex := slices.IndexFunc(appTypes, func(appType m.ApplicationType) bool {
+			return expectedAppType.Id == appType.Id && expectedAppType.Name == appType.Name
+		})
+
+		if atIndex == -1 {
+			t.Errorf(`unexpected application types fetched. Want "%v", got "%v"`, expectedAppTypes, appTypes)
+		}
+	}
+
+	DropSchema("app_types_list_disabled_app_types")
+}
+
+// TestApplicationTypeGetById tests that the function under test is able to
+// fetch an application by its ID.
+func TestApplicationTypeGetById(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_get_by_id")
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	gotAppType, err := appTypeDao.GetById(&fixtures.TestApplicationTypeData[0].Id)
+
+	// Verify that no error was returned.
+	if err != nil {
+		t.Errorf(`unexpected error when fetching an application type by its id: "%s"`, err)
+	}
+
+	// Verify that the correct application type was fetched.
+	if gotAppType.Id != fixtures.TestApplicationTypeData[0].Id {
+		t.Errorf(`unexpected application type fetched. Want "%v", got "%v"`, fixtures.TestApplicationTypeData[0], gotAppType)
+	}
+
+	DropSchema("app_types_get_by_id")
+}
+
+// TestApplicationTypeGetByIdDisabledApplicationTypes tests that a disabled
+// application type cannot be fetched.
+func TestApplicationTypeGetByIdDisabledApplicationTypes(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_get_by_id_disabled_app_types")
+
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[0].Name}
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	gotAppType, err := appTypeDao.GetById(&fixtures.TestApplicationTypeData[0].Id)
+
+	// Verify that the expected error was returned.
+	if gotAppType != nil {
+		t.Error("got application type object, want nil")
+	}
+
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf("want not found err, got '%v'", err)
+	}
+
+	DropSchema("app_types_get_by_id_disabled_app_types")
+}
+
 func TestApplicationTypeGetByName(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("app_type_by_name")
@@ -115,6 +272,33 @@ func TestApplicationTypeGetByName(t *testing.T) {
 	}
 
 	DropSchema("app_type_by_name")
+}
+
+// TestApplicationTypeGetByNameDisabledApplicationTypes tests that an
+// application type cannot be fetched by its name if it is disabled.
+func TestApplicationTypeGetByNameDisabledApplicationTypes(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_get_by_name_disabled_app_types")
+
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[4].Name}
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	gotAppType, err := appTypeDao.GetByName(fixtures.TestApplicationTypeData[4].Name)
+
+	// Verify that the expected error was returned.
+	if gotAppType != nil {
+		t.Error("got application type object, want nil")
+	}
+
+	if !errors.As(err, &util.ErrNotFound{}) {
+		t.Errorf("want not found err, got '%v'", err)
+	}
+
+	DropSchema("app_types_get_by_name_disabled_app_types")
 }
 
 func TestApplicationTypeGetByNameNotFound(t *testing.T) {
@@ -137,6 +321,7 @@ func TestApplicationTypeGetByNameNotFound(t *testing.T) {
 
 	DropSchema("app_type_by_name")
 }
+
 func TestApplicationTypeGetByNameBadRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("app_type_by_name")
@@ -155,4 +340,147 @@ func TestApplicationTypeGetByNameBadRequest(t *testing.T) {
 	}
 
 	DropSchema("app_type_by_name")
+}
+
+// TestApplicationTypeCompatibleWithSourceSourceNotFound tests that when a
+// non-existent source is specified, the function under test returns an error.
+func TestApplicationTypeCompatibleWithSourceSourceNotFound(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_source_app_type_compatible_non_existing_source")
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	err := appTypeDao.ApplicationTypeCompatibleWithSource(fixtures.TestApplicationTypeData[0].Id, 12345)
+
+	// Verify that the expected error was returned.
+	if err == nil {
+		t.Error("want error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "source not found") {
+		t.Errorf(`want "source not found" error, got "%s"`, err)
+	}
+
+	DropSchema("app_types_source_app_type_compatible_non_existing_source")
+}
+
+// TestApplicationTypeCompatibleWithSourceSourceNotFound tests that when a non
+// compatible source and application type are specified, the function under
+// test returns an error.
+func TestApplicationTypeCompatibleWithSourceNotCompatible(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_source_app_type_not_compatible")
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	err := appTypeDao.ApplicationTypeCompatibleWithSource(fixtures.TestApplicationTypeData[4].Id, fixtures.TestSourceData[5].ID)
+
+	// Verify that the expected error was returned.
+	if err == nil {
+		t.Error("want error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "record not found") {
+		t.Errorf(`want "record not found" error, got "%s"`, err)
+	}
+
+	DropSchema("app_types_source_app_type_not_compatible")
+}
+
+// TestApplicationTypeCompatibleWithSource tests that when a source is
+// compatible with the given application type, the function under test does not
+// return an error.
+func TestApplicationTypeCompatibleWithSource(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_source_app_type_compatible")
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	err := appTypeDao.ApplicationTypeCompatibleWithSource(fixtures.TestApplicationTypeData[5].Id, fixtures.TestSourceData[0].ID)
+
+	// Verify that no error was returned.
+	if err != nil {
+		t.Errorf("want nil, got error: %s", err)
+	}
+
+	DropSchema("app_types_source_app_type_compatible")
+}
+
+// TestApplicationTypeCompatibleWithSourceDisabledApplicationType tests that
+// when an application type is disabled, the function under test returns an
+// error even for a source that would be compatible with the disabled
+// application type.
+func TestApplicationTypeCompatibleWithSourceDisabledApplicationType(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_source_app_type_compatible_disabled_app_type")
+
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[5].Name}
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	err := appTypeDao.ApplicationTypeCompatibleWithSource(fixtures.TestApplicationTypeData[5].Id, fixtures.TestSourceData[0].ID)
+
+	// Verify that the expected error was returned.
+	if err == nil {
+		t.Error("want error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "record not found") {
+		t.Errorf(`want "record not found" error, got "%s"`, err)
+	}
+
+	DropSchema("app_types_source_app_type_compatible_disabled_app_type")
+}
+
+// TestApplicationTypesGetSuperkeyResultType tests that the function under test
+// fetches the expected authentication type.
+func TestApplicationTypesGetSuperkeyResultType(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_source_superkey_result_type")
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	authType, err := appTypeDao.GetSuperKeyResultType(fixtures.TestApplicationTypeData[5].Id, "amazon")
+
+	// Verify that no error was returned.
+	if err != nil {
+		t.Errorf("unexpected error when fetching the superkey result type: %s", err)
+	}
+
+	if authType != "arn" {
+		t.Errorf(`unexpected authentication type fetched. Want "arn", got "%s"`, authType)
+	}
+
+	DropSchema("app_types_source_superkey_result_type")
+}
+
+// TestApplicationTypesGetSuperkeyResultTypeDisabledApplicationType tests that
+// the function under test returns an empty authentication type if the
+// given application type is disabled.
+func TestApplicationTypesGetSuperkeyResultTypeDisabledApplicationType(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("app_types_source_superkey_result_type_disabled_app_type")
+
+	// Disable an application type.
+	defer func() { config.Get().DisabledApplicationTypes = []string{} }()
+
+	config.Get().DisabledApplicationTypes = []string{fixtures.TestApplicationTypeData[5].Name}
+
+	// Call the function under test.
+	appTypeDao := GetApplicationTypeDao(&fixtures.TestTenantData[0].Id)
+	authType, err := appTypeDao.GetSuperKeyResultType(fixtures.TestApplicationTypeData[5].Id, "amazon")
+
+	// Verify that no error was returned.
+	if err != nil {
+		t.Errorf("unexpected error when fetching the superkey result type: %s", err)
+	}
+
+	if authType != "" {
+		t.Errorf(`unexpected authentication type fetched. Want "", got "%s"`, authType)
+	}
+
+	DropSchema("app_types_source_superkey_result_type_disabled_app_type")
 }

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -66,6 +66,8 @@ objects:
           value: ${SECRET_STORE}
         - name: LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: DISABLED_APPLICATION_TYPES
+          value: ${DISABLED_APPLICATION_TYPES}
         - name: ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:
@@ -124,6 +126,8 @@ objects:
           value: ${SECRET_STORE}
         - name: LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: DISABLED_APPLICATION_TYPES
+          value: ${DISABLED_APPLICATION_TYPES}
         - name: ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:
@@ -192,6 +196,8 @@ objects:
           value: ${CLOUD_CONNECTOR_SCHEME}://${CLOUD_CONNECTOR_HOST}:${CLOUD_CONNECTOR_PORT}${CLOUD_CONNECTOR_BASE_PATH}
         - name: CLOUD_CONNECTOR_STATUS_PATH
           value: ${CLOUD_CONNECTOR_STATUS_PATH}
+        - name: DISABLED_APPLICATION_TYPES
+          value: ${DISABLED_APPLICATION_TYPES}
         - name: PROVISIONING_AVAILABILITY_CHECK_URL
           value: ${PROVISIONING_SCHEME}://${PROVISIONING_HOST}:${PROVISIONING_PORT}${PROVISIONING_CHECK_PATH}
         - name: SOURCES_ENV
@@ -263,6 +269,8 @@ objects:
               optional: true
         - name: HANDLE_TENANT_REFRESH
           value: ${HANDLE_TENANT_REFRESH}
+        - name: DISABLED_APPLICATION_TYPES
+          value: ${DISABLED_APPLICATION_TYPES}
         readinessProbe:
           tcpSocket:
             port: 8000
@@ -450,3 +458,6 @@ parameters:
 - description: Whether to handle conflicts on user_ids during a tenant refresh
   name: HANDLE_TENANT_REFRESH
   value: "false"
+- description: A comma-separated list of application types that are disabled in Sources
+  name: DISABLED_APPLICATION_TYPES
+  value: ""

--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -34,9 +34,10 @@ var TestApplicationTypeData = []m.ApplicationType{
 		SupportedSourceTypes: []byte(`["bitbucket", "dockerhub", "github", "gitlab", "quay"]`),
 	},
 	{
-		Id:                   4,
-		DisplayName:          "Cost Management",
-		Name:                 "/insights/platform/cost-management",
-		SupportedSourceTypes: []byte(`["amazon", "azure", "google", "openshift", "ibm"]`),
+		Id:                           4,
+		DisplayName:                  "Cost Management",
+		Name:                         "/insights/platform/cost-management",
+		SupportedSourceTypes:         []byte(`["amazon", "azure", "google", "openshift", "ibm"]`),
+		SupportedAuthenticationTypes: []byte(`{"amazon": ["arn", "arn-2", "arn-3"], "azure": ["azure-auth", "azure-auth-2"]}`),
 	},
 }

--- a/internal/testutils/mocks/mock_dao_application_type.go
+++ b/internal/testutils/mocks/mock_dao_application_type.go
@@ -3,7 +3,9 @@ package mocks
 import (
 	"errors"
 	"fmt"
+	"slices"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -15,14 +17,21 @@ type MockApplicationTypeDao struct {
 }
 
 func (mockAppTypeDao *MockApplicationTypeDao) List(_ int, _ int, _ []util.Filter) ([]m.ApplicationType, int64, error) {
-	count := int64(len(mockAppTypeDao.ApplicationTypes))
-	return mockAppTypeDao.ApplicationTypes, count, nil
+	appTypes := []m.ApplicationType{}
+
+	for _, appType := range mockAppTypeDao.ApplicationTypes {
+		if mockAppTypeDao.isAppTypeEnabled(appType) {
+			appTypes = append(appTypes, appType)
+		}
+	}
+
+	return appTypes, int64(len(appTypes)), nil
 }
 
 func (mockAppTypeDao *MockApplicationTypeDao) GetById(id *int64) (*m.ApplicationType, error) {
-	for _, i := range mockAppTypeDao.ApplicationTypes {
-		if i.Id == *id {
-			return &i, nil
+	for _, appType := range mockAppTypeDao.ApplicationTypes {
+		if mockAppTypeDao.isAppTypeEnabled(appType) && appType.Id == *id {
+			return &appType, nil
 		}
 	}
 
@@ -68,7 +77,7 @@ func (mockAppTypeDao *MockApplicationTypeDao) SubCollectionList(primaryCollectio
 
 		for _, appType := range mockAppTypeDao.ApplicationTypes {
 			for id := range appTypes {
-				if appType.Id == id {
+				if mockAppTypeDao.isAppTypeEnabled(appType) && appType.Id == id {
 					appTypesOut = append(appTypesOut, appType)
 					break
 				}
@@ -105,4 +114,13 @@ func (mockAppTypeDao *MockApplicationTypeDao) ApplicationTypeCompatibleWithSourc
 
 func (mockAppTypeDao *MockApplicationTypeDao) GetByName(_ string) (*m.ApplicationType, error) {
 	return nil, nil
+}
+
+// isAppTypeEnabled returns true when the given application type is enabled.
+func (mockAppTypeDao *MockApplicationTypeDao) isAppTypeEnabled(appType m.ApplicationType) bool {
+	idx := slices.IndexFunc(config.Get().DisabledApplicationTypes, func(disabledAppTypeName string) bool {
+		return disabledAppTypeName == appType.Name
+	})
+
+	return idx == -1
 }


### PR DESCRIPTION
With this feature, we can filter all the application types that are not ready to be used with Sources.

## Jira ticket
[[RHCLOUD-39281]](https://issues.redhat.com/browse/RHCLOUD-39281)