### PR TITLE
RHCLOUD-39282 | fix: authentication's structure is wrong

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -67,7 +67,8 @@
   supported_source_types:
     - amazon
   supported_authentication_types:
-    - image-builder-aws-account-id
+    amazon:
+      - image-builder-aws-account-id
 "/insights/platform/provisioning":
   display_name: Launch images
   dependent_applications: []


### PR DESCRIPTION
The authentication type must be under the source type, and I forgot to add that too.

## Jira ticket
[[RHCLOUD-39282]](https://issues.redhat.com/browse/RHCLOUD-39282)