### PR TITLE
Available status by default

### DIFF
--- a/dao/source_type_dao_test.go
+++ b/dao/source_type_dao_test.go
@@ -92,7 +92,7 @@ func TestSourceTypeGetByNameBadRequest(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
 	SwitchSchema("source_type_by_name")
 
-	wantSourceType := m.SourceType{Name: "amazon"}
+	wantSourceType := m.SourceType{Name: "a"}
 
 	sourceTypeDao := GetSourceTypeDao()
 

--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -51,7 +51,7 @@ var TestApplicationTypeData = []m.ApplicationType{
 		Id:                           7,
 		DisplayName:                  "Image Builder",
 		Name:                         "/insights/platform/image-builder",
-		SupportedSourceTypes:         []byte(`["amazon"]`),
-		SupportedAuthenticationTypes: []byte(`{"amazon": ["arn", "arn-2", "arn-3"]}`),
+		SupportedSourceTypes:         []byte(`["amazon", "azure", "google", "openshift", "ibm"]`),
+		SupportedAuthenticationTypes: []byte(`{"amazon": ["arn", "arn-2", "arn-3"], "azure": ["azure-auth", "azure-auth-2"]}`),
 	},
 }

--- a/internal/testutils/fixtures/source.go
+++ b/internal/testutils/fixtures/source.go
@@ -11,6 +11,9 @@ var (
 	uid4 = "1c8b6c9a-af40-11ec-b909-0242ac120002"
 	uid5 = "5cbb40a8-f66a-4efb-8ed2-5f18c59ff7ca"
 	uid6 = "f6d1e4ae-781c-4be0-a4ed-8935af5d9f47"
+	uid7 = "ddacfb4c-9964-11f0-9a59-083a885cd988"
+	uid8 = "ac8f9e74-9bbc-4964-817c-3f1785d33026"
+	uid9 = "c5a28805-906a-4ba3-9df1-740e77898e0e"
 )
 
 var TestSourceData = []m.Source{
@@ -61,5 +64,32 @@ var TestSourceData = []m.Source{
 		TenantID:           1,
 		AvailabilityStatus: "available",
 		Uid:                &uid6,
+	},
+	{
+		ID:                 7,
+		Name:               "amazon",
+		SourceType:         TestSourceTypeData[0],
+		SourceTypeID:       TestSourceTypeData[0].Id,
+		TenantID:           TestTenantData[0].Id,
+		AvailabilityStatus: "in_progress",
+		Uid:                &uid7,
+	},
+	{
+		ID:                 8,
+		Name:               "google",
+		SourceType:         TestSourceTypeData[1],
+		SourceTypeID:       TestSourceTypeData[1].Id,
+		TenantID:           1,
+		AvailabilityStatus: "in_progress",
+		Uid:                &uid8,
+	},
+	{
+		ID:                 9,
+		Name:               "bitbucket",
+		SourceType:         TestSourceTypeData[2],
+		SourceTypeID:       TestSourceTypeData[2].Id,
+		TenantID:           TestTenantData[0].Id,
+		AvailabilityStatus: "in_progress",
+		Uid:                &uid9,
 	},
 }

