### PR TITLE
RHCLOUD-39282 | fix: existing auth type got removed from Image Builder

### DIFF
--- a/dao/seeds/application_types.yml
+++ b/dao/seeds/application_types.yml
@@ -66,4 +66,6 @@
   dependent_applications: []
   supported_source_types:
     - amazon
-    
+  supported_authentication_types:
+    amazon:
+      - image-builder-aws-account-id

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -90,7 +90,27 @@ amazon:
       - name: authentication.extra.external_id
         component: text-field
         hideField: true
-        initializeOnMount: true       
+        initializeOnMount: true
+    - type: image-builder-aws-account-id
+      name: Image Builder AWS Account ID
+      fields:
+        - name: authentication.authtype
+          component: text-field
+          hideField: true
+          initializeOnMount: true
+          initialValue: image-builder-aws-account-id
+        - name: authentication.username
+          component: text-field
+          label: Account ID
+          isRequired: true
+          validate:
+          - type: required
+          - type: pattern
+            pattern: "^\\d{12}$"
+          - type: max-length
+            threshold: 12
+          - type: min-length
+            threshold: 12
   vendor: Amazon
   icon_url: "/apps/frontend-assets/partners-icons/aws-long.svg"
 google:


### PR DESCRIPTION
For some reason the files got overridden and the image builder's authentication type got removed.

## Jira ticket
[[RHCLOUD-39282]](https://issues.redhat.com/browse/RHCLOUD-39282)