### PR TITLE
RHCLOUD-42273 | Migrate app seeding data into app-interface / configMap

### DIFF
--- a/dao/seeding.go
+++ b/dao/seeding.go
@@ -289,7 +289,7 @@ func seedSuperkeyMetadata(appTypes map[string]*m.ApplicationType) error {
 }
 
 func seedAppMetadata(appTypes map[string]*m.ApplicationType) error {
-	seeds := make(appMetadataSeedMap)
+	seeds := make(appMetaDataSeed)
 	// reading from the embedded fs for the seeds directory
 	data, err := os.ReadFile("/tmp/sources/app_metadata.yml")
 	if err != nil {
@@ -301,15 +301,7 @@ func seedAppMetadata(appTypes map[string]*m.ApplicationType) error {
 		return err
 	}
 
-	// defaulting to "eph" if no var is set.
-	env, ok := os.LookupEnv("SOURCES_ENV")
-	if !ok {
-		l.Log.Infof("Defaulting SOURCES_ENV to eph")
-
-		env = "eph"
-	}
-
-	for name, values := range seeds[env] {
+	for name, values := range seeds {
 		appType, ok := appTypes[name]
 		if !ok {
 			return fmt.Errorf("failed find application type %v", name)

--- a/dao/seeding.go
+++ b/dao/seeding.go
@@ -291,7 +291,7 @@ func seedSuperkeyMetadata(appTypes map[string]*m.ApplicationType) error {
 func seedAppMetadata(appTypes map[string]*m.ApplicationType) error {
 	seeds := make(appMetaDataSeed)
 	// reading from the embedded fs for the seeds directory
-	data, err := os.ReadFile("/tmp/sources/app_metadata.yml")
+	data, err := os.ReadFile("/mnt/sources/app_metadata.yml")
 	if err != nil {
 		return err
 	}

--- a/dao/seeding.go
+++ b/dao/seeding.go
@@ -291,7 +291,7 @@ func seedSuperkeyMetadata(appTypes map[string]*m.ApplicationType) error {
 func seedAppMetadata(appTypes map[string]*m.ApplicationType) error {
 	seeds := make(appMetadataSeedMap)
 	// reading from the embedded fs for the seeds directory
-	data, err := seedsFS.ReadFile("seeds/app_metadata.yml")
+	data, err := os.ReadFile("/tmp/sources/app_metadata.yml")
 	if err != nil {
 		return err
 	}

--- a/dao/seeds/app_metadata.yml
+++ b/dao/seeds/app_metadata.yml
@@ -7,8 +7,8 @@
 # Fallback metadata file for local development
 "/insights/platform/cost-management":
   gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com
-  aws_wizard_account_number: "111111111111"
+  aws_wizard_account_number: "587172791893"
 "/insights/platform/cloud-meter":
-  aws_wizard_account_number: "222222222222"
+  aws_wizard_account_number: "587172791893"
 "/insights/platform/image-builder":
-  aws_wizard_account_number: "333333333333"
+  aws_wizard_account_number: "587172791893"

--- a/dao/seeds/app_metadata.yml
+++ b/dao/seeds/app_metadata.yml
@@ -5,33 +5,11 @@
 # string is valid json. So plain key/value works fine.
 #####
 
-eph:
-  "/insights/platform/cost-management":
-    gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com
-    aws_wizard_account_number: "897722705726"
-  "/insights/platform/cloud-meter":
-    aws_wizard_account_number: "372779871274"
-  "/insights/platform/image-builder":
-    aws_wizard_account_number: "399777895069"
-stage:
-  "/insights/platform/cost-management":
-    gcp_service_account: billing-export@red-hat-cost-management-stage.iam.gserviceaccount.com
-    aws_wizard_account_number: "148761653619"
-    retry_source_creation: false
-  "/insights/platform/cloud-meter":
-    aws_wizard_account_number: "998366406740"
-    azure_lighthouse_template: "https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fcloudigrade-stage-azure-offer-cloudigrade-stage.apps.crcs02ue1.urby.p1.openshiftapps.com%2Fapi%2Fcloudigrade%2Fv2%2Fazure-offer-template%2F"
-    retry_source_creation: true
-  "/insights/platform/image-builder":
-    aws_wizard_account_number: "351356922033"
-prod:
-  "/insights/platform/cost-management":
-    gcp_service_account: billing-export@red-hat-cost-management.iam.gserviceaccount.com
-    aws_wizard_account_number: "589173575009"
-    retry_source_creation: false
-  "/insights/platform/cloud-meter":
-    aws_wizard_account_number: "998366406740"
-    azure_lighthouse_template: "https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fconsole.redhat.com%2Fapi%2Fcloudigrade%2Fv2%2Fazure-offer-template%2F"
-    retry_source_creation: true
-  "/insights/platform/image-builder":
-    aws_wizard_account_number: "296389277756"
+# Fallback metadata file for local development
+"/insights/platform/cost-management":
+  gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com
+  aws_wizard_account_number: "111111111111"
+"/insights/platform/cloud-meter":
+  aws_wizard_account_number: "222222222222"
+"/insights/platform/image-builder":
+  aws_wizard_account_number: "333333333333"

--- a/dao/seeds/app_metadata.yml
+++ b/dao/seeds/app_metadata.yml
@@ -1,7 +1,6 @@
 ######
 # Seed file for application specific metadata.
-# Outer object is the env (in case there are per-env settings)
-# Inner object is in the form of `key`: `jsonb`, but a plain
+# The object is in the form of `key`: `jsonb`, but a plain
 # string is valid json. So plain key/value works fine.
 #####
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -288,7 +288,7 @@ objects:
             memory: ${MEMORY_REQUEST}
         volumeMounts:
           - name: sources-app-metadata
-            mountPath: /tmp/sources
+            mountPath: /mnt/sources
             readOnly: true
         volumes:
           - name: sources-app-metadata

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -286,6 +286,14 @@ objects:
           requests:
             cpu: ${CPU_REQUEST}
             memory: ${MEMORY_REQUEST}
+        volumeMounts:
+          - name: sources-app-metadata
+            mountPath: /tmp/sources
+            readOnly: true
+        volumes:
+          - name: sources-app-metadata
+            configMap:
+              name: sources-app-metadata
     database:
       name: sources
       version: 12
@@ -306,6 +314,15 @@ objects:
     featureFlags: true
     dependencies:
     - rbac
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: sources-api
+    name: sources-app-metadata
+  data:
+    app_metadata.yml: |
+      ${APP_METADATA}
 parameters:
 - description: Scheme of the Cloud Meter API
   displayName: Cloud Meter API Scheme
@@ -460,4 +477,7 @@ parameters:
   value: "false"
 - description: A comma-separated list of application types that are disabled in Sources
   name: DISABLED_APPLICATION_TYPES
+  value: ""
+- description: A YAML file containing app_metadata for the supported applications in Sources.
+  name: APP_METADATA
   value: ""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,8 @@ services:
       - SOURCES_PSKS=thisMustBeEphemeralOrMinikube
       - BYPASS_RBAC=true
       - ENCRYPTION_KEY=YWFhYWFhYWFhYWFhYWFhYQ
+    volumes:
+      - ./dao/seeds:/tmp/sources
     ports:
       - 3000:8000
       - 9394:9394

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - BYPASS_RBAC=true
       - ENCRYPTION_KEY=YWFhYWFhYWFhYWFhYWFhYQ
     volumes:
-      - ./dao/seeds:/tmp/sources
+      - ./dao/seeds:/mnt/sources
     ports:
       - 3000:8000
       - 9394:9394


### PR DESCRIPTION
This PR configures the service side of the migration of the application metadata from a local file into appInterface. The seeding logic stays the same but:

- Now metadata is expected to live in a file inside `/tmp/sources` folder (`/tmp` was the best fitting path I could find but subject to change)
- The metadata.yml file will be populated through a volume (both in appInterface using configMaps and docker-compose)
- Metadata file cannot be read with `embed` now so switching back to `os.Readfile`
- Metadata object has been simplified and has now one less "layer" as the env is not needed anymore. Each env will provide the correct associated metadata