### PR TITLE
 RHCLOUD-42357 | fix: Sources is returning "405 — Method not allowed" errors

### DIFF
--- a/middleware/authorization_test.go
+++ b/middleware/authorization_test.go
@@ -192,32 +192,46 @@ func TestSystemCN(t *testing.T) {
 	}
 }
 
-func TestSystemPatch(t *testing.T) {
-	c, rec := request.CreateTestContext(
+// TestSystemMethodNotAllowed tests that "405 — Method not allowed" errors are
+// returned when using disallowed methods with System or certificate based
+// authentications.
+func TestSystemMethodNotAllowed(t *testing.T) {
+	testMethods := []string{
+		http.MethodConnect,
+		http.MethodHead,
+		http.MethodOptions,
 		http.MethodPatch,
-		"/",
-		nil,
-		map[string]interface{}{
-			h.XRHID: "dummy",
-			h.ParsedIdentity: &identity.XRHID{
-				Identity: identity.Identity{
-					System: &identity.System{
-						CommonName: "test_cert",
+		http.MethodPut,
+		http.MethodTrace,
+	}
+
+	for _, method := range testMethods {
+		c, rec := request.CreateTestContext(
+			method,
+			"/",
+			nil,
+			map[string]interface{}{
+				h.XRHID: "dummy",
+				h.ParsedIdentity: &identity.XRHID{
+					Identity: identity.Identity{
+						System: &identity.System{
+							CommonName: "test_cert",
+						},
 					},
 				},
 			},
-		},
-	)
+		)
 
-	middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{})
+		middleware := setUpMiddleware(false, []string{}, mockedRbacResponse{})
 
-	err := middleware(c)
-	if err != nil {
-		t.Errorf("caught an error when there should not have been one")
-	}
+		err := middleware(c)
+		if err != nil {
+			t.Errorf(`want no error, got "%s"`, err)
+		}
 
-	if rec.Code != http.StatusMethodNotAllowed {
-		t.Errorf("%v was returned instead of %v", rec.Code, http.StatusMethodNotAllowed)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf(`want status code "%d", got "%d"`, http.StatusMethodNotAllowed, rec.Code)
+		}
 	}
 }
 
@@ -370,5 +384,35 @@ func TestRbacNoConnection(t *testing.T) {
 	err := middleware(c)
 	if err == nil {
 		t.Errorf("no error was returned when we were expecting one!")
+	}
+}
+
+// TestIsUsingCertificateBasedAuthentication tests that the function under test
+// correctly identifies a certificate based authentication.
+func TestIsUsingCertificateBasedAuthentication(t *testing.T) {
+	// An empty identity simulates that no "system" object was present in the
+	// JSON object.
+	if isUsingCertificateBasedAuthentication(&identity.XRHID{Identity: identity.Identity{}}) {
+		t.Error(`the function under test incorrectly identified a "nil" "System" struct as a certificate based authentication`)
+	}
+
+	// An empty "System" struct simulates that the "system" JSON object was
+	// defined but empty, like so: "system": {}
+	if isUsingCertificateBasedAuthentication(&identity.XRHID{Identity: identity.Identity{System: &identity.System{}}}) {
+		t.Error(`the function under test incorrectly identified a default "System" struct as a certificate based authentication`)
+	}
+
+	// Tests that non-empty "System" structs are correctly identified as
+	// certificate based authentications.
+	certificateBasedAuthenticationStructs := []*identity.XRHID{
+		{Identity: identity.Identity{System: &identity.System{CertType: "ct"}}},
+		{Identity: identity.Identity{System: &identity.System{ClusterId: "cid"}}},
+		{Identity: identity.Identity{System: &identity.System{CommonName: "cn"}}},
+	}
+
+	for _, cbas := range certificateBasedAuthenticationStructs {
+		if !isUsingCertificateBasedAuthentication(cbas) {
+			t.Errorf(`the given identity struct was not correctly identified as a system based authentication: %#v`, cbas)
+		}
 	}
 }


### PR DESCRIPTION
The upgrade of the "Platform Go Middlewares" library changed the "System" struct to now be a pointer inside the "Identity" struct, and the "emptiness" check was not being correctly performed. This caused some requests to be incorrectly identified as being authenticated with certificates, and since not all of them met the requirements, those requests were getting responded with "405" responses.

## Jira ticket
[[RHCLOUD-42357]](https://issues.redhat.com/browse/RHCLOUD-42357)