### PR TITLE
RHCLOUD-42337 | fix: Sources returns 500 errors for requests made with service accounts

### DIFF
--- a/middleware/user.go
+++ b/middleware/user.go
@@ -33,7 +33,9 @@ func UserCatcher(next echo.HandlerFunc) echo.HandlerFunc {
 				return fmt.Errorf("failed to fetch the identity header")
 			}
 
-			userIDFromContext = xRhIdentity.Identity.User.UserID
+			if xRhIdentity.Identity.User != nil {
+				userIDFromContext = xRhIdentity.Identity.User.UserID
+			}
 		}
 
 		if userIDFromContext != "" {


### PR DESCRIPTION
The recent changes to the "Platform Go Middlewares" library turned the "User" struct into a pointer, and I forgot to add a nil check for a middleware which is causing issues.

## Jira ticket
[[RHCLOUD-42337]](https://issues.redhat.com/browse/RHCLOUD-42337)