### PR TITLE
Redis to valkey

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -112,7 +112,7 @@ services:
 
   sources-redis:
     container_name: sources-redis
-    image: redis:5.0.4
+    image: valkey/valkey:8
     ports:
       - 6378:6379
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/aws/smithy-go v1.24.0
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-gormigrate/gormigrate/v2 v2.1.5
-	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang-migrate/migrate/v4 v4.19.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
@@ -35,6 +34,7 @@ require (
 	github.com/segmentio/kafka-go v0.4.49
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.21.0
+	github.com/valkey-io/valkey-go v1.0.51
 	github.com/vektah/gqlparser/v2 v2.5.31
 	gorm.io/datatypes v1.2.6
 	gorm.io/driver/postgres v1.6.0
@@ -91,7 +91,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -151,8 +149,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
-github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/go-sql-driver/mysql v1.9.3 h1:U/N249h2WzJ3Ukj8SowVFjdtZKfu9vlLZxjPXV1aweo=
 github.com/go-sql-driver/mysql v1.9.3/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI64Gl8i5p1WMU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -520,6 +516,8 @@ github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
 github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/valkey-io/valkey-go v1.0.51 h1:qioDrTBplnkWLK5TrUq0rkuIv7HUL/RPJU/79wB93Lg=
+github.com/valkey-io/valkey-go v1.0.51/go.mod h1:BXlVAPIL9rFQinSFM+N32JfWzfCaUAqBpZkc4vPY6fM=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=

--- a/jobs/client.go
+++ b/jobs/client.go
@@ -15,7 +15,7 @@ type JobRequest struct {
 	Job     Job
 }
 
-// implementing binary mashaler/unmarshaler interfaces for valkey encoding/decoding.
+// MarshalBinary implements the encoding.BinaryMarshaler interface for valkey encoding.
 func (jr JobRequest) MarshalBinary() (data []byte, err error) {
 	return json.Marshal(&jr)
 }
@@ -53,7 +53,7 @@ func (jr *JobRequest) Parse() error {
 	return nil
 }
 
-// Throws a `job` on the valkey list to be picked up by the worker
+// Enqueue adds a job to the valkey list to be picked up by the worker.
 func Enqueue(j Job) {
 	l.Log.Infof("Submitting job %v to valkey with %v", j.Name(), j.Arguments())
 

--- a/jobs/types.go
+++ b/jobs/types.go
@@ -15,7 +15,7 @@ Interface to codify jobs against, mostly consisting of a few methods:
 
 4. Run, what do we do?
 
-5. ToJSON, serialize the job into a byte array for sending off to redis
+5. ToJSON, serialize the job into a byte array for sending off to valkey
 */
 type Job interface {
 	// how long to wait until performing (just do a sleep)

--- a/jobs/worker.go
+++ b/jobs/worker.go
@@ -13,7 +13,7 @@ import (
 // the queue on valkey we'll be sending the jobs to
 const workQueue = "sources_api_jobs"
 
-// Runs the worker just consuming off of a valkey list
+// Run starts the worker consuming jobs off a valkey list.
 func Run(shutdown chan struct{}) {
 	l.Log.Infof("Starting up Background worker listening to valkey queue [%v]", workQueue)
 

--- a/redis/client.go
+++ b/redis/client.go
@@ -18,9 +18,10 @@ func Init() {
 	cfg := config.Get()
 
 	var err error
+
 	Client, err = valkey.NewClient(valkey.ClientOption{
-		InitAddress: []string{fmt.Sprintf("%s:%d", cfg.CacheHost, cfg.CachePort)},
-		Password:    cfg.CachePassword,
+		InitAddress:  []string{fmt.Sprintf("%s:%d", cfg.CacheHost, cfg.CachePort)},
+		Password:     cfg.CachePassword,
 		DisableCache: true,
 	})
 	if err != nil {


### PR DESCRIPTION
The Redis library used in Sources is outdated, as the repository was renamed to [redis/go-redis](https://github.com/redis/go-redis). Additionally, we are migrating from using Redis to Valkey. In order to prevent issues from future incompatible Valkey releases, Sources should switch to using the Valkey client library, [valkey-io/valkey-go](https://github.com/valkey-io/valkey-go).

https://issues.redhat.com/browse/RHCLOUD-44598