### PR TITLE
RHCLOUD-39282 | feature: new authentication type for Image Builder

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -66,7 +66,8 @@
   dependent_applications: []
   supported_source_types:
     - amazon
-  supported_authentication_types: []
+  supported_authentication_types:
+    - image-builder-aws-account-id
 "/insights/platform/provisioning":
   display_name: Launch images
   dependent_applications: []

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -46,7 +46,7 @@ amazon:
       - name: authentication.extra.external_id
         component: text-field
         hideField: true
-        initializeOnMount: true   
+        initializeOnMount: true
       - name: authentication.username
         stepKey: arn
         component: text-field
@@ -62,7 +62,7 @@ amazon:
         name: application.extra.metered
         label: Metered Product
         simpleValue: true
-        options: 
+        options:
           - label: None
             value: ""
           - label: Red Hat Enterprise Linux
@@ -90,7 +90,26 @@ amazon:
       - name: authentication.extra.external_id
         component: text-field
         hideField: true
-        initializeOnMount: true       
+        initializeOnMount: true
+    - type: image-builder-aws-account-id
+      name: Image Builder AWS Account ID
+      fields:
+        - name: authentication.authtype
+          hideField: true
+          initializeOnMount: true
+          initialValue: image-builder-aws-account-id
+        - name: authentication.username
+          component: text-field
+          label: Account ID
+          isRequired: true
+          validate:
+          - type: required
+          - type: pattern
+            pattern: "^\\d{12}*"
+          - type: max-length
+            threshold: 12
+          - type: min-length
+            threshold: 12
     - type: provisioning-arn
       name: Provisioning's ARN
       fields:
@@ -234,7 +253,7 @@ azure:
         name: application.extra.metered
         label: Metered Product
         simpleValue: true
-        options: 
+        options:
           - label: None
             value: ""
           - label: Red Hat Enterprise Linux


### PR DESCRIPTION
We need to store the AWS Account ID in an authentication for Image Builder.

## Jira ticket
[[RHCLOUD-39282]](https://issues.redhat.com/browse/RHCLOUD-39282)