### PR TITLE
RHCLOUD-39282 | fix: missing "component" in "authentication type" for Image Builder

### DIFF
--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -95,6 +95,7 @@ amazon:
       name: Image Builder AWS Account ID
       fields:
         - name: authentication.authtype
+          component: text-field
           hideField: true
           initializeOnMount: true
           initialValue: image-builder-aws-account-id


### PR DESCRIPTION
I forgot to add it in the authentication's definition, which is making the UI render incorrectly.

## Jira ticket
[[RHCLOUD-39282]](https://issues.redhat.com/browse/RHCLOUD-39282)