### PR TITLE
build(tekton): bump konflux-pipelines from v1.70.0 to v1.71.0

### DIFF
--- a/.tekton/sources-api-pull-request.yaml
+++ b/.tekton/sources-api-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
       == "main"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: sources

--- a/.tekton/sources-api-push.yaml
+++ b/.tekton/sources-api-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
       == "main"
-    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.70.0/pipelines/docker-build-oci-ta.yaml
+    pipelinesascode.tekton.dev/pipeline: https://github.com/RedHatInsights/konflux-pipelines/raw/v1.71.0/pipelines/docker-build-oci-ta.yaml
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: sources


### PR DESCRIPTION
## Summary
- Update `pipelinesascode.tekton.dev/pipeline` annotation from v1.70.0 to v1.71.0 in both Tekton PipelineRun files (`sources-api-pull-request.yaml` and `sources-api-push.yaml`)

## Test plan
- [ ] Verify Konflux pull-request pipeline triggers correctly with the new version
- [ ] Verify Konflux push pipeline triggers correctly with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)