### PR TITLE
Fix app_metadata seeding and testing in local env

### DIFF
--- a/dao/main_test.go
+++ b/dao/main_test.go
@@ -220,6 +220,7 @@ func UpdateTablesSequences(schema string) {
 		"rhc_connections",
 		"authentications",
 		"application_authentications",
+		"meta_data",
 	}
 
 	for _, table := range tables {

--- a/dao/seeding.go
+++ b/dao/seeding.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/RedHatInsights/sources-api-go/config"
 	l "github.com/RedHatInsights/sources-api-go/logger"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"github.com/RedHatInsights/sources-api-go/util"
@@ -291,7 +292,17 @@ func seedSuperkeyMetadata(appTypes map[string]*m.ApplicationType) error {
 func seedAppMetadata(appTypes map[string]*m.ApplicationType) error {
 	seeds := make(appMetaDataSeed)
 	// reading from the embedded fs for the seeds directory
-	data, err := os.ReadFile("/mnt/sources/app_metadata.yml")
+	env := config.Get().Env
+
+	var data []byte
+
+	var err error
+	if strings.ToLower(env) == "stage" || strings.ToLower(env) == "prod" {
+		data, err = os.ReadFile("/mnt/sources/app_metadata.yml")
+	} else {
+		data, err = seedsFS.ReadFile("seeds/app_metadata.yml")
+	}
+
 	if err != nil {
 		return err
 	}

--- a/dao/seeding_test.go
+++ b/dao/seeding_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/sources-api-go/internal/testutils"
+	"github.com/RedHatInsights/sources-api-go/internal/testutils/fixtures"
 	m "github.com/RedHatInsights/sources-api-go/model"
 	"sigs.k8s.io/yaml"
 )
@@ -21,9 +22,11 @@ func getSeedFilesystemDir() string {
 
 func TestSeedingSourceTypes(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
-	CloseConnection()
-	ConnectToTestDB("seeding")
-	MigrateSchema()
+	SwitchSchema("seeding_source_types")
+
+	defer func() {
+		DropSchema("seeding_source_types")
+	}()
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")
@@ -58,6 +61,11 @@ func TestSeedingSourceTypes(t *testing.T) {
 
 func TestSeedingApplicationTypes(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("seeding_application_types")
+
+	defer func() {
+		DropSchema("seeding_application_types")
+	}()
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")
@@ -92,6 +100,11 @@ func TestSeedingApplicationTypes(t *testing.T) {
 
 func TestSeedingSuperkeyMetadata(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("seeding_superkey_metadata")
+
+	defer func() {
+		DropSchema("seeding_superkey_metadata")
+	}()
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")
@@ -134,6 +147,11 @@ func TestSeedingSuperkeyMetadata(t *testing.T) {
 
 func TestSeedingApplicationMetadata(t *testing.T) {
 	testutils.SkipIfNotRunningIntegrationTests(t)
+	SwitchSchema("seeding_application_metadata")
+
+	defer func() {
+		DropSchema("seeding_application_metadata")
+	}()
 
 	if DB == nil {
 		t.Fatal("DB is nil - cannot continue test.")
@@ -148,7 +166,7 @@ func TestSeedingApplicationMetadata(t *testing.T) {
 	}
 
 	bytes, _ := os.ReadFile(seedsDir + "app_metadata.yml")
-	seeds := make(appMetadataSeedMap)
+	seeds := make(appMetaDataSeed)
 
 	err = yaml.Unmarshal(bytes, &seeds)
 	if err != nil {
@@ -164,14 +182,12 @@ func TestSeedingApplicationMetadata(t *testing.T) {
 		t.Fatalf("failed to list appmetadata: %v", result.Error)
 	}
 
-	count := 0
-	for _, v := range seeds["eph"] {
+	count := 0 + len(fixtures.TestMetaDataData)
+	for _, v := range seeds {
 		count += len(v)
 	}
 
 	if len(appmdata) != count {
 		t.Errorf("Seeding did not match values, got %v expected %v", len(appmdata), count)
 	}
-
-	DropSchema("seeding")
 }

--- a/dao/seeding_types.go
+++ b/dao/seeding_types.go
@@ -5,7 +5,6 @@ type (
 	sourceTypeSeedMap       map[string]sourceTypeSeed
 	applicationTypeSeedMap  map[string]applicationTypeSeed
 	superkeyMetadataSeedMap map[string]superKeySeed
-	appMetadataSeedMap      map[string]appMetaDataSeed
 )
 
 type sourceTypeSeed struct {

--- a/internal/testutils/fixtures/application_type.go
+++ b/internal/testutils/fixtures/application_type.go
@@ -40,4 +40,18 @@ var TestApplicationTypeData = []m.ApplicationType{
 		SupportedSourceTypes:         []byte(`["amazon", "azure", "google", "openshift", "ibm"]`),
 		SupportedAuthenticationTypes: []byte(`{"amazon": ["arn", "arn-2", "arn-3"], "azure": ["azure-auth", "azure-auth-2"]}`),
 	},
+	{
+		Id:                           6,
+		DisplayName:                  "Cloud Meter",
+		Name:                         "/insights/platform/cloud-meter",
+		SupportedSourceTypes:         []byte(`["amazon", "azure", "google", "openshift", "ibm"]`),
+		SupportedAuthenticationTypes: []byte(`{"amazon": ["arn", "arn-2", "arn-3"], "azure": ["azure-auth", "azure-auth-2"]}`),
+	},
+	{
+		Id:                           7,
+		DisplayName:                  "Image Builder",
+		Name:                         "/insights/platform/image-builder",
+		SupportedSourceTypes:         []byte(`["amazon"]`),
+		SupportedAuthenticationTypes: []byte(`{"amazon": ["arn", "arn-2", "arn-3"]}`),
+	},
 }


### PR DESCRIPTION
Migration of metadata into appInterface  / containers caused an issue in the local env where the app_metadata.yml is not correctly loading as it is not present in /mnt.

This PR addresses the conditional loading of the app_metadata based on env