--- a/internal/testutils/fixtures/source_type.go
+++ b/internal/testutils/fixtures/source_type.go
@@ -17,7 +17,7 @@ var TestSourceTypeData = []m.SourceType{
 	},
 	{
 		Id:   4,
-		Name: "amazon123",
+		Name: "ibm",
 	},
 	{
 		Id:   100,

--- a/internal/testutils/helpers.go
+++ b/internal/testutils/helpers.go
@@ -78,15 +78,25 @@ func IdentityHeaderForUser(testUserId string) *identity.XRHID {
 }
 
 func SingleResourceBulkCreateRequest(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType string) *model.BulkCreateRequest {
-	sourceCreateRequest := model.SourceCreateRequest{Name: &nameSource, AvailabilityStatus: model.Available}
+	return SingleResourceBulkCreateRequestWithStatus(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType, model.Available)
+}
+
+// SingleResourceBulkCreateRequestWithStatus similar to the other function, but
+// it allows specifying the availability status for the resources.
+func SingleResourceBulkCreateRequestWithStatus(nameSource, sourceTypeName, applicationTypeName, authenticationResourceType, availablityStatus string) *model.BulkCreateRequest {
+	// Set up the source.
+	sourceCreateRequest := model.SourceCreateRequest{Name: &nameSource, AvailabilityStatus: availablityStatus}
 	bulkCreateSource := model.BulkCreateSource{SourceCreateRequest: sourceCreateRequest, SourceTypeName: sourceTypeName}
 
+	// Set up the application.
 	bulkCreateApplication := model.BulkCreateApplication{SourceName: nameSource, ApplicationTypeName: applicationTypeName}
 
+	// Set up the authentication.
 	authenticationCreateRequest := model.AuthenticationCreateRequest{ResourceType: authenticationResourceType}
 	bulkCreateAuthentication := model.BulkCreateAuthentication{AuthenticationCreateRequest: authenticationCreateRequest, ResourceName: applicationTypeName}
 
-	endpointCreateRequest := model.EndpointCreateRequest{AvailabilityStatus: model.Unavailable}
+	// set up the endpoint.
+	endpointCreateRequest := model.EndpointCreateRequest{AvailabilityStatus: availablityStatus}
 	bulkCreateEndpoints := model.BulkCreateEndpoint{EndpointCreateRequest: endpointCreateRequest, SourceName: nameSource}
 
 	return &model.BulkCreateRequest{Sources: []model.BulkCreateSource{bulkCreateSource},

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -51,7 +52,7 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 			return err
 		}
 
-		err = tx.Omit(clause.Associations).Create(&output.Sources[0]).Error
+		err = tx.Omit(clause.Associations).Create(&output.Sources).Error
 		if err != nil {
 			return err
 		}
@@ -115,6 +116,11 @@ func BulkAssembly(req m.BulkCreateRequest, tenant *m.Tenant, user *m.User) (*m.B
 		err = tx.Omit(clause.Associations).Create(&output.ApplicationAuthentications).Error
 		if err != nil && !errors.Is(err, gorm.ErrEmptySlice) {
 			return err
+		}
+
+		err = setCorrespondingResourcesAsAvailable(tx, output.Sources, output.Applications, output.Authentications)
+		if err != nil {
+			return fmt.Errorf(`unable to override the sources' or applications' availability status to "available": %w`, err)
 		}
 
 		return nil
@@ -561,4 +567,108 @@ func userResourceFromBulkCreateApplications(user *m.User, applications []m.BulkC
 	}
 
 	return userResource, nil
+}
+
+// setCorrespondingResourcesAsAvailable overrides the sources', applications'
+// and authentications' availability status and sets them to "available", for
+// those source and application combinations that do not have or cannot perform
+// availability checks.
+func setCorrespondingResourcesAsAvailable(tx *gorm.DB, sources []m.Source, applications []m.Application, authentications []m.Authentication) error {
+	sourcesToUpdate := []int64{}
+	applicationsToUpdate := []int64{}
+
+	// Identify which sources and applications need their availability status
+	// to be overridden.
+	for i, source := range sources {
+		shouldSourceBeUpdated := false
+
+		for j, application := range applications {
+			if application.SourceID == source.ID && shouldSourceApplicationSetAvailable(source, application) {
+				// We need to update the collection's element's availability
+				// status directly, as the "application" variable holds a copy
+				// of the struct.
+				applications[j].AvailabilityStatus = m.Available
+
+				applicationsToUpdate = append(applicationsToUpdate, applications[j].ID)
+
+				shouldSourceBeUpdated = true
+			}
+		}
+
+		if shouldSourceBeUpdated {
+			// We need to update the collection's element's availability
+			// status directly, as the "source" variable holds a copy of the
+			// struct.
+			sources[i].AvailabilityStatus = m.Available
+
+			sourcesToUpdate = append(sourcesToUpdate, sources[i].ID)
+		}
+	}
+
+	// Identify which authentications need their availability status to be
+	// overridden.
+	authenticationsToUpdate := []int64{}
+	for i, authentication := range authentications {
+		idx := slices.IndexFunc(sourcesToUpdate, func(sourceId int64) bool {
+			return authentication.ResourceType == "Source" && sourceId == authentication.ResourceID
+		})
+
+		if idx != -1 {
+			// We need to update the collection's element's availability
+			// status directly, as the "authentication" variable holds a copy
+			// of the struct.
+			authentications[i].AvailabilityStatus = util.StringRef(m.Available)
+
+			authenticationsToUpdate = append(authenticationsToUpdate, authentications[i].DbID)
+
+			continue
+		}
+
+		idx = slices.IndexFunc(applicationsToUpdate, func(applicationId int64) bool {
+			return authentication.ResourceType == "Application" && applicationId == authentication.ResourceID
+		})
+
+		if idx != -1 {
+			// We need to update the collection's element's availability
+			// status directly, as the "authentication" variable holds a copy
+			// of the struct.
+			authentications[i].AvailabilityStatus = util.StringRef(m.Available)
+
+			authenticationsToUpdate = append(authenticationsToUpdate, authentications[i].DbID)
+		}
+	}
+
+	// Update the sources' availability status.
+	if len(sourcesToUpdate) > 0 {
+		err := tx.Model(m.Source{}).Where("id IN ?", sourcesToUpdate).UpdateColumn("availability_status", m.Available).Error
+		if err != nil {
+			return fmt.Errorf(`unable to override the sources' availability status to "available": %w`, err)
+		}
+	}
+
+	// Update the applications' availability status.
+	if len(applicationsToUpdate) > 0 {
+		err := tx.Model(m.Application{}).Where("id IN ?", applicationsToUpdate).UpdateColumn("availability_status", m.Available).Error
+		if err != nil {
+			return fmt.Errorf(`unable to override the applications' availability status to "available": %w`, err)
+		}
+	}
+
+	// Update the authentications' availability status.
+	if len(authenticationsToUpdate) > 0 {
+		err := tx.Model(m.Authentication{}).Where("id IN ?", authenticationsToUpdate).UpdateColumn("availability_status", m.Available).Error
+		if err != nil {
+			return fmt.Errorf(`unable to override the authentications' availability status to "available": %w`, err)
+		}
+	}
+
+	return nil
+}
+
+// shouldSourceApplicationSetAvailable returns true if the given source and
+// application pairs should have their availability status set to
+// "available".
+func shouldSourceApplicationSetAvailable(source m.Source, application m.Application) bool {
+	return source.SourceType.Name == "amazon" && application.ApplicationType.Name == "/insights/platform/image-builder" ||
+		source.SourceType.Name == "google" && application.ApplicationType.Name == "/insights/platform/cloud-meter"
 }

--- a/service/bulk_create_test.go
+++ b/service/bulk_create_test.go
@@ -2,13 +2,18 @@ package service
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/dao"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/database"
 	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	"github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // TestParseEndpointsTestRegression is a regression test for RHCLOUD-19931. It tests that the "parseEndpoints" function
@@ -755,5 +760,567 @@ func TestParseApplicationsBadRequestNotCompatible(t *testing.T) {
 	// Check the results
 	if apps != nil {
 		t.Errorf("expected nil returned from parseApplications() but got %d applications", len(apps))
+	}
+}
+
+// TestShouldSourceApplicationSetAvailable tests that the function under test
+// correctly identifies which source-application pairs should be set as
+// "available" by default.
+func TestShouldSourceApplicationSetAvailable(t *testing.T) {
+	testCases := []struct {
+		Source         model.Source
+		Application    model.Application
+		ExpectedResult bool
+	}{
+		{
+			Source:         model.Source{SourceType: model.SourceType{Name: "amazon"}},
+			Application:    model.Application{ApplicationType: model.ApplicationType{Name: "/insights/platform/image-builder"}},
+			ExpectedResult: true,
+		},
+		{
+			Source:         model.Source{SourceType: model.SourceType{Name: "google"}},
+			Application:    model.Application{ApplicationType: model.ApplicationType{Name: "/insights/platform/image-builder"}},
+			ExpectedResult: false,
+		},
+		{
+			Source:         model.Source{SourceType: model.SourceType{Name: "azure"}},
+			Application:    model.Application{ApplicationType: model.ApplicationType{Name: "/insights/platform/image-builder"}},
+			ExpectedResult: false,
+		},
+		{
+			Source:         model.Source{SourceType: model.SourceType{Name: "amazon"}},
+			Application:    model.Application{ApplicationType: model.ApplicationType{Name: "/insights/platform/cloud-meter"}},
+			ExpectedResult: false,
+		},
+		{
+			Source:         model.Source{SourceType: model.SourceType{Name: "google"}},
+			Application:    model.Application{ApplicationType: model.ApplicationType{Name: "/insights/platform/cloud-meter"}},
+			ExpectedResult: true,
+		},
+		{
+			Source:         model.Source{SourceType: model.SourceType{Name: "azure"}},
+			Application:    model.Application{ApplicationType: model.ApplicationType{Name: "/insights/platform/cloud-meter"}},
+			ExpectedResult: false,
+		},
+		{
+			Source:         model.Source{SourceType: model.SourceType{Name: "amazon"}},
+			Application:    model.Application{ApplicationType: model.ApplicationType{Name: "/insights/platform/another-app"}},
+			ExpectedResult: false,
+		},
+		{
+			Source:         model.Source{SourceType: model.SourceType{Name: "google"}},
+			Application:    model.Application{ApplicationType: model.ApplicationType{Name: "/insights/platform/another-app"}},
+			ExpectedResult: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		want := testCase.ExpectedResult
+		got := shouldSourceApplicationSetAvailable(testCase.Source, testCase.Application)
+
+		if want != got {
+			t.Errorf(`incorrectly identified source type "%s" and application type "%s" pair. Want "%t", got "%t"`, testCase.Source.SourceType.Name, testCase.Application.ApplicationType.Name, want, got)
+		}
+	}
+}
+
+// TestSetCorrespondingResourcesAsAvailable tests that the function under test
+// overrides the availability status for the relevant source-application pairs.
+//
+// It sets up three sources with a "Cost Management" and an "Image Builder"
+// application, and three authentications each: one for the source, and one for
+// each application.
+//
+// Two of the sources and all its dependant elements should get the
+// availability status overridden, and the last one should keep its original
+// availability status left untouched.
+func TestSetCorrespondingResourcesAsAvailable(t *testing.T) {
+	testutils.SkipIfNotRunningIntegrationTests(t)
+	database.SwitchSchema("test_bulk_create_corresponding_resouces_available")
+
+	defer func() {
+		database.DropSchema("test_bulk_create_corresponding_resouces_available")
+		database.SwitchSchema("service")
+	}()
+
+	// Get the application types.
+	cloudMeterAppType := fixtures.TestApplicationTypeData[6]
+	imageBuilderAppType := fixtures.TestApplicationTypeData[7]
+
+	// Get the sources.
+	amazonSource := fixtures.TestSourceData[6]
+	googleSource := fixtures.TestSourceData[7]
+	bitBucketSource := fixtures.TestSourceData[8]
+
+	// Create the applications and the authentications for the Amazon
+	// source.
+	amazonSourceApps := []model.Application{
+		{
+			AvailabilityStatus: model.InProgress,
+			SourceID:           amazonSource.ID,
+			ApplicationType:    cloudMeterAppType,
+			ApplicationTypeID:  cloudMeterAppType.Id,
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			AvailabilityStatus: model.InProgress,
+			SourceID:           amazonSource.ID,
+			ApplicationType:    imageBuilderAppType,
+			ApplicationTypeID:  imageBuilderAppType.Id,
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+	}
+
+	// Create the applications so that we obtain an ID for them, and so that
+	// we can associate them to the authentications.
+	err := dao.DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.Omit(clause.Associations).Create(&amazonSourceApps).Error
+		if err != nil {
+			return fmt.Errorf("failed to create applications in database: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Errorf(`unable to create applications in the database: %s`, err)
+	}
+
+	amazonAuthentications := []model.Authentication{
+		{
+			ID:                 "amazon-source-auth",
+			AuthType:           "basic",
+			ResourceType:       "Source",
+			ResourceID:         amazonSource.ID,
+			SourceID:           amazonSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			ID:                 "cloud-meter-auth",
+			AuthType:           "basic",
+			ResourceType:       "Application",
+			ResourceID:         amazonSourceApps[0].ID, // Cloud-Meter.
+			SourceID:           amazonSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			ID:                 "image-builder-auth",
+			AuthType:           "basic",
+			ResourceType:       "Application",
+			ResourceID:         amazonSourceApps[1].ID, // Image-Builder.
+			SourceID:           amazonSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+	}
+
+	// Create the authentications as well.
+	err = dao.DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.Omit(clause.Associations).Create(&amazonAuthentications).Error
+		if err != nil {
+			return fmt.Errorf("failed to create authentications in database: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Errorf(`unable to create authentications in the database: %s`, err)
+	}
+
+	// Create the applications and the authentications for the Google
+	// source.
+	googleSourceApps := []model.Application{
+		{
+			AvailabilityStatus: model.InProgress,
+			SourceID:           googleSource.ID,
+			ApplicationType:    cloudMeterAppType,
+			ApplicationTypeID:  cloudMeterAppType.Id,
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			AvailabilityStatus: model.InProgress,
+			SourceID:           googleSource.ID,
+			ApplicationType:    imageBuilderAppType,
+			ApplicationTypeID:  imageBuilderAppType.Id,
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+	}
+
+	// Create the applications so that we obtain an ID for them, and so that
+	// we can associate them to the authentications.
+	err = dao.DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.Omit(clause.Associations).Create(&googleSourceApps).Error
+		if err != nil {
+			return fmt.Errorf("failed to create applications in database: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Errorf(`unable to create applications in the database: %s`, err)
+	}
+
+	googleAuthentications := []model.Authentication{
+		{
+			ID:                 "google-source-auth",
+			AuthType:           "basic",
+			ResourceType:       "Source",
+			ResourceID:         googleSource.ID,
+			SourceID:           googleSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			ID:                 "cloud-meter-auth",
+			AuthType:           "basic",
+			ResourceType:       "Application",
+			ResourceID:         googleSourceApps[0].ID, // Cloud-Meter.
+			SourceID:           googleSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			ID:                 "image-builder-auth",
+			AuthType:           "basic",
+			ResourceType:       "Application",
+			ResourceID:         googleSourceApps[1].ID, // Image-Builder.
+			SourceID:           googleSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+	}
+
+	// Create the authentications as well.
+	err = dao.DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.Omit(clause.Associations).Create(&googleAuthentications).Error
+		if err != nil {
+			return fmt.Errorf("failed to create authentications in database: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Errorf(`unable to create authentications in the database: %s`, err)
+	}
+
+	// Create the applications and the authentications for the BitBucket
+	// source.
+	bitBucketSourceApps := []model.Application{
+		// Source 2 applications (google): 2 should satisfy, 1 should not
+		{
+			AvailabilityStatus: model.InProgress,
+			SourceID:           bitBucketSource.ID,
+			ApplicationType:    cloudMeterAppType,
+			ApplicationTypeID:  cloudMeterAppType.Id,
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			AvailabilityStatus: model.InProgress,
+			SourceID:           bitBucketSource.ID,
+			ApplicationType:    imageBuilderAppType,
+			ApplicationTypeID:  imageBuilderAppType.Id,
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+	}
+
+	// Create the applications so that we obtain an ID for them, and so that
+	// we can associate them to the authentications.
+	err = dao.DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.Omit(clause.Associations).Create(&bitBucketSourceApps).Error
+		if err != nil {
+			return fmt.Errorf("failed to create applications in database: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Errorf(`unable to create applications in the database: %s`, err)
+	}
+
+	bitBucketAuthentications := []model.Authentication{
+		{
+			ID:                 "bitbucket-source-auth",
+			AuthType:           "basic",
+			ResourceType:       "Source",
+			ResourceID:         bitBucketSource.ID,
+			SourceID:           bitBucketSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			ID:                 "cloud-meter-auth",
+			AuthType:           "basic",
+			ResourceType:       "Application",
+			ResourceID:         bitBucketSourceApps[0].ID, // Cloud-Meter.
+			SourceID:           bitBucketSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+		{
+			ID:                 "image-builder-auth",
+			AuthType:           "basic",
+			ResourceType:       "Application",
+			ResourceID:         bitBucketSourceApps[1].ID, // Image-Builder.
+			SourceID:           bitBucketSource.ID,
+			AvailabilityStatus: util.StringRef(model.InProgress),
+			TenantID:           fixtures.TestTenantData[0].Id,
+		},
+	}
+
+	// Create the authentications as well.
+	err = dao.DB.Transaction(func(tx *gorm.DB) error {
+		err := tx.Omit(clause.Associations).Create(&bitBucketAuthentications).Error
+		if err != nil {
+			return fmt.Errorf("failed to create authentications in database: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Errorf(`unable to create authentications in the database: %s`, err)
+	}
+
+	// Prepare the slices for the function under test.
+	sources := []model.Source{amazonSource, googleSource, bitBucketSource}
+
+	applications := []model.Application{}
+	applications = append(applications, amazonSourceApps...)
+	applications = append(applications, googleSourceApps...)
+	applications = append(applications, bitBucketSourceApps...)
+
+	authentications := []model.Authentication{}
+	authentications = append(authentications, amazonAuthentications...)
+	authentications = append(authentications, googleAuthentications...)
+	authentications = append(authentications, bitBucketAuthentications...)
+
+	// Call the function under test.
+	err = dao.DB.Transaction(func(tx *gorm.DB) error {
+		err = setCorrespondingResourcesAsAvailable(tx, sources, applications, authentications)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Errorf(`unexpected error when calling the function under test: %s`, err)
+	}
+
+	// Verify that the Amazon source is available.
+	if model.Available != sources[0].AvailabilityStatus {
+		t.Errorf(`Unexpected Amazon source availability status. Want "%s", got "%s"`, model.Available, sources[0].AvailabilityStatus)
+	}
+
+	// Verify that the Amazon source's Cost Management application is still in
+	// progress.
+	if model.InProgress != applications[0].AvailabilityStatus {
+		t.Errorf(`Unexpected Amazon source's Cost Management availability status. Want "%s", got "%s"`, model.InProgress, applications[0].AvailabilityStatus)
+	}
+
+	// Verify that the Amazon source's Image Builder application is available.
+	if model.Available != applications[1].AvailabilityStatus {
+		t.Errorf(`Unexpected Amazon source's Image Builder availability status. Want "%s", got "%s"`, model.InProgress, applications[1].AvailabilityStatus)
+	}
+
+	// Verify that the Amazon source's authentication is available, that the
+	// Cost Management's authentication is still in progress, and that Image
+	// Builder's authentication is available.
+	if model.Available != *authentications[0].AvailabilityStatus {
+		t.Errorf(`Unexpected Amazon source's authentication's status. Want "%s", got "%s"`, model.Available, *authentications[0].AvailabilityStatus)
+	}
+
+	if model.InProgress != *authentications[1].AvailabilityStatus {
+		t.Errorf(`Unexpected Amazon source's Cost Management application's authentication's availability status. Want "%s", got "%s"`, model.InProgress, *authentications[1].AvailabilityStatus)
+	}
+
+	if model.Available != *authentications[2].AvailabilityStatus {
+		t.Errorf(`Unexpected Amazon source's Image Builder application's authentication's availability status. Want "%s", got "%s"`, model.Available, *authentications[2].AvailabilityStatus)
+	}
+
+	// Verify that the Google source is available.
+	if model.Available != sources[1].AvailabilityStatus {
+		t.Errorf(`Unexpected Google source availability status. Want "%s", got "%s"`, model.Available, sources[1].AvailabilityStatus)
+	}
+
+	// Verify that the Google source's Cloud Meter application is available.
+	if model.Available != applications[2].AvailabilityStatus {
+		t.Errorf(`Unexpected Google source's Cloud Meter availability status. Want "%s", got "%s"`, model.Available, applications[2].AvailabilityStatus)
+	}
+
+	// Verify that the Google source's Image Builder application is still in progress.
+	if model.InProgress != applications[3].AvailabilityStatus {
+		t.Errorf(`Unexpected Google source's Image Builder availability status. Want "%s", got "%s"`, model.InProgress, applications[3].AvailabilityStatus)
+	}
+
+	// Verify that the Google source's authentication is available, that the
+	// Cloud Meter's authentication is available, and that Image Builder's
+	// authentication is still in progress.
+	if model.Available != *authentications[3].AvailabilityStatus {
+		t.Errorf(`Unexpected Google source's authentication's status. Want "%s", got "%s"`, model.Available, *authentications[3].AvailabilityStatus)
+	}
+
+	if model.Available != *authentications[4].AvailabilityStatus {
+		t.Errorf(`Unexpected Google source's Cloud Meter application's authentication's availability status. Want "%s", got "%s"`, model.Available, *authentications[4].AvailabilityStatus)
+	}
+
+	if model.InProgress != *authentications[5].AvailabilityStatus {
+		t.Errorf(`Unexpected Google source's Image Builder application's authentication's availability status. Want "%s", got "%s"`, model.InProgress, *authentications[5].AvailabilityStatus)
+	}
+
+	// Verify that the BitBucket source is still in progress.
+	if model.InProgress != sources[2].AvailabilityStatus {
+		t.Errorf(`Unexpected BitBucket source availability status. Want "%s", got "%s"`, model.InProgress, sources[2].AvailabilityStatus)
+	}
+
+	// Verify that the BitBucket source's Cloud Meter application is still in
+	// progress.
+	if model.InProgress != applications[4].AvailabilityStatus {
+		t.Errorf(`Unexpected BitBucket source's Cloud Meter availability status. Want "%s", got "%s"`, model.InProgress, applications[4].AvailabilityStatus)
+	}
+
+	// Verify that the BitBucket source's Image Builder application is still in
+	// progress.
+	if model.InProgress != applications[5].AvailabilityStatus {
+		t.Errorf(`Unexpected BitBucket source's Image Builder availability status. Want "%s", got "%s"`, model.InProgress, applications[5].AvailabilityStatus)
+	}
+
+	// Verify that the BitBucket source's authentication is still in progress,
+	// that the Cloud Meter's authentication is still in progress, and that
+	// Image Builder's authentication is still in progress.
+	if model.InProgress != *authentications[6].AvailabilityStatus {
+		t.Errorf(`Unexpected BitBucket source's authentication's status. Want "%s", got "%s"`, model.InProgress, *authentications[6].AvailabilityStatus)
+	}
+
+	if model.InProgress != *authentications[7].AvailabilityStatus {
+		t.Errorf(`Unexpected BitBucket source's Cloud Meter application's authentication's availability status. Want "%s", got "%s"`, model.InProgress, *authentications[7].AvailabilityStatus)
+	}
+
+	if model.InProgress != *authentications[8].AvailabilityStatus {
+		t.Errorf(`Unexpected BitBucket source's Image Builder application's authentication's availability status. Want "%s", got "%s"`, model.InProgress, *authentications[8].AvailabilityStatus)
+	}
+
+	databaseChecks := struct {
+		ExpectedAvailableSources          []model.Source
+		ExpectedInProgressSources         []model.Source
+		ExpectedAvailableApplications     []model.Application
+		ExpectedInProgressApplications    []model.Application
+		ExpectedAvailableAuthentications  []model.Authentication
+		ExpectedInProgressAuthentications []model.Authentication
+	}{
+		ExpectedAvailableSources: []model.Source{
+			sources[0], // Amazon.
+			sources[1], // Google.
+		},
+		ExpectedInProgressSources: []model.Source{
+			sources[2], // BitBucket.
+		},
+		ExpectedAvailableApplications: []model.Application{
+			applications[1], // Amazon — Image Builder.
+			applications[2], // Google — Cloud Meter.
+		},
+		ExpectedInProgressApplications: []model.Application{
+			applications[0], // Amazon — Cost Management.
+			applications[3], // Google — Image Builder.
+			applications[4], // BitBucket — Cost Management.
+			applications[5], // BitBucket — Image Builder.
+		},
+		ExpectedAvailableAuthentications: []model.Authentication{
+			authentications[0], // Amazon source authentication.
+			authentications[2], // Amazon Image Builder authentication.
+			authentications[3], // Google source authentication.
+			authentications[4], // Google Cloud Meter authentication.
+		},
+		ExpectedInProgressAuthentications: []model.Authentication{
+			authentications[1], // Amazon Cost Management authentication.
+			authentications[5], // Google Image Builder authentication.
+			authentications[6], // BitBucket source authentication.
+			authentications[7], // BitBucket Cost Management authentication.
+			authentications[8], // BitBucket Image Builder authentication.
+		},
+	}
+
+	// Get the DAO.
+	tenantID := fixtures.TestTenantData[0].Id
+	requestParams := dao.RequestParams{TenantID: &tenantID}
+
+	sourceDao := dao.GetSourceDao(&requestParams)
+
+	// Check available sources.
+	for _, expectedSource := range databaseChecks.ExpectedAvailableSources {
+		dbSource, err := sourceDao.GetById(&expectedSource.ID)
+		if err != nil {
+			t.Errorf(`Error fetching source %d from database: %s`, expectedSource.ID, err)
+		}
+
+		if dbSource.AvailabilityStatus != model.Available {
+			t.Errorf(`Source %d availability status not persisted to database. Want "%s", got "%s"`, expectedSource.ID, model.Available, dbSource.AvailabilityStatus)
+		}
+	}
+
+	// Check in-progress sources.
+	for _, expectedSource := range databaseChecks.ExpectedInProgressSources {
+		dbSource, err := sourceDao.GetById(&expectedSource.ID)
+		if err != nil {
+			t.Errorf(`Error fetching source %d from database: %s`, expectedSource.ID, err)
+		}
+
+		if dbSource.AvailabilityStatus != model.InProgress {
+			t.Errorf(`Source %d availability status not persisted to database. Want "%s", got "%s"`, expectedSource.ID, model.InProgress, dbSource.AvailabilityStatus)
+		}
+	}
+
+	// Verify applications in database
+	applicationDao := dao.GetApplicationDao(&requestParams)
+
+	// Check available applications.
+	for _, expectedApp := range databaseChecks.ExpectedAvailableApplications {
+		dbApp, err := applicationDao.GetById(&expectedApp.ID)
+		if err != nil {
+			t.Errorf(`Error fetching application %d from database: %s`, expectedApp.ID, err)
+		}
+
+		if dbApp.AvailabilityStatus != model.Available {
+			t.Errorf(`Application %d availability status not persisted to database. Want "%s", got "%s"`, expectedApp.ID, model.Available, dbApp.AvailabilityStatus)
+		}
+	}
+
+	// Check in-progress applications.
+	for _, expectedApp := range databaseChecks.ExpectedInProgressApplications {
+		dbApp, err := applicationDao.GetById(&expectedApp.ID)
+		if err != nil {
+			t.Errorf(`Error fetching application %d from database: %s`, expectedApp.ID, err)
+		}
+
+		if dbApp.AvailabilityStatus != model.InProgress {
+			t.Errorf(`Application %d availability status not persisted to database. Want "%s", got "%s"`, expectedApp.ID, model.InProgress, dbApp.AvailabilityStatus)
+		}
+	}
+
+	// Verify authentications in database.
+	authenticationDao := dao.GetAuthenticationDao(&requestParams)
+
+	// Check available authentications.
+	for _, expectedAuth := range databaseChecks.ExpectedAvailableAuthentications {
+		dbAuth, err := authenticationDao.GetById(strconv.FormatInt(expectedAuth.DbID, 10))
+		if err != nil {
+			t.Errorf(`Error fetching authentication %d from database: %s`, expectedAuth.DbID, err)
+		}
+
+		if *dbAuth.AvailabilityStatus != model.Available {
+			t.Errorf(`Authentication %d availability status not persisted to database. Want "%s", got "%s"`, expectedAuth.DbID, model.Available, *dbAuth.AvailabilityStatus)
+		}
+	}
+
+	// Check in-progress authentications.
+	for _, expectedAuth := range databaseChecks.ExpectedInProgressAuthentications {
+		dbAuth, err := authenticationDao.GetById(strconv.FormatInt(expectedAuth.DbID, 10))
+		if err != nil {
+			t.Errorf(`Error fetching authentication %d from database: %s`, expectedAuth.DbID, err)
+		}
+
+		if *dbAuth.AvailabilityStatus != model.InProgress {
+			t.Errorf(`Authentication %d availability status not persisted to database. Want "%s", got "%s"`, expectedAuth.DbID, model.InProgress, *dbAuth.AvailabilityStatus)
+		}
 	}
 }


### PR DESCRIPTION
[RHCLOUD-40737]
The goal is to update the "Bulk assembly" method in Sources so that when a combination of "GCP & Cloud Meter" entities get created, they get created with an "available" status by default.