### PR TITLE
Add application subresource to REST filter parsing

### DIFF
--- a/middleware/filtering.go
+++ b/middleware/filtering.go
@@ -39,8 +39,7 @@ func parseFilter(c echo.Context) ([]util.Filter, error) {
 			}
 
 			// matching filter[subresource][field][operation]
-			// we only support filtering on source type/application type
-			if matches[1][0] == "source_type" || matches[1][0] == "application_type" {
+			if matches[1][0] == "source_type" || matches[1][0] == "application_type" || matches[1][0] == "application" {
 				filter = util.Filter{
 					Subresource: matches[1][0],
 					Name:        matches[2][0],

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -166,6 +166,35 @@ func TestParseSubresourceFilterWithoutOperation(t *testing.T) {
 	}
 }
 
+func TestParseApplicationSubresourceFilter(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[application][application_type_id][eq]=1", nil)
+	c := e.NewContext(req, nil)
+
+	filters, _ := parseFilter(c)
+
+	if len(filters) != 1 {
+		t.Error("wrong number of filters")
+	}
+
+	f := filters[0]
+
+	if f.Subresource != "application" {
+		t.Errorf("expected subresource %q, got %q", "application", f.Subresource)
+	}
+
+	if f.Name != "application_type_id" {
+		t.Errorf("expected name %q, got %q", "application_type_id", f.Name)
+	}
+
+	if f.Operation != "eq" {
+		t.Errorf("expected operation %q, got %q", "eq", f.Operation)
+	}
+
+	if f.Value[0] != "1" {
+		t.Errorf("expected value %q, got %q", "1", f.Value[0])
+	}
+}
+
 func TestParseFilteringWithoutFilterArg(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?name=test", nil)
 	c := e.NewContext(req, nil)

--- a/middleware/filtering_test.go
+++ b/middleware/filtering_test.go
@@ -167,7 +167,7 @@ func TestParseSubresourceFilterWithoutOperation(t *testing.T) {
 }
 
 func TestParseApplicationSubresourceFilter(t *testing.T) {
-	req := httptest.NewRequest(http.MethodGet, "/api/sources/v3.1/sources?filter[application][application_type_id][eq]=1", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/sources/v3.1/sources?filter[application][application_type_id][eq]=1", nil)
 	c := e.NewContext(req, nil)
 
 	filters, _ := parseFilter(c)


### PR DESCRIPTION
## Summary
- The REST middleware `parseFilter` only recognized `source_type` and `application_type` as subresources, missing `application`
- When the UI sends `filter[application][application_type_id]=1`, the middleware misparsed it as a column filter on `application`, which then failed the column allowlist check introduced in #1329, returning a 400 error
- This caused the UI to crash with `TypeError: can't access property "filter", e is undefined` because it received an error response where it expected data

## Test plan
- [ ] Verify `filter[application][application_type_id][eq]=1` correctly parses as a subresource filter
- [ ] Verify existing source_type and application_type subresource filters still work
- [ ] Verify the UI can filter sources by application without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)