### PR TITLE
Fix various typos in comments and log messages

### DIFF
--- a/authentication_handlers_test.go
+++ b/authentication_handlers_test.go
@@ -328,7 +328,7 @@ func TestAuthenticationCreate(t *testing.T) {
 	// Set the encryption key
 	util.OverrideEncryptionKey(strings.Repeat("test", 8))
 
-	// Test the creation of authentication for an application, fpr an endpoint
+	// Test the creation of authentication for an application, for an endpoint
 	// and for a source
 
 	for _, resourceType := range []string{"Application", "Endpoint", "Source"} {

--- a/dao/authentication_dao_test.go
+++ b/dao/authentication_dao_test.go
@@ -120,7 +120,7 @@ func TestAuthFromVault(t *testing.T) {
 
 			got := resultingAuth.ResourceType
 			if want != got {
-				t.Errorf(`authentication resoource types are different. Want "%s", got "%s"`, want, got)
+				t.Errorf(`authentication resource types are different. Want "%s", got "%s"`, want, got)
 			}
 		}
 

--- a/dao/authentication_secrets_manager_dao.go
+++ b/dao/authentication_secrets_manager_dao.go
@@ -13,7 +13,7 @@ type authenticationSecretsManagerDaoImpl struct {
 	// tenant ID + User ID + context information
 	*RequestParams
 
-	// embedded isntance of the db - since we use it for all fields except the
+	// embedded instance of the db - since we use it for all fields except the
 	// password. the only glaring difference is that we will store an
 	// unencrypted ARN as the password field, so we can just fetch it directly
 	// from amazon when we need to decrypt it.

--- a/dao/authentication_secrets_manager_dao.go
+++ b/dao/authentication_secrets_manager_dao.go
@@ -186,7 +186,7 @@ func (a *authenticationSecretsManagerDaoImpl) BulkDelete(authentications []m.Aut
 		return nil, err
 	}
 
-	// go through and clean up the aws resoures, logging if there is a failure.
+	// go through and clean up the aws resources, logging if there is a failure.
 	for i := range authentications {
 		if authentications[i].Password != nil {
 			err := sm.DeleteSecret(*authentications[i].Password)

--- a/dao/mappers/rhcConnection_row_mapper_test.go
+++ b/dao/mappers/rhcConnection_row_mapper_test.go
@@ -102,7 +102,7 @@ func TestMapRowToRhcConnection(t *testing.T) {
 	{
 		got := *result.LastCheckedAt
 		if now != got {
-			t.Errorf(`Unexpected different last cheked at times found. Want "%s", got "%s"`, now, got)
+			t.Errorf(`Unexpected different last checked at times found. Want "%s", got "%s"`, now, got)
 		}
 	}
 

--- a/dao/mappers/rhcConnection_row_mapper_test.go
+++ b/dao/mappers/rhcConnection_row_mapper_test.go
@@ -142,7 +142,7 @@ func TestIdListToRhcConnection(t *testing.T) {
 
 		got := len(rhcConnection.Sources)
 		if want != got {
-			t.Errorf(`want "%d" soruces, got "%d"`, want, got)
+			t.Errorf(`want "%d" sources, got "%d"`, want, got)
 		}
 	}
 

--- a/dao/seeds/source_types.yml
+++ b/dao/seeds/source_types.yml
@@ -257,7 +257,7 @@ dockerhub:
             label: Username of the Docker Hub account
           - component: text-field
             name: authentication.password
-            label: Acces Token for the Docker Hub account
+            label: Access Token for the Docker Hub account
 github:
   product_name: GitHub
   category: Developer sources
@@ -277,7 +277,7 @@ github:
             label: Username of the GitHub account
           - component: text-field
             name: authentication.password
-            label: Personal Acces Token (PAT) for the GitHub account
+            label: Personal Access Token (PAT) for the GitHub account
 gitlab:
   product_name: GitLab
   category: Developer sources
@@ -297,7 +297,7 @@ gitlab:
             label: Username of the GitLab account
           - component: text-field
             name: authentication.password
-            label: Personal Acces Token for the GitLab account
+            label: Personal Access Token for the GitLab account
 openshift:
   product_name: Red Hat OpenShift Container Platform
   category: Red Hat

--- a/dao/tenant_dao_test.go
+++ b/dao/tenant_dao_test.go
@@ -223,7 +223,7 @@ func TestTenantByIdentityNotFound(t *testing.T) {
 		AccountNumber: "invalid",
 	})
 	if !errors.As(err, &util.ErrNotFound{}) {
-		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	// Call the function under test by providing it an invalid orgId.
@@ -231,7 +231,7 @@ func TestTenantByIdentityNotFound(t *testing.T) {
 		OrgID: "invalid",
 	})
 	if !errors.As(err, &util.ErrNotFound{}) {
-		t.Errorf(`unexpected error recevied. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
+		t.Errorf(`unexpected error received. Want "%s", got "%s"`, reflect.TypeOf(util.ErrNotFound{}), reflect.TypeOf(err))
 	}
 
 	DropSchema("tenant_tests")

--- a/dao/user_dao_test.go
+++ b/dao/user_dao_test.go
@@ -38,7 +38,7 @@ func TestFindOrCreateUser(t *testing.T) {
 	got := expectedUser.UserID
 
 	if want != got {
-		t.Errorf(`unexpected user fetched - exptected user :%v ,obtained user:" %v`, want, got)
+		t.Errorf(`unexpected user fetched - expected user :%v ,obtained user:" %v`, want, got)
 	}
 
 	DropSchema("user_tests")

--- a/jobs/worker.go
+++ b/jobs/worker.go
@@ -71,7 +71,7 @@ func Run(shutdown chan struct{}) {
 // Run a Job with a delay but in the background so it does _not_ block the
 // calling routine.
 func RunJobAsync(j Job) {
-	l.Log.Infof("Running job asyncronously %v, %v", j.Name(), j.Arguments())
+	l.Log.Infof("Running job asynchronously %v, %v", j.Name(), j.Arguments())
 
 	go func() {
 		RunJob(j)

--- a/logger/gorm_logger.go
+++ b/logger/gorm_logger.go
@@ -76,6 +76,6 @@ func getEntryFromContext(ctx context.Context) *logrus.Entry {
 		}
 	}
 
-	// falling back to a default logger if the asserion fails
+	// falling back to a default logger if the assertion fails
 	return Log.WithFields(logrus.Fields{})
 }

--- a/middleware/event_stream.go
+++ b/middleware/event_stream.go
@@ -10,7 +10,7 @@ import (
 // event type from the context.
 func RaiseEvent(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
-		// first call the handler function (or the next middlware)
+		// first call the handler function (or the next middleware)
 		err := next(c)
 		if err != nil {
 			return err

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -62,7 +62,7 @@ IQE_MARKER_EXPRESSION="smoke and not ui"  # This is the value passed to pytest -
 IQE_PARALLEL_ENABLED="false"
 IQE_PLUGINS="sources"  # name of the IQE plugin for this app.
 
-# Install and configur Bonfire to be able to build, deploy and run the tests
+# Install and configure Bonfire to be able to build, deploy and run the tests
 # in the ephemeral environment.
 
 curl -s "https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/bootstrap.sh" > .cicd_bootstrap.sh && source .cicd_bootstrap.sh

--- a/service/bulk_create.go
+++ b/service/bulk_create.go
@@ -26,7 +26,7 @@ and creates the resources in this order:
 2. Endpoints/Applications
 
 It dynamically looks up both the SourceType as well as ApplicationType if
-given the *_type_name paremeters.
+given the *_type_name parameters.
 
 3. Saving the Authentications
 4. Saving the ApplicationAuthentications if necessary

--- a/statuslistener/statuslistener.go
+++ b/statuslistener/statuslistener.go
@@ -268,7 +268,7 @@ func (avs *AvailabilityStatusListener) healthCheckConsumer() {
 	for range avs.healthcheck {
 		now := time.Now()
 		avs.lastMsg = now
-		l.Log.Debugf("Got Healthcheck Messsage %v", now.Format(time.Kitchen))
+		l.Log.Debugf("Got Healthcheck Message %v", now.Format(time.Kitchen))
 	}
 }
 


### PR DESCRIPTION
These patches fix various simple typos in the code.

I did not touch any variable/function names, but there is more potentially to be fixed. See `$ rg "resouces|availalable|availablity"`. I also did not touch `public/openapi-3-v3.1.json`